### PR TITLE
St3fan/bug1109656 location completion

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		E42CCE021A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
 		E42CCE031A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
 		E42CCE041A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
-		E49373591A41FF5000FDB16A /* LocationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49373581A41FF5000FDB16A /* LocationTextField.swift */; };
+		E49373801A432A4E00FDB16A /* LocationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E493737F1A432A4E00FDB16A /* LocationTextField.swift */; };
 		E4D6BEA61A092A4700F538BD /* Login.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEA51A092A4700F538BD /* Login.xcassets */; };
 		E4D6BEB21A092D5700F538BD /* Snappy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E4D6BEAD1A092AD300F538BD /* Snappy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
@@ -346,7 +346,7 @@
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E42CCDE21A23A6F900B794D3 /* Clients.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Clients.swift; sourceTree = "<group>"; };
 		E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionUtils.swift; sourceTree = "<group>"; };
-		E49373581A41FF5000FDB16A /* LocationTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationTextField.swift; sourceTree = "<group>"; };
+		E493737F1A432A4E00FDB16A /* LocationTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationTextField.swift; sourceTree = "<group>"; };
 		E4D6BEA51A092A4700F538BD /* Login.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Login.xcassets; sourceTree = "<group>"; };
 		E4D6BEA71A092AD300F538BD /* Snappy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Snappy.xcodeproj; path = ThirdParty/Snappy/Snappy.xcodeproj; sourceTree = "<group>"; };
 		E4D6BEB51A092E0300F538BD /* Client.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Client.entitlements; sourceTree = "<group>"; };
@@ -551,7 +551,8 @@
 				D3A994961A3686BD008AD1AC /* Browser.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
-				E49373581A41FF5000FDB16A /* LocationTextField.swift */,
+				0AE491A51A41C88C0046C724 /* BackForwardListViewController.swift */,
+				E493737F1A432A4E00FDB16A /* LocationTextField.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -1152,7 +1153,6 @@
 				28CE84301A1E571900576538 /* json.swift in Sources */,
 				0BD19A671A25309B0084FBA7 /* AccountPrefs.swift in Sources */,
 				F84B221D1A0911BF00AAB793 /* HistoryViewController.swift in Sources */,
-				E49373591A41FF5000FDB16A /* LocationTextField.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,
 				0BDB95211A3B9844000F2B0F /* Models.xcdatamodeld in Sources */,
@@ -1161,6 +1161,7 @@
 				E42CCE011A24C4E300B794D3 /* ExtensionUtils.swift in Sources */,
 				F84B22201A0911D400AAB793 /* LoginViewController.swift in Sources */,
 				F84B22131A0910F600AAB793 /* Tabs.swift in Sources */,
+				E49373801A432A4E00FDB16A /* LocationTextField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		E42CCE021A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
 		E42CCE031A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
 		E42CCE041A24C4E300B794D3 /* ExtensionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */; };
+		E49373591A41FF5000FDB16A /* LocationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49373581A41FF5000FDB16A /* LocationTextField.swift */; };
 		E4D6BEA61A092A4700F538BD /* Login.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEA51A092A4700F538BD /* Login.xcassets */; };
 		E4D6BEB21A092D5700F538BD /* Snappy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E4D6BEAD1A092AD300F538BD /* Snappy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
@@ -343,6 +344,7 @@
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
 		E42CCDE21A23A6F900B794D3 /* Clients.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Clients.swift; sourceTree = "<group>"; };
 		E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionUtils.swift; sourceTree = "<group>"; };
+		E49373581A41FF5000FDB16A /* LocationTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationTextField.swift; sourceTree = "<group>"; };
 		E4D6BEA51A092A4700F538BD /* Login.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Login.xcassets; sourceTree = "<group>"; };
 		E4D6BEA71A092AD300F538BD /* Snappy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Snappy.xcodeproj; path = ThirdParty/Snappy/Snappy.xcodeproj; sourceTree = "<group>"; };
 		E4D6BEB51A092E0300F538BD /* Client.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Client.entitlements; sourceTree = "<group>"; };
@@ -547,6 +549,7 @@
 				D3A994961A3686BD008AD1AC /* Browser.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
+				E49373581A41FF5000FDB16A /* LocationTextField.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -1146,6 +1149,7 @@
 				28CE84301A1E571900576538 /* json.swift in Sources */,
 				0BD19A671A25309B0084FBA7 /* AccountPrefs.swift in Sources */,
 				F84B221D1A0911BF00AAB793 /* HistoryViewController.swift in Sources */,
+				E49373591A41FF5000FDB16A /* LocationTextField.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,
 				0BDB95211A3B9844000F2B0F /* Models.xcdatamodeld in Sources */,

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -12,12 +12,12 @@ protocol BrowserToolbarDelegate {
     func didClickAddTab()
 }
 
-class BrowserToolbar: UIView, UITextFieldDelegate {
+class BrowserToolbar: UIView, LocationTextFieldDelegate {
     var browserToolbarDelegate: BrowserToolbarDelegate?
 
     private var forwardButton: UIButton!
     private var backButton: UIButton!
-    private var toolbarTextField: ToolbarTextField!
+    private var toolbarTextField: LocationTextField!
     private var cancelButton: UIButton!
     private var tabsButton: UIButton!
 
@@ -50,7 +50,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
         forwardButton.addTarget(self, action: "SELdidClickForward", forControlEvents: UIControlEvents.TouchUpInside)
         self.addSubview(forwardButton)
 
-        toolbarTextField = ToolbarTextField()
+        toolbarTextField = LocationTextField(frame: CGRectZero)
         toolbarTextField.keyboardType = UIKeyboardType.URL
         toolbarTextField.autocorrectionType = UITextAutocorrectionType.No
         toolbarTextField.autocapitalizationType = UITextAutocapitalizationType.None
@@ -59,7 +59,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
         toolbarTextField.layer.backgroundColor = UIColor.whiteColor().CGColor
         toolbarTextField.layer.cornerRadius = 8
         toolbarTextField.setContentHuggingPriority(0, forAxis: UILayoutConstraintAxis.Horizontal)
-        toolbarTextField.delegate = self
+        toolbarTextField.locationTextFieldDelegate = self
         self.addSubview(toolbarTextField)
 
         cancelButton = UIButton()
@@ -174,42 +174,62 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
         browserToolbarDelegate?.didClickAddTab()
     }
 
-    func textFieldDidBeginEditing(textField: UITextField) {
+    func locationTextFieldDidBeginEditing(locationTextField: LocationTextField) {
         arrangeToolbar(editing: true)
     }
+
+    func locationTextFieldDidReturn(locationTextField: LocationTextField, url: NSURL) {
+        arrangeToolbar(editing: false)
+        locationTextField.resignFirstResponder()
+        browserToolbarDelegate?.didEnterURL(url)
+    }
     
-    func textFieldShouldReturn(textField: UITextField) -> Bool {
-        let urlString = toolbarTextField.text
-        
-        // If the URL is missing a scheme then parse then we manually prefix it with http:// and try
-        // again. We can probably do some smarter things here but I think this is a
-        // decent start that at least lets people skip typing the protocol.
-        
-        var url = NSURL(string: urlString)
-        if url == nil || url?.scheme == nil {
-            url = NSURL(string: "http://" + urlString)
-            if url == nil {
-                println("Error parsing URL: " + urlString)
-                return false
+    /// Suggest a completion based on a prefix. Currently this just has some predefined sites and this also only works for hostnames and is currently ignoring paths.
+    /// TODO: Hook this up to our real data sources.
+
+    func locationTextField(locationTextField: LocationTextField, completionForPrefix prefix: String) -> LocationSuggestion? {
+        let MOCK_SUGGESTIONS = [
+            "http://www.apple.com",
+            "https://ask.mozilla.org",
+            "http://apple.stackexchange.com",
+            "http://www.wikipedia.org",
+            "https://wiki.mozilla.org",
+            "https://www.mozilla.org",
+            "https://news.ycombinator.com",
+            "https://bugzilla.mozilla.org",
+            "http://www.reddit.com",
+            "https://twitter.com",
+            "https://mobile.twitter.com"
+        ]
+
+        // First try to find a match on full urls that include the scheme
+        for s in MOCK_SUGGESTIONS {
+            if s.hasPrefix(prefix) {
+                return LocationSuggestion(location: s, url: NSURL(string: s)!)
             }
         }
-
-        arrangeToolbar(editing: false)
-
-        textField.resignFirstResponder()
-        browserToolbarDelegate?.didEnterURL(url!)
-        return false
-    }
-}
-
-private class ToolbarTextField: UITextField {
-    override func textRectForBounds(bounds: CGRect) -> CGRect {
-        let rect = super.textRectForBounds(bounds)
-        return rect.rectByInsetting(dx: 5, dy: 5)
-    }
-
-    override func editingRectForBounds(bounds: CGRect) -> CGRect {
-        let rect = super.editingRectForBounds(bounds)
-        return rect.rectByInsetting(dx: 5, dy: 5)
+        
+        // Then, if the partial completion has no scheme, try to find a match on just the hostname
+        if !prefix.hasPrefix("http://") && !prefix.hasPrefix("https://") {
+            for s in MOCK_SUGGESTIONS {
+                let url = NSURL(string: s)!
+                if let host = url.host {
+                    if host.hasPrefix(prefix) {
+                        // If we directly match the host then we are done
+                        return LocationSuggestion(location: host, url: url)
+                    } else {
+                        // If the host has a www. prefix, chop that off and see if we can match
+                        if host.hasPrefix("www.") {
+                            let partialHost = host.substringFromIndex(advance(host.startIndex, countElements("www.")))
+                            if partialHost.hasPrefix(prefix) {
+                                return LocationSuggestion(location: partialHost, url: url)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        return nil
     }
 }

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -208,7 +208,7 @@ class BrowserToolbar: UIView, LocationTextFieldDelegate {
     /// Suggest a completion based on a prefix. Currently this just has some predefined sites and this also only works for hostnames and is currently ignoring paths.
     /// TODO: Hook this up to our real data sources.
 
-    func locationTextField(locationTextField: LocationTextField, completionForPrefix prefix: String) -> LocationSuggestion? {
+    func locationTextField(locationTextField: LocationTextField, suggestionForPartialLocation partialLocation: String) -> LocationSuggestion? {
         let MOCK_SUGGESTIONS = [
             "http://www.apple.com",
             "https://ask.mozilla.org",
@@ -225,25 +225,25 @@ class BrowserToolbar: UIView, LocationTextFieldDelegate {
 
         // First try to find a match on full urls that include the scheme
         for s in MOCK_SUGGESTIONS {
-            if s.hasPrefix(prefix) {
+            if s.hasPrefix(partialLocation) {
                 return LocationSuggestion(location: s, url: NSURL(string: s)!)
             }
         }
         
         // Then, if the partial completion has no scheme, try to find a match on just the hostname
-        if !prefix.hasPrefix("http://") && !prefix.hasPrefix("https://") {
+        if !partialLocation.hasPrefix("http://") && !partialLocation.hasPrefix("https://") {
             for s in MOCK_SUGGESTIONS {
                 let url = NSURL(string: s)!
                 if let host = url.host {
-                    if host.hasPrefix(prefix) {
+                    if host.hasPrefix(partialLocation) {
                         // If we directly match the host then we are done
                         return LocationSuggestion(location: host, url: url)
                     } else {
                         // If the host has a www. prefix, chop that off and see if we can match
                         if host.hasPrefix("www.") {
-                            let partialHost = host.substringFromIndex(advance(host.startIndex, countElements("www.")))
-                            if partialHost.hasPrefix(prefix) {
-                                return LocationSuggestion(location: partialHost, url: url)
+                            let domain = host.substringFromIndex(advance(host.startIndex, countElements("www.")))
+                            if domain.hasPrefix(partialLocation) {
+                                return LocationSuggestion(location: domain, url: url)
                             }
                         }
                     }

--- a/Client/Frontend/Browser/LocationTextField.swift
+++ b/Client/Frontend/Browser/LocationTextField.swift
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This code is loosely based on https://github.com/Antol/APAutocompleteTextField
+
+import UIKit
+
+struct LocationSuggestion {
+    var location: String
+    var url: NSURL?
+}
+
+protocol LocationTextFieldDelegate {
+    /// Fired when the text field becomes active
+    func locationTextFieldDidBeginEditing(locationTextField: LocationTextField)
+    /// Fired with the text field has been submitted
+    func locationTextFieldDidReturn(locationTextField: LocationTextField, url: NSURL)
+    /// Fired when the text field is asking for a completion suggestion. Return nil if no completion is available.
+    func locationTextField(locationTextField: LocationTextField, completionForPrefix prefix: String) -> LocationSuggestion?
+}
+
+class LocationTextField: UITextField, UITextFieldDelegate {
+    var locationTextFieldDelegate: LocationTextFieldDelegate?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.delegate = self
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.delegate = self
+    }
+    
+    override func textRectForBounds(bounds: CGRect) -> CGRect {
+        let rect = super.textRectForBounds(bounds)
+        return rect.rectByInsetting(dx: 5, dy: 5)
+    }
+    
+    override func editingRectForBounds(bounds: CGRect) -> CGRect {
+        let rect = super.editingRectForBounds(bounds)
+        return rect.rectByInsetting(dx: 5, dy: 5)
+    }
+    
+    func textFieldDidBeginEditing(textField: UITextField) {
+        locationTextFieldDelegate?.locationTextFieldDidBeginEditing(self)
+    }
+    
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        let urlString = textField.text
+        
+        // If the URL is missing a scheme then parse then we manually prefix it with http:// and try
+        // again. We can probably do some smarter things here but I think this is a
+        // decent start that at least lets people skip typing the protocol.
+        
+        var url = NSURL(string: urlString)
+        if url == nil || url?.scheme == nil {
+            url = NSURL(string: "http://" + urlString)
+            if url == nil {
+                println("Error parsing URL: " + urlString)
+                return false
+            }
+        }
+        
+        dispatch_async(dispatch_get_main_queue()) {
+            if let locationTextFieldDelegate = self.locationTextFieldDelegate {
+                locationTextFieldDelegate.locationTextFieldDidReturn(self, url: url!)
+            }
+        }
+        
+        return false
+    }
+    
+    // MARK: Completion handling
+    
+    private var completionActive = false
+    private var completionColor: UIColor = UIColor(red: 0.8, green: 0.87, blue: 0.93, alpha: 1.0)
+    private var completionPrefixLength = 0
+    
+    private func applyCompletion() {
+        if completionActive {
+            self.attributedText = NSAttributedString(string: self.text)
+            completionActive = false
+        }
+    }
+    
+    private func removeCompletion() {
+        if completionActive {
+            var notCompletedString = self.text
+            if countElements(notCompletedString) > completionPrefixLength {
+                notCompletedString = self.text.substringToIndex(advance(self.text.startIndex, completionPrefixLength))
+            }
+            self.attributedText = NSAttributedString(string: notCompletedString)
+            completionActive = false
+        }
+    }
+
+    private func completeString() {
+        var completedAndMarkedString: NSMutableAttributedString?
+        
+        if let endingString = endingString() {
+            let completedString = self.text + endingString
+            
+            completedAndMarkedString = NSMutableAttributedString(string: completedString)
+            completedAndMarkedString?.addAttribute(NSBackgroundColorAttributeName, value: completionColor, range: NSMakeRange(completionPrefixLength, countElements(endingString)))
+        }
+        
+        if completedAndMarkedString != nil {
+            self.attributedText = completedAndMarkedString
+            completionActive = true
+        }
+    }
+    
+    private func endingString() -> String? {
+        if countElements(self.text) != 0 {
+            if let suggestion = locationTextFieldDelegate?.locationTextField(self, completionForPrefix: self.text) {
+                let location = suggestion.location
+                return location.substringFromIndex(advance(location.startIndex, countElements(self.text!)))
+            }
+        }
+        return nil
+    }
+    
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        if completionActive {
+            // Special range that is fired in case of deletion
+            if range.length == 1 && countElements(string) == 0 {
+                removeCompletion()
+                return false
+            }
+        }
+        return true
+    }
+
+    // MARK: UIKeyInput Overrides
+    
+    override func insertText(text: String) {
+        removeCompletion()
+        super.insertText(text)
+        completionPrefixLength = countElements(self.text)
+        completeString()
+    }
+    
+    override func caretRectForPosition(position: UITextPosition!) -> CGRect {
+        if !completionActive {
+            return super.caretRectForPosition(position)
+        } else {
+            return CGRectZero
+        }
+    }
+    
+    override func resignFirstResponder() -> Bool {
+        applyCompletion()
+        return super.resignFirstResponder()
+    }
+    
+    // MARK: UIResponder Overrides
+    
+    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+        if !completionActive {
+            super.touchesBegan(touches, withEvent: event)
+        }
+    }
+    
+    override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
+        if !completionActive {
+            super.touchesMoved(touches, withEvent: event)
+        }
+    }
+    
+    override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
+        if !completionActive {
+            super.touchesBegan(touches, withEvent: event)
+        } else {
+            applyCompletion()
+            self.selectedTextRange = textRangeFromPosition(self.positionFromPosition(self.beginningOfDocument, offset: completionPrefixLength), toPosition: self.endOfDocument)
+        }
+    }
+}

--- a/Client/Frontend/Browser/LocationTextField.swift
+++ b/Client/Frontend/Browser/LocationTextField.swift
@@ -17,7 +17,7 @@ protocol LocationTextFieldDelegate {
     /// Fired with the text field has been submitted
     func locationTextFieldDidReturn(locationTextField: LocationTextField, url: NSURL)
     /// Fired when the text field is asking for a completion suggestion. Return nil if no completion is available.
-    func locationTextField(locationTextField: LocationTextField, completionForPrefix prefix: String) -> LocationSuggestion?
+    func locationTextField(locationTextField: LocationTextField, suggestionForPartialLocation partialLocation: String) -> LocationSuggestion?
 }
 
 class LocationTextField: UITextField, UITextFieldDelegate {
@@ -125,7 +125,7 @@ class LocationTextField: UITextField, UITextFieldDelegate {
     
     private func endingString() -> String? {
         if countElements(self.text) != 0 {
-            if let suggestion = locationTextFieldDelegate?.locationTextField(self, completionForPrefix: self.text) {
+            if let suggestion = locationTextFieldDelegate?.locationTextField(self, suggestionForPartialLocation: self.text) {
                 let location = suggestion.location
                 self.completionURL = suggestion.url
                 return location.substringFromIndex(advance(location.startIndex, countElements(self.text!)))


### PR DESCRIPTION
This implemented a first iteration of location completion. It implements the following rules:

* If the user types `www.m` and we have a completion suggestion `http://www.mozilla.org`, the completion will be `www.mozilla.org`.
* If the user types `m` and we have a completion suggestion `http://www.mozilla.org`, the completion will be `mozilla.org`.
* If the user types `http://wwww.m` and we have a completion suggestion `http://www.mozilla.org`, the completion will be `http://www.mozilla.org`.

In all cases the completion suggestion will *also* include the actual source URL `http://www.mozilla.org` - so that we can make a difference between what is typed in the location field and what that actually resolves to.

Currently the patch includes a fixed list of mock suggestions. I will file a followup bug to hook this up to our real datasources.

The code currently does not deal with paths in URLs. This is intentional. If we require that, then I will add a followup bug to adjust the API accordingly.
