### PR TITLE
Bug 1109641 - Disable the back/forward buttons when there is nothing to do

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -167,7 +167,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
                 completion: {_ in self.progressBar.setProgress(0.0, animated: false)})
         } else {
             self.progressBar.alpha = 1.0
-            self.progressBar.setProgress(progress, animated: true)
+            self.progressBar.setProgress(progress, animated: (progress > progressBar.progress))
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -45,6 +45,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
 
         backButton = UIButton()
         backButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
+        backButton.setTitleColor(UIColor.grayColor(), forState: UIControlState.Disabled)
         backButton.setTitle("<", forState: UIControlState.Normal)
         backButton.addTarget(self, action: "SELdidClickBack", forControlEvents: UIControlEvents.TouchUpInside)
         longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBack")
@@ -53,6 +54,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
 
         forwardButton = UIButton()
         forwardButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
+        forwardButton.setTitleColor(UIColor.grayColor(), forState: UIControlState.Disabled)
         forwardButton.setTitle(">", forState: UIControlState.Normal)
         forwardButton.addTarget(self, action: "SELdidClickForward", forControlEvents: UIControlEvents.TouchUpInside)
         longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressForward")
@@ -124,6 +126,14 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
 
     func updateTabCount(count: Int) {
         tabsButton.setTitle(count.description, forState: UIControlState.Normal)
+    }
+
+    func updateBackStatus(canGoBack: Bool) {
+        backButton.enabled = canGoBack
+    }
+
+    func updateFowardStatus(canGoForward: Bool) {
+        forwardButton.enabled = canGoForward
     }
 
     func SELdidClickBack() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -85,6 +85,10 @@ extension BrowserViewController: TabManagerDelegate {
         selected?.webView.navigationDelegate = self
         toolbar.updateURL(selected?.url)
         toolbar.updateProgressBar(0.0)
+        if let selected = selected {
+            toolbar.updateBackStatus(selected.canGoBack)
+            toolbar.updateFowardStatus(selected.canGoForward)
+        }
     }
 
     func didAddTab(tab: Browser) {
@@ -111,7 +115,10 @@ extension BrowserViewController: TabManagerDelegate {
 extension BrowserViewController: WKNavigationDelegate {
     func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
         toolbar.updateURL(webView.URL);
+        toolbar.updateBackStatus(webView.canGoBack)
+        toolbar.updateFowardStatus(webView.canGoForward)
     }
+
 
     override func observeValueForKeyPath(keyPath: String, ofObject object:
         AnyObject, change:[NSObject: AnyObject], context:


### PR DESCRIPTION
This is a fix for this 'bug' that is inline with having a public webView, as opposed to my alternative implementation in #53. Cheers.