### PR TITLE
Bug 1120465 - Make the browser toolbar more iOS 8 friendly

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -90,24 +90,24 @@ class BrowserToolbar: UIView, UITextFieldDelegate {
 
         self.backButton.snp_remakeConstraints { make in
             make.left.equalTo(self)
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(self).offset(10)
             make.width.height.equalTo(44)
         }
 
         self.forwardButton.snp_remakeConstraints { make in
             make.left.equalTo(self.backButton.snp_right)
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(self).offset(10)
             make.width.height.equalTo(44)
         }
 
         self.toolbarTextButton.snp_remakeConstraints { make in
             make.left.equalTo(self.forwardButton.snp_right)
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(self).offset(10)
         }
 
         self.tabsButton.snp_remakeConstraints { make in
             make.left.equalTo(self.toolbarTextButton.snp_right)
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(self).offset(10)
             make.width.height.equalTo(44)
             make.right.equalTo(self).offset(-8)
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -6,20 +6,32 @@ import Foundation
 import UIKit
 import WebKit
 
-private let StatusBarHeight = 20
+private let StatusBarHeight: CGFloat = 20 // TODO: Can't assume this is correct. Status bar height is dynamic.
+private let ToolbarHeight: CGFloat = 44
 
 class BrowserViewController: UIViewController {
     private var toolbar: BrowserToolbar!
     private let tabManager = TabManager()
 
     override func viewDidLoad() {
+        let headerView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.ExtraLight))
+        view.addSubview(headerView);
+        
+        headerView.snp_makeConstraints { make in
+            make.top.equalTo(self.view.snp_top)
+            make.height.equalTo(ToolbarHeight + StatusBarHeight)
+            make.leading.trailing.equalTo(self.view)
+        }
+        
         toolbar = BrowserToolbar()
-        view.addSubview(toolbar)
+        toolbar.backgroundColor = UIColor.clearColor()
+        headerView.addSubview(toolbar)
 
         toolbar.snp_makeConstraints { make in
-            make.top.equalTo(self.view).offset(StatusBarHeight)
-            make.height.equalTo(44)
-            make.leading.trailing.equalTo(self.view)
+            make.top.equalTo(headerView.snp_top)
+            make.left.equalTo(headerView.snp_left)
+            make.bottom.equalTo(headerView.snp_bottom)
+            make.right.equalTo(headerView.snp_right)
         }
 
         toolbar.browserToolbarDelegate = self
@@ -91,9 +103,11 @@ extension BrowserViewController: TabManagerDelegate {
         toolbar.updateTabCount(tabManager.count)
 
         tab.webView.hidden = true
-        view.addSubview(tab.webView)
+        view.insertSubview(tab.webView, atIndex: 0)
+        tab.webView.scrollView.contentInset = UIEdgeInsetsMake(ToolbarHeight + StatusBarHeight, 0, 0, 0)
+        tab.webView.scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(ToolbarHeight + StatusBarHeight, 0, 0, 0)
         tab.webView.snp_makeConstraints { make in
-            make.top.equalTo(self.toolbar.snp_bottom)
+            make.top.equalTo(self.view.snp_top)
             make.leading.trailing.bottom.equalTo(self.view)
         }
         tab.webView.addObserver(self, forKeyPath: "estimatedProgress", options: .New, context: nil)


### PR DESCRIPTION
Extend the toolbar under the status bar. Use Vibrancy on the toolbar.