### PR TITLE
Bug 1123086: Move VoiceOver cursor after loading webpage

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,6 +163,13 @@ extension BrowserViewController: WKNavigationDelegate {
         info["title"] = webView.title
 
         notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
+
+        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
+        // must be followed by LayoutChanged, as ScreenChanged will make VoiceOver
+        // cursor land on the correct initial element, but if not followed by LayoutChanged,
+        // VoiceOver will sometimes be stuck on the element, not allowing user to move
+        // forward/backward. Strange, but LayoutChanged fixes that.
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
     }
 
 


### PR DESCRIPTION
After loading a new page (regardless whether by entering and confirming
a URL, or using the back or forward button), VoiceOver user expects the
VoiceOver cursor to automatically move to the correct element. The
"correct element" is (because this way it behaves in Safari, and seems
reasonable as it saves the user from navigating VoiceOver cursor
manually):

- the element that has focus
- if there is no such focused element:
  - if the page was loaded by entering a URL / following a link, it is
    the first element on the webpage accessible to VoiceOver
  - if the page was loaded by using back/forward button, it is the
    element where VoiceOver cursor was last present on the page

The UIAccessibilityScreenChangedNotification seems to move the VoiceOver
cursor to the "correct element", and
UIAccessibilityLayoutChangedNotification then ensures we can move from
that element to other elements.