### PR TITLE
Bug 1120730 - Implement search suggestions

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -92,6 +92,10 @@
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314E7F51A37B98700426A76 /* BrowserToolbar.swift */; };
+		D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
+		D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
+		D31A0FC91A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
+		D31A0FCA1A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
 		D34C5AF21A5E0C9800E0DF7B /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34C5AF11A5E0C9800E0DF7B /* SWXMLHash.swift */; };
 		D34C5AF31A5E0C9B00E0DF7B /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34C5AF11A5E0C9800E0DF7B /* SWXMLHash.swift */; };
 		D34C5AF41A5E0C9B00E0DF7B /* SWXMLHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34C5AF11A5E0C9800E0DF7B /* SWXMLHash.swift */; };
@@ -339,6 +343,7 @@
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D314E7F51A37B98700426A76 /* BrowserToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
+		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		D34C5AF11A5E0C9800E0DF7B /* SWXMLHash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SWXMLHash.swift; path = ThirdParty/SWXMLHash.swift; sourceTree = "<group>"; };
 		D34DC84D1A16C40C00D49B7B /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		D34DC84E1A16C40C00D49B7B /* AccountManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
@@ -572,6 +577,7 @@
 				D3A994951A3686BD008AD1AC /* BrowserViewController.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
+				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
@@ -1136,6 +1142,7 @@
 				282DA4711A68C1C500A406E2 /* HistoryTable.swift in Sources */,
 				E42CCDE31A23A6F900B794D3 /* Clients.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
+				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				F84B22241A09122500AAB793 /* TabBarViewController.swift in Sources */,
 				D34F86E71A1AC7DD00331EC4 /* PasswordTextField.swift in Sources */,
 				28CE83C91A1D1D3200576538 /* TokenServerClient.swift in Sources */,
@@ -1196,6 +1203,7 @@
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
 				0BE108361A1B1EC700D4B712 /* TestLocking.swift in Sources */,
 				28784D3E1A39BF2A00021E35 /* Bookmarks.swift in Sources */,
+				D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				28C0779A1A3B064F00834FE5 /* FxAClientTests.swift in Sources */,
 				0BD19A6F1A2530D30084FBA7 /* TabsViewController.swift in Sources */,
 				D35179BD1A5C6D4200E7622E /* SearchViewController.swift in Sources */,
@@ -1227,6 +1235,7 @@
 				E418D0D91A251B3200CAE47A /* Profile.swift in Sources */,
 				282DA4701A68C16900A406E2 /* FileAccessor.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,
+				D31A0FC91A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				E418D0DF1A251B3200CAE47A /* RestAPI.swift in Sources */,
 				28CDA55C1A43C37C005C318C /* ProfilePrefs.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
@@ -1250,6 +1259,7 @@
 				0B33431B1A5CB14B000AE428 /* Cursor.swift in Sources */,
 				E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */,
 				0B3342D71A5CA89E000AE428 /* BrowserDB.swift in Sources */,
+				D31A0FCA1A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				E42CCE041A24C4E300B794D3 /* ExtensionUtils.swift in Sources */,
 				F8708D2A1A0970B40051AB07 /* ActionViewController.swift in Sources */,
 				28784D4A1A39C48A00021E35 /* Bytes.swift in Sources */,

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -6,6 +6,7 @@ import Foundation
 import UIKit
 
 private let TypeSearch = "text/html"
+private let TypeSuggest = "application/x-suggestions+json"
 
 private class OpenSearchURL {
     let template: String
@@ -22,12 +23,14 @@ class OpenSearchEngine {
     let description: String?
     let image: UIImage?
     private let searchURL: OpenSearchURL
+    private let suggestURL: OpenSearchURL?
 
-    private init(shortName: String, description: String?, image: UIImage?, searchURL: OpenSearchURL) {
+    private init(shortName: String, description: String?, image: UIImage?, searchURL: OpenSearchURL, suggestURL: OpenSearchURL?) {
         self.shortName = shortName
         self.description = description
         self.image = image
         self.searchURL = searchURL
+        self.suggestURL = suggestURL
     }
 
     /**
@@ -35,6 +38,17 @@ class OpenSearchEngine {
      */
     func searchURLForQuery(query: String) -> NSURL? {
         return getURLFromTemplate(searchURL, query: query)
+    }
+
+    /**
+     * Returns the search suggestion URL for the given query.
+     */
+    func suggestURLForQuery(query: String) -> NSURL? {
+        if suggestURL == nil {
+            return nil
+        }
+
+        return getURLFromTemplate(suggestURL!, query: query)
     }
 
     private func getURLFromTemplate(openSearchURL: OpenSearchURL, query: String) -> NSURL? {
@@ -104,6 +118,7 @@ class OpenSearchParser {
         }
 
         var searchURL: OpenSearchURL!
+        var suggestURL: OpenSearchURL?
         var searchURLs = [OpenSearchURL]()
         for url in urls! {
             let type = url.attributes["type"]
@@ -112,7 +127,7 @@ class OpenSearchParser {
                 return nil
             }
 
-            if type != TypeSearch {
+            if type != TypeSearch && type != TypeSuggest {
                 // Not a supported search type.
                 continue
             }
@@ -150,6 +165,8 @@ class OpenSearchParser {
             let url = OpenSearchURL(template: template!, type: type!)
             if type == TypeSearch {
                 searchURL = url
+            } else {
+                suggestURL = url
             }
         }
 
@@ -191,6 +208,6 @@ class OpenSearchParser {
             }
         }
 
-        return OpenSearchEngine(shortName: shortName!, description: description, image: uiImage, searchURL: searchURL)
+        return OpenSearchEngine(shortName: shortName!, description: description, image: uiImage, searchURL: searchURL, suggestURL: suggestURL)
     }
 }

--- a/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Alamofire
+import Foundation
+
+let SearchSuggestClientErrorDomain = "org.mozilla.firefox.SearchSuggestClient"
+let SearchSuggestClientErrorInvalidEngine = 0
+let SearchSuggestClientErrorInvalidResponse = 1
+
+class SearchSuggestClient {
+    private let searchEngine: OpenSearchEngine
+    private weak var request: Request?
+
+    init(searchEngine: OpenSearchEngine) {
+        self.searchEngine = searchEngine
+    }
+
+    func query(query: String, callback: (response: [String]?, error: NSError?) -> ()) {
+        let url = searchEngine.suggestURLForQuery(query)
+        if url == nil {
+            let error = NSError(domain: SearchSuggestClientErrorDomain, code: SearchSuggestClientErrorInvalidEngine, userInfo: nil)
+            callback(response: nil, error: error)
+            return
+        }
+
+        request = Alamofire.request(.GET, url!)
+            .validate(statusCode: 200..<300)
+            .responseJSON { (_, _, data, err) in
+                if err != nil {
+                    callback(response: nil, error: err)
+                    return
+                }
+
+                // The response will be of the following format:
+                //    ["foobar",["foobar","foobar2000 mac","foobar skins",...]]
+                // That is, an array of at least two elements: the search term and an array of suggestions.
+                let array = data as? NSArray
+                if array == nil || array?.count < 2 {
+                    let error = NSError(domain: SearchSuggestClientErrorDomain, code: SearchSuggestClientErrorInvalidResponse, userInfo: nil)
+                    callback(response: nil, error: error)
+                    return
+                }
+
+                let suggestions = array![1] as? [String]
+                if suggestions == nil {
+                    let error = NSError(domain: SearchSuggestClientErrorDomain, code: SearchSuggestClientErrorInvalidResponse, userInfo: nil)
+                    callback(response: nil, error: error)
+                    return
+                }
+
+                callback(response: suggestions!, error: nil)
+        }
+    }
+
+    func cancelPendingRequest() {
+        if request != nil {
+            println("cancelled!")
+        }
+        request?.cancel()
+    }
+}

--- a/Client/Frontend/TabBar/SearchViewController.swift
+++ b/Client/Frontend/TabBar/SearchViewController.swift
@@ -82,7 +82,7 @@ extension SearchViewController: UITableViewDataSource {
 extension SearchViewController: UITableViewDelegate {
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let engine = sortedEngines[indexPath.row]
-        let url = engine.urlForQuery(searchQuery)
+        let url = engine.searchURLForQuery(searchQuery)
         if let url = url {
             delegate?.didClickSearchResult(url)
         }

--- a/Client/Frontend/TabBar/TabBarViewController.swift
+++ b/Client/Frontend/TabBar/TabBarViewController.swift
@@ -247,7 +247,7 @@ class TabBarViewController: UIViewController, UITextFieldDelegate, SearchViewCon
 
         // If we can't make a valid URL, do a search query.
         if url == nil {
-            url = profile.searchEngines.defaultEngine.urlForQuery(text)
+            url = profile.searchEngines.defaultEngine.searchURLForQuery(text)
         }
 
         // If we still don't have a valid URL, something is broken. Give up.

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -20,7 +20,7 @@ class SearchTests: XCTestCase {
         XCTAssertNil(engine.description)
 
         // Test regular search queries.
-        XCTAssertEqual(engine.urlForQuery("foobar")!.absoluteString!, "https://www.google.com/search?q=foobar&ie=utf-8&oe=utf-8")
+        XCTAssertEqual(engine.searchURLForQuery("foobar")!.absoluteString!, "https://www.google.com/search?q=foobar&ie=utf-8&oe=utf-8")
     }
 
     func testSearchEngines() {

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -63,4 +63,30 @@ class SearchTests: XCTestCase {
     private func checkInvalidURL(beforeFixup: String) {
         XCTAssertNil(uriFixup.getURL(beforeFixup))
     }
+
+    // TODO: Use a mock HTTP server instead.
+    func testSuggestClient() {
+        let parser = OpenSearchParser(pluginMode: true)
+        let file = NSBundle.mainBundle().pathForResource("google", ofType: "xml", inDirectory: "Locales/en-US/searchplugins")
+        let engine: OpenSearchEngine! = parser.parse(file!)
+        let client = SearchSuggestClient(searchEngine: engine)
+
+        let expectation = self.expectationWithDescription("Response received")
+
+        client.query("foobar", callback: { response, error in
+            if error != nil {
+                XCTFail("Error: \(error?.description)")
+            }
+
+            // TODO: This test is especially fragile since the suggestions list may change at any time.
+            // Check just the first few results since they're likely more stable.
+            XCTAssertEqual(response![0], "foobar")
+            XCTAssertEqual(response![1], "foobar2000 mac")
+            XCTAssertEqual(response![2], "foobar skins")
+
+            expectation.fulfill()
+        })
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
 }

--- a/ClientTests/SearchTests.swift
+++ b/ClientTests/SearchTests.swift
@@ -21,6 +21,9 @@ class SearchTests: XCTestCase {
 
         // Test regular search queries.
         XCTAssertEqual(engine.searchURLForQuery("foobar")!.absoluteString!, "https://www.google.com/search?q=foobar&ie=utf-8&oe=utf-8")
+
+        // Test search suggestion queries.
+        XCTAssertEqual(engine.suggestURLForQuery("foobar")!.absoluteString!, "https://www.google.com/complete/search?client=firefox&q=foobar")
     }
 
     func testSearchEngines() {


### PR DESCRIPTION
Ignore first commit; this is built on top of #81.

Commit 1: rather than storing all URLs in the OpenSearch file, only store ones we can use.
Commit 2: make those include application/x-suggestion+json, which is used for search suggestions
Commit 3: create a client that uses this URL to make HTTP queries
Commit 4: use this client to populate the search view