### PR TITLE
Bug 1123809 - History visits

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -12,6 +12,17 @@
 		0B3342D71A5CA89E000AE428 /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342CC1A5CA893000AE428 /* BrowserDB.swift */; };
 		0B3342DE1A5CA93D000AE428 /* libsqlite3.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B3342DB1A5CA929000AE428 /* libsqlite3.0.dylib */; };
 		0B33431B1A5CB14B000AE428 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8501A16C40C00D49B7B /* Cursor.swift */; };
+		0B3B97241A6EC7EF003D18D9 /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */; };
+		0B3B97281A6ECC44003D18D9 /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */; };
+		0B3B97291A6ECC45003D18D9 /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */; };
+		0B3B972A1A6ECC46003D18D9 /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */; };
+		0B3B973E1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */; };
+		0B3B97421A6EFD09003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */; };
+		0B3B97431A6EFD09003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */; };
+		0B3B97441A6EFD0A003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */; };
+		0B3B97461A6F0805003D18D9 /* TestVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97451A6F0805003D18D9 /* TestVisitsTable.swift */; };
+		0B3B97481A6F0810003D18D9 /* TestJoinedHistoryVisits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97471A6F0810003D18D9 /* TestJoinedHistoryVisits.swift */; };
+		0B3B974A1A6F0827003D18D9 /* TestHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B97491A6F0827003D18D9 /* TestHistoryTable.swift */; };
 		0B657B451A3B9CAB005A9E43 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BDB952B1A3B9918000F2B0F /* Site.swift */; };
 		0B657B461A3B9CAB005A9E43 /* Favicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BDB95291A3B9917000F2B0F /* Favicon.swift */; };
 		0B79B17F1A3F6DD500DBECB3 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8511A16C40C00D49B7B /* Favicons.swift */; };
@@ -22,6 +33,14 @@
 		0B79B18B1A3F6DE900DBECB3 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BDB952B1A3B9918000F2B0F /* Site.swift */; };
 		0B925B491A5C56E1007EA8E7 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8501A16C40C00D49B7B /* Cursor.swift */; };
 		0B9E3DE71A23FBD1008A7877 /* TestPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */; };
+		0BA2E3891A688167000581FA /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3881A688167000581FA /* Visit.swift */; };
+		0BA2E38D1A6881FF000581FA /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3881A688167000581FA /* Visit.swift */; };
+		0BA2E38E1A688200000581FA /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3881A688167000581FA /* Visit.swift */; };
+		0BA2E38F1A688201000581FA /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3881A688167000581FA /* Visit.swift */; };
+		0BA2E3911A6882B0000581FA /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3901A6882B0000581FA /* VisitsTable.swift */; };
+		0BA2E3921A688771000581FA /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3901A6882B0000581FA /* VisitsTable.swift */; };
+		0BA2E3931A688772000581FA /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3901A6882B0000581FA /* VisitsTable.swift */; };
+		0BA2E3941A688773000581FA /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA2E3901A6882B0000581FA /* VisitsTable.swift */; };
 		0BA2E3FC1A69D754000581FA /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3343021A5CADA2000AE428 /* History.swift */; };
 		0BA2E4001A69D755000581FA /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3343021A5CADA2000AE428 /* History.swift */; };
 		0BA2E4011A69D755000581FA /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3343021A5CADA2000AE428 /* History.swift */; };
@@ -31,10 +50,11 @@
 		0BA2E4051A69D769000581FA /* HistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342F81A5CAD94000AE428 /* HistoryTable.swift */; };
 		0BA2E4061A69D76A000581FA /* HistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342F81A5CAD94000AE428 /* HistoryTable.swift */; };
 		0BA2E4071A69D77C000581FA /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342CC1A5CA893000AE428 /* BrowserDB.swift */; };
-		0BA2E4081A69D77D000581FA /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342CC1A5CA893000AE428 /* BrowserDB.swift */; };
 		0BA2E4091A69D798000581FA /* SwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0E923E1A6079B0006A606F /* SwiftData.swift */; };
 		0BA2E40A1A69D799000581FA /* SwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0E923E1A6079B0006A606F /* SwiftData.swift */; };
 		0BA2E40B1A69D9CC000581FA /* libsqlite3.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B3342DB1A5CA929000AE428 /* libsqlite3.0.dylib */; };
+		0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
+		0BA2E4401A69EDBD000581FA /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3342CC1A5CA893000AE428 /* BrowserDB.swift */; };
 		0BA8964B1A250E6500C1010C /* AccountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA896491A250E6500C1010C /* AccountTest.swift */; };
 		0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA8964A1A250E6500C1010C /* TestBookmarks.swift */; };
 		0BD19A5F1A2530320084FBA7 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B22221A09122500AAB793 /* TabBarViewController.swift */; };
@@ -119,7 +139,6 @@
 		D34DC8561A16C40C00D49B7B /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8501A16C40C00D49B7B /* Cursor.swift */; };
 		D34DC8571A16C40C00D49B7B /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8511A16C40C00D49B7B /* Favicons.swift */; };
 		D34DC8581A16C40C00D49B7B /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8521A16C40C00D49B7B /* RestAPI.swift */; };
-		D34DC8611A16C47300D49B7B /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		D34DC8621A16C49600D49B7B /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84E1A16C40C00D49B7B /* AccountManager.swift */; };
 		D34F86DB1A1AC35B00331EC4 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34F86DA1A1AC35B00331EC4 /* LoginView.swift */; };
 		D34F86E71A1AC7DD00331EC4 /* PasswordTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34F86E61A1AC7DD00331EC4 /* PasswordTextField.swift */; };
@@ -355,8 +374,15 @@
 		0B3342F81A5CAD94000AE428 /* HistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryTable.swift; sourceTree = "<group>"; };
 		0B3343021A5CADA2000AE428 /* History.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = History.swift; path = Client/DataAccess/History.swift; sourceTree = "<group>"; };
 		0B3343041A5CADC1000AE428 /* TestHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHistory.swift; sourceTree = "<group>"; };
+		0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericTable.swift; sourceTree = "<group>"; };
+		0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinedHistoryVisitsTable.swift; sourceTree = "<group>"; };
+		0B3B97451A6F0805003D18D9 /* TestVisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestVisitsTable.swift; sourceTree = "<group>"; };
+		0B3B97471A6F0810003D18D9 /* TestJoinedHistoryVisits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJoinedHistoryVisits.swift; sourceTree = "<group>"; };
+		0B3B97491A6F0827003D18D9 /* TestHistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHistoryTable.swift; sourceTree = "<group>"; };
 		0B9E3DD91A23FBBC008A7877 /* Panels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Panels.swift; sourceTree = "<group>"; };
 		0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPanels.swift; sourceTree = "<group>"; };
+		0BA2E3881A688167000581FA /* Visit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visit.swift; sourceTree = "<group>"; };
+		0BA2E3901A6882B0000581FA /* VisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitsTable.swift; sourceTree = "<group>"; };
 		0BA896491A250E6500C1010C /* AccountTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountTest.swift; sourceTree = "<group>"; };
 		0BA8964A1A250E6500C1010C /* TestBookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBookmarks.swift; sourceTree = "<group>"; };
 		0BD19A661A25309B0084FBA7 /* ProfilePrefs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfilePrefs.swift; sourceTree = "<group>"; };
@@ -535,6 +561,9 @@
 				282DA44F1A68BFEF00A406E2 /* SQLiteHistory.swift */,
 				0B3342F81A5CAD94000AE428 /* HistoryTable.swift */,
 				0B3342CC1A5CA893000AE428 /* BrowserDB.swift */,
+				0BA2E3901A6882B0000581FA /* VisitsTable.swift */,
+				0B3B97231A6EC7EF003D18D9 /* GenericTable.swift */,
+				0B3B973D1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift */,
 			);
 			name = SQL;
 			path = Client/DataAccess/SQL;
@@ -640,6 +669,7 @@
 				0BDB952B1A3B9918000F2B0F /* Site.swift */,
 				0BDB95291A3B9917000F2B0F /* Favicon.swift */,
 				0BE00DB91A5DE1420081E374 /* FileAccessor.swift */,
+				0BA2E3881A688167000581FA /* Visit.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -800,6 +830,9 @@
 				0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
+				0B3B97451A6F0805003D18D9 /* TestVisitsTable.swift */,
+				0B3B97471A6F0810003D18D9 /* TestJoinedHistoryVisits.swift */,
+				0B3B97491A6F0827003D18D9 /* TestHistoryTable.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -1252,6 +1285,7 @@
 				E4CD9F0A1A6D9B0900318571 /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				0BDB952C1A3B9918000F2B0F /* Site.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
+				0BA2E3891A688167000581FA /* Visit.swift in Sources */,
 				0B0E923F1A6079B0006A606F /* SwiftData.swift in Sources */,
 				F84B22191A0911B500AAB793 /* BookmarksViewController.swift in Sources */,
 				28CE83C51A1D1D3200576538 /* EncryptedRecord.swift in Sources */,
@@ -1297,15 +1331,18 @@
 				28CE83C71A1D1D3200576538 /* Records.swift in Sources */,
 				282DA47C1A68C43300A406E2 /* BrowserDB.swift in Sources */,
 				F84B22111A0910F600AAB793 /* SettingsViewController.swift in Sources */,
+				0BA2E3911A6882B0000581FA /* VisitsTable.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				282DA47D1A68C45C00A406E2 /* SearchViewController.swift in Sources */,
 				D34F86DB1A1AC35B00331EC4 /* LoginView.swift in Sources */,
 				D34DC8551A16C40C00D49B7B /* BookmarksREST.swift in Sources */,
 				28CE84301A1E571900576538 /* json.swift in Sources */,
 				E4CD9F041A6D9B0900318571 /* GCDWebServerResponse.m in Sources */,
+				0B3B97241A6EC7EF003D18D9 /* GenericTable.swift in Sources */,
 				0BD19A671A25309B0084FBA7 /* ProfilePrefs.swift in Sources */,
 				E4CD9F101A6D9B0900318571 /* GCDWebServerErrorResponse.m in Sources */,
 				F84B221D1A0911BF00AAB793 /* HistoryViewController.swift in Sources */,
+				0B3B973E1A6EED0F003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */,
 				D34C5AF21A5E0C9800E0DF7B /* SWXMLHash.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,
@@ -1327,19 +1364,25 @@
 				0BD19A691A2530B60084FBA7 /* BookmarksViewController.swift in Sources */,
 				E4CD9F111A6D9B0900318571 /* GCDWebServerErrorResponse.m in Sources */,
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
+				0B3B97281A6ECC44003D18D9 /* GenericTable.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* AccountTest.swift in Sources */,
 				0BA2E4091A69D798000581FA /* SwiftData.swift in Sources */,
 				0BD19A701A2530DE0084FBA7 /* Tabs.swift in Sources */,
 				0B657B451A3B9CAB005A9E43 /* Site.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				E42CCDEE1A23C2C600B794D3 /* Clients.swift in Sources */,
+				0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */,
+				0BA2E3921A688771000581FA /* VisitsTable.swift in Sources */,
+				0B3B97461A6F0805003D18D9 /* TestVisitsTable.swift in Sources */,
+				0BA2E38D1A6881FF000581FA /* Visit.swift in Sources */,
 				28784D451A39C48900021E35 /* Bytes.swift in Sources */,
 				0BA2E4071A69D77C000581FA /* BrowserDB.swift in Sources */,
-				D34DC8611A16C47300D49B7B /* Profile.swift in Sources */,
 				E4CD9F151A6D9B0900318571 /* GCDWebServerStreamedResponse.m in Sources */,
 				D34DC8621A16C49600D49B7B /* AccountManager.swift in Sources */,
+				0B3B974A1A6F0827003D18D9 /* TestHistoryTable.swift in Sources */,
 				E4CD9F091A6D9B0900318571 /* GCDWebServerFileRequest.m in Sources */,
 				0BD19A6B1A2530C20084FBA7 /* SiteTableViewController.swift in Sources */,
+				0B3B97481A6F0810003D18D9 /* TestJoinedHistoryVisits.swift in Sources */,
 				E42CCE021A24C4E300B794D3 /* ExtensionUtils.swift in Sources */,
 				E4CD9F131A6D9B0900318571 /* GCDWebServerFileResponse.m in Sources */,
 				E4CD9F011A6D9B0900318571 /* GCDWebServerFunctions.m in Sources */,
@@ -1372,6 +1415,7 @@
 				0BE108361A1B1EC700D4B712 /* TestLocking.swift in Sources */,
 				28784D3E1A39BF2A00021E35 /* Bookmarks.swift in Sources */,
 				D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
+				0B3B97421A6EFD09003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */,
 				28C0779A1A3B064F00834FE5 /* FxAClientTests.swift in Sources */,
 				0BD19A6F1A2530D30084FBA7 /* TabsViewController.swift in Sources */,
 				D35179BD1A5C6D4200E7622E /* SearchViewController.swift in Sources */,
@@ -1389,17 +1433,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B3B97431A6EFD09003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */,
 				D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */,
+				0BA2E38E1A688200000581FA /* Visit.swift in Sources */,
 				0B79B18A1A3F6DE900DBECB3 /* Site.swift in Sources */,
 				E418D0DA1A251B3200CAE47A /* AccountManager.swift in Sources */,
 				0BA2E4031A69D766000581FA /* SQLiteHistory.swift in Sources */,
 				0BA2E4061A69D76A000581FA /* HistoryTable.swift in Sources */,
 				0BD2C61D1A643B6000BB4BB9 /* Locking.swift in Sources */,
+				0BA2E4401A69EDBD000581FA /* BrowserDB.swift in Sources */,
+				0B3B97291A6ECC45003D18D9 /* GenericTable.swift in Sources */,
 				282DA46D1A68C15100A406E2 /* SearchEngines.swift in Sources */,
 				28784D491A39C48900021E35 /* Bytes.swift in Sources */,
 				E418D0DC1A251B3200CAE47A /* Clients.swift in Sources */,
 				0B79B1881A3F6DE000DBECB3 /* Favicon.swift in Sources */,
 				282DA4741A68C1FE00A406E2 /* OpenSearch.swift in Sources */,
+				0BA2E3931A688772000581FA /* VisitsTable.swift in Sources */,
 				0B925B491A5C56E1007EA8E7 /* Cursor.swift in Sources */,
 				0BA2E4001A69D755000581FA /* History.swift in Sources */,
 				28784D1A1A38CA9400021E35 /* Bookmarks.swift in Sources */,
@@ -1412,7 +1461,6 @@
 				D31A0FC91A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				E418D0DF1A251B3200CAE47A /* RestAPI.swift in Sources */,
 				28CDA55C1A43C37C005C318C /* ProfilePrefs.swift in Sources */,
-				0BA2E4081A69D77D000581FA /* BrowserDB.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
 				0B79B17F1A3F6DD500DBECB3 /* Favicons.swift in Sources */,
 				E418D0DB1A251B3200CAE47A /* BookmarksREST.swift in Sources */,
@@ -1435,10 +1483,14 @@
 				E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */,
 				0B3342D71A5CA89E000AE428 /* BrowserDB.swift in Sources */,
 				D31A0FCA1A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
+				0BA2E3941A688773000581FA /* VisitsTable.swift in Sources */,
+				0B3B97441A6EFD0A003D18D9 /* JoinedHistoryVisitsTable.swift in Sources */,
+				0BA2E38F1A688201000581FA /* Visit.swift in Sources */,
 				E42CCE041A24C4E300B794D3 /* ExtensionUtils.swift in Sources */,
 				0BA2E4041A69D767000581FA /* SQLiteHistory.swift in Sources */,
 				F8708D2A1A0970B40051AB07 /* ActionViewController.swift in Sources */,
 				28784D4A1A39C48A00021E35 /* Bytes.swift in Sources */,
+				0B3B972A1A6ECC46003D18D9 /* GenericTable.swift in Sources */,
 				282DA4721A68C1D000A406E2 /* HistoryTable.swift in Sources */,
 				0BA2E4011A69D755000581FA /* History.swift in Sources */,
 				28784D1B1A38CA9400021E35 /* Bookmarks.swift in Sources */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -53,10 +53,13 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "TokenServerClientTests">
+                  Identifier = "FxAClientTests/testLoginSuccess()">
                </Test>
                <Test
-                  Identifier = "FxAClientTests/testLoginSuccess()">
+                  Identifier = "SearchTests">
+               </Test>
+               <Test
+                  Identifier = "TokenServerClientTests">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Client/DataAccess/History.swift
+++ b/Client/DataAccess/History.swift
@@ -2,14 +2,11 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-enum HistoryOptions {
-}
-
 /* The base history protocol */
 protocol History {
     init(profile: Profile)
 
-    func clear(filter: String?, options: HistoryOptions?, complete: (success: Bool) -> Void)
-    func get(filter: String?, options: HistoryOptions?, complete: (data: Cursor) -> Void)
-    func addVisit(site: Site, options: HistoryOptions?, complete: (success: Bool) -> Void)
+    func clear(complete: (success: Bool) -> Void)
+    func get(options: QueryOptions?, complete: (data: Cursor) -> Void)
+    func addVisit(visit: Visit, complete: (success: Bool) -> Void)
 }

--- a/Client/DataAccess/SQL/BrowserDB.swift
+++ b/Client/DataAccess/SQL/BrowserDB.swift
@@ -12,7 +12,7 @@ enum FilterType {
 
 class QueryOptions {
     // A filter string to apploy to the query
-    var filter: String = ""
+    var filter: String? = nil
 
     // Allows for customizing how the filter is applied (i.e. only urls or urls and titles?)
     var filterType: FilterType = .None

--- a/Client/DataAccess/SQL/GenericTable.swift
+++ b/Client/DataAccess/SQL/GenericTable.swift
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class GenericTable<T>: Table {
+    // Implementors need override these methods
+    let debug_enabled = false
+    var name: String { return "" }
+    var rows: String { return "" }
+    var factory: ((row: SDRow) -> T)? {
+        return nil
+    }
+
+    func getInsertAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        return (nil, [AnyObject?]())
+    }
+
+    func getUpdateAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        return (nil, [AnyObject?]())
+    }
+
+    func getDeleteAndArgs<T>(item: T?) -> (String?, [AnyObject?]) {
+        return (nil, [AnyObject?]())
+    }
+
+    func getQueryAndArgs(options: QueryOptions?) -> (String?, [AnyObject?]) {
+        return (nil, [AnyObject?]())
+    }
+
+    // Here's the real implementation
+    func debug(msg: String) {
+        if debug_enabled {
+            println("GenericTable: \(msg)")
+        }
+    }
+
+    func create(db: SQLiteDBConnection, version: Int) -> Bool {
+        db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(rows))")
+        return true
+    }
+
+    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
+        debug("Update table \(name) from \(from) to \(to)")
+        return false
+    }
+
+    func insert<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        debug("Insert into \(name) \(item)")
+        if let site = item {
+            let (query, args) = getInsertAndArgs(site)
+            if let query = query {
+                if let error = db.executeChange(query, withArgs: args) {
+                    err = error
+                    return -1
+                }
+
+                return db.lastInsertedRowID
+            }
+        }
+
+        err = NSError(domain: "mozilla.org", code: 0, userInfo: [
+            NSLocalizedDescriptionKey: "Tried to save something that isn't a site"
+        ])
+        return -1
+    }
+
+    func update<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        debug("Update into \(name) \(item)")
+        if let site = item {
+            let (query, args) = getUpdateAndArgs(site)
+            if let query = query {
+                if let error = db.executeChange(query, withArgs: args) {
+                    println(error.description)
+                    err = error
+                    return 0
+                }
+
+                return db.numberOfRowsModified
+            }
+        }
+
+        err = NSError(domain: "mozilla.org", code: 0, userInfo: [
+            NSLocalizedDescriptionKey: "Tried to save something that isn't a site"
+            ])
+        return 0
+    }
+
+    func delete<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        debug("Delete from \(name) \(item)")
+        var numDeleted: Int = 0
+
+        let (query, args) = getDeleteAndArgs(item);
+        if let query = query {
+            if let error = db.executeChange(query, withArgs: args) {
+                println(error.description)
+                err = error
+                return 0
+            }
+
+            return db.numberOfRowsModified
+        }
+        return 0
+    }
+
+    func query(db: SQLiteDBConnection, options: QueryOptions?) -> Cursor {
+        var (query, args) = getQueryAndArgs(options)
+        if var query = query {
+            if let factory = self.factory {
+                return db.executeQuery(query, factory: factory, withArgs: args)
+            }
+        }
+        return Cursor(status: CursorStatus.Failure, msg: "Invalid query: \(options?.filter)")
+    }
+}

--- a/Client/DataAccess/SQL/HistoryTable.swift
+++ b/Client/DataAccess/SQL/HistoryTable.swift
@@ -5,111 +5,59 @@
 let TableNameHistory = "history"
 let NotASiteErrorCode = 100
 
-class HistoryTable: Table {
-    let name = "History"
-    private let rows = "guid TEXT NOT NULL UNIQUE, " +
+class HistoryTable<T>: GenericTable<Site> {
+    override var name: String { return TableNameHistory }
+    override var rows: String { return "guid TEXT NOT NULL UNIQUE, " +
                        "url TEXT NOT NULL UNIQUE, " +
-                       "title TEXT NOT NULL"
+                       "title TEXT NOT NULL" }
 
-    let debug_enabled = false
-    func debug(msg: String) {
-        if debug_enabled {
-            println("HistoryTable: \(msg)")
+    override func getInsertAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        let site = item as Site
+        // Runtime errors happen if we let Swift try to infer the type of this array
+        // so we construct it very specifically.
+        var args = [AnyObject?]()
+        if site.guid == nil {
+            site.guid = NSUUID().UUIDString
         }
+        args.append(site.guid!)
+        args.append(site.url)
+        args.append(site.title)
+        return ("INSERT INTO \(TableNameHistory) (guid, url, title) VALUES (?,?,?)", args)
     }
 
-    func create(db: SQLiteDBConnection, version: Int) -> Bool {
-        db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(self.rows))")
-        return true
+    override func getUpdateAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        let site = item as Site
+        // Runtime errors happen if we let Swift try to infer the type of this array
+        // so we construct it very specifically.
+        var args = [AnyObject?]()
+        args.append(site.title)
+        args.append(site.url)
+        return ("UPDATE \(TableNameHistory) SET title = ? WHERE url = ?", args)
     }
 
-    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
-        debug("Update table \(name) from \(from) to \(to)")
-        // No upgrades yet
-        return false
-    }
-
-    func insert<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
-        debug("Insert into \(name) \(item)")
+    override func getDeleteAndArgs<T>(item: T?) -> (String?, [AnyObject?]) {
+        var args = [AnyObject?]()
         if let site = item as? Site {
-            let query = "INSERT INTO \(self.name) (guid, url, title) VALUES (?,?,?)"
-            let args: [AnyObject?] = [site.guid, site.url, site.title]
-            if let error = db.executeChange(query, withArgs: args) {
-                err = error
-                return 0
-            }
-            return db.lastInsertedRowID
-        }
-
-        err = NSError(domain: "mozilla.org", code: NotASiteErrorCode, userInfo: [
-            NSLocalizedDescriptionKey: "Tried to save something that isn't a site"
-        ])
-        return 0
-    }
-
-    func update<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
-        debug("Update into \(name) \(item)")
-        if let site = item as? Site {
-            let query = "UPDATE \(self.name) SET title = ? WHERE guid = ? AND url = ?"
-            let args = [site.title, site.guid, site.url]
-            if let error = db.executeChange(query, withArgs: args) {
-                println(error.description)
-                err = error
-                return 0
-            }
-
-            return db.numberOfRowsModified
-        }
-
-        err = NSError(domain: "mozilla.org", code: NotASiteErrorCode, userInfo: [
-            NSLocalizedDescriptionKey: "Tried to save something that isn't a site"
-        ])
-        return 0
-    }
-
-    func delete<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
-        debug("Delete from \(name) \(item)")
-        var numDeleted: Int = 0
-        var str = "DELETE FROM \(name)"
-        var args = [String]()
-
-        if let site = item as? Site {
-            str += " WHERE url = ?"
             args.append(site.url)
-        } else if item != nil {
-            err = NSError(domain: "org.mozilla", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid object"])
-            return numDeleted
+            return ("DELETE FROM \(TableNameHistory) WHERE url = ?", args)
         }
+        return ("DELETE FROM \(TableNameHistory)", args)
+    }
 
-        if str != "" {
-            if let error = db.executeChange(str, withArgs: args) {
-                println(error.description)
-                err = error
-                return 0
-            }
+    override var factory: ((row: SDRow) -> Site)? {
+        return { row -> Site in
+            let site = Site(url: row[1] as String, title: row[2] as String)
+            site.guid = row[0] as? String
+            return site
         }
-
-        return db.numberOfRowsModified
     }
 
-    private func fromResult(result: SDRow) -> Site {
-        let site = Site(url: result[1] as String, title: result[2] as String)
-        site.guid = result[0] as String
-        return site
-    }
-
-    func factory(row: SDRow) -> Site {
-        let url = row["url"] as String
-        let title = row["title"] as String
-        let guid = row["guid"] as String
-
-        let s = Site(url: url, title: title)
-        s.guid = guid
-        return s
-    }
-
-    func query(db: SQLiteDBConnection) -> Cursor {
-        debug("Query \(name)")
-        return db.executeQuery("SELECT guid, url, title FROM \(name)", factory: self.factory)
+    override func getQueryAndArgs(options: QueryOptions?) -> (String?, [AnyObject?]) {
+        var args = [AnyObject?]()
+        if let filter = options?.filter {
+            args.append(filter)
+            return ("SELECT guid, url, title FROM \(TableNameHistory) WHERE url LIKE ?", args)
+        }
+        return ("SELECT guid, url, title FROM \(TableNameHistory)", args)
     }
 }

--- a/Client/DataAccess/SQL/JoinedHistoryVisitsTable.swift
+++ b/Client/DataAccess/SQL/JoinedHistoryVisitsTable.swift
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+let HistoryVisits = "history-visits"
+
+class JoinedHistoryVisitsTable: Table {
+    var name: String { return HistoryVisits }
+
+    private let visits = VisitsTable<Visit>()
+    private let history = HistoryTable<Site>()
+
+    private func getGuidFor(db: SQLiteDBConnection, site: Site) -> String? {
+        let opts = QueryOptions()
+        opts.filter = site.url
+
+        let cursor = history.query(db, options: opts)
+        if (cursor.count != 1) {
+            return nil
+        }
+        return (cursor[0] as Site).guid
+    }
+
+    func create(db: SQLiteDBConnection, version: Int) -> Bool {
+        return history.create(db, version: version) && visits.create(db, version: version)
+    }
+
+    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
+        return history.updateTable(db, from: from, to: to) && visits.updateTable(db, from: from, to: to)
+    }
+
+    private func updateSite(db: SQLiteDBConnection, site: Site, inout err: NSError?) -> Int {
+        // If our site doesn't have a guid, we need to find one
+        if site.guid == nil {
+            if let guid = getGuidFor(db, site: site) {
+                site.guid = guid
+                // Update the page title
+                return history.update(db, item: site, err: &err);
+            } else {
+                // Make sure we have a site in the table first
+                site.guid = NSUUID().UUIDString
+                return history.insert(db, item: site, err: &err)
+            }
+        }
+
+        // Update the page title
+        return history.update(db, item: site, err: &err)
+    }
+
+    func insert<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        if let visit = item as? Visit {
+            if updateSite(db, site: visit.site, err: &err) < 0 {
+                return -1;
+            }
+
+            // Now add a visit
+            return visits.insert(db, item: visit, err: &err)
+        } else if let site = item as? Site {
+            if updateSite(db, site: site, err: &err) < 0 {
+                return -1;
+            }
+
+            // Now add a visit
+            let visit = Visit(site: site, date: NSDate())
+            return visits.insert(db, item: visit, err: &err)
+        }
+
+        return -1
+    }
+
+    func update<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        return visits.update(db, item: item, err: &err);
+    }
+
+    func delete<T>(db: SQLiteDBConnection, item: T?, inout err: NSError?) -> Int {
+        if let visit = item as? Visit {
+            return visits.delete(db, item: visit, err: &err)
+        } else if let site = item as? Site {
+            visits.delete(db, item: site, err: &err)
+            return history.delete(db, item: site, err: &err)
+        } else if item == nil {
+            let site: Site? = nil
+            let visit: Visit? = nil
+            history.delete(db, item: site, err: &err);
+            return visits.delete(db, item: visit, err: &err);
+        }
+        return -1
+    }
+
+    func factory(result: SDRow) -> AnyObject {
+        let site = Site(url: result[1] as String, title: result[2] as String)
+        site.guid = result[0] as? String
+        return site
+    }
+
+    func query(db: SQLiteDBConnection, options: QueryOptions?) -> Cursor {
+        println("Query \(options)")
+        var args = [AnyObject?]()
+        var sql = "SELECT siteGuid as guid, url, title FROM \(TableNameVisits) " +
+            "INNER JOIN \(TableNameHistory) ON \(TableNameHistory).guid = \(TableNameVisits).siteGuid ";
+
+        if let filter = options?.filter {
+            sql += "WHERE url LIKE ? "
+            args.append(filter)
+        }
+        sql += "GROUP BY siteGuid";
+
+        // if options?.sort == .LastVisit {
+            // sql += " ORDER BY date DESC"
+        // }
+
+        return db.executeQuery(sql, factory: factory, withArgs: args)
+    }
+}

--- a/Client/DataAccess/SQL/JoinedHistoryVisitsTable.swift
+++ b/Client/DataAccess/SQL/JoinedHistoryVisitsTable.swift
@@ -94,20 +94,23 @@ class JoinedHistoryVisitsTable: Table {
     }
 
     func query(db: SQLiteDBConnection, options: QueryOptions?) -> Cursor {
-        println("Query \(options)")
         var args = [AnyObject?]()
         var sql = "SELECT siteGuid as guid, url, title FROM \(TableNameVisits) " +
-            "INNER JOIN \(TableNameHistory) ON \(TableNameHistory).guid = \(TableNameVisits).siteGuid ";
+                  "INNER JOIN \(TableNameHistory) ON \(TableNameHistory).guid = \(TableNameVisits).siteGuid ";
 
         if let filter = options?.filter {
             sql += "WHERE url LIKE ? "
             args.append(filter)
         }
+
         sql += "GROUP BY siteGuid";
 
-        // if options?.sort == .LastVisit {
-            // sql += " ORDER BY date DESC"
-        // }
+        // Trying to do this in one line (i.e. options?.sort == .LastVisit) breaks the Swift compiler
+        if let sort = options?.sort {
+            if sort == .LastVisit {
+                sql += " ORDER BY date DESC"
+            }
+        }
 
         return db.executeQuery(sql, factory: factory, withArgs: args)
     }

--- a/Client/DataAccess/SQL/SQLiteHistory.swift
+++ b/Client/DataAccess/SQL/SQLiteHistory.swift
@@ -12,10 +12,10 @@ class SqliteHistory : History {
         self.db = BrowserDB(profile: profile)!
     }
 
-    func clear(filter: String?, options: HistoryOptions?, complete: (success: Bool) -> Void) {
+    func clear(complete: (success: Bool) -> Void) {
         let s: Site? = nil
         var err: NSError? = nil
-        db.delete(TableNameHistory, item: s, err: &err)
+        db.delete(HistoryVisits, item: s, err: &err)
         dispatch_async(dispatch_get_main_queue()) {
             if err != nil {
                 self.debug("Clear failed: \(err!.localizedDescription)")
@@ -23,18 +23,17 @@ class SqliteHistory : History {
         }
     }
 
-    func get(filter: String?, options: HistoryOptions?, complete: (data: Cursor) -> Void) {
-        let res = db.query(TableNameHistory)
+    func get(options: QueryOptions?, complete: (data: Cursor) -> Void) {
+        let res = db.query(HistoryVisits, options: options)
+
         dispatch_async(dispatch_get_main_queue()) {
             complete(data: res)
         }
     }
 
-    func addVisit(site: Site, options: HistoryOptions?, complete: (success: Bool) -> Void) {
+    func addVisit(visit: Visit, complete: (success: Bool) -> Void) {
         var err: NSError? = nil
-        db.insert(TableNameHistory, item: site, err: &err)
-        // TODO: Track visits in a separate table
-
+        db.insert(HistoryVisits, item: visit, err: &err)
         dispatch_async(dispatch_get_main_queue()) {
             if err != nil {
                 self.debug("Add failed: \(err!.localizedDescription)")

--- a/Client/DataAccess/SQL/VisitsTable.swift
+++ b/Client/DataAccess/SQL/VisitsTable.swift
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+let TableNameVisits = "visits"
+
+class VisitsTable<T>: GenericTable<Visit> {
+    override var name: String { return TableNameVisits }
+    override var rows: String { return "guid TEXT NOT NULL UNIQUE, " +
+                      "siteGuid TEXT NOT NULL, " +
+                      "date REAL NOT NULL" }
+
+    override func getInsertAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        let visit = item as Visit
+        // Runtime errors happen if we let Swift try to infer the type of this array
+        // so we construct it very specifically.
+        var args = [AnyObject?]()
+        args.append(visit.guid)
+        args.append(visit.site.guid!)
+        args.append(visit.date.timeIntervalSince1970)
+        return ("INSERT INTO \(TableNameVisits) (guid, siteGuid, date) VALUES (?,?,?)", args)
+    }
+
+    override func getUpdateAndArgs<T>(item: T) -> (String?, [AnyObject?]) {
+        let visit = item as Visit
+        return (nil, [AnyObject?]());
+    }
+
+    override func getDeleteAndArgs<T>(item: T?) -> (String?, [AnyObject?]) {
+        if let visit = item as? Visit {
+            return ("DELETE FROM \(TableNameVisits) WHERE guid = ?", [visit.guid])
+        } else if let site = item as? Site {
+            return ("DELETE FROM \(TableNameVisits) WHERE siteGuid = ?", [site.guid])
+        } else if item != nil {
+            return (nil, [String]())
+        }
+        return ("DELETE FROM \(TableNameVisits)", [AnyObject]())
+    }
+
+    override var factory: ((row: SDRow) -> Visit)? {
+        return { row -> Visit in
+            let site = Site(url: "", title: "")
+            site.guid = row["siteGuid"] as? String
+
+            let dt = row["date"] as NSTimeInterval
+            let date = NSDate(timeIntervalSince1970: dt)
+            let v = Visit(site: site, date: date)
+            v.guid = row["guid"] as String
+            return v
+        }
+    }
+
+    override func getQueryAndArgs(options: QueryOptions?) -> (String?, [AnyObject?]) {
+        if let filter = options?.filter {
+            let args : [AnyObject?] = [filter]
+            return ("SELECT guid, siteGuid, date FROM \(TableNameVisits) WHERE siteGuid = ?", args)
+        }
+        return ("SELECT guid, siteGuid, date FROM \(TableNameVisits)", [AnyObject?]())
+    }
+}

--- a/Client/Frontend/History/HistoryViewController.swift
+++ b/Client/Frontend/History/HistoryViewController.swift
@@ -19,7 +19,11 @@ class HistoryViewController: UITableViewController, UrlViewController {
 
         set (profile) {
             self._profile = profile
-            profile.history.get(nil, complete: { (data: Cursor) -> Void in
+
+            let opts = QueryOptions()
+            opts.sort = .LastVisit
+
+            profile.history.get(opts, complete: { (data: Cursor) -> Void in
                 if data.status != .Success {
                     println("Err: \(data.statusMessage)")
                 } else {

--- a/Client/Frontend/History/HistoryViewController.swift
+++ b/Client/Frontend/History/HistoryViewController.swift
@@ -19,7 +19,7 @@ class HistoryViewController: UITableViewController, UrlViewController {
 
         set (profile) {
             self._profile = profile
-            profile.history.get(nil, options: nil, complete: { (data: Cursor) -> Void in
+            profile.history.get(nil, complete: { (data: Cursor) -> Void in
                 if data.status != .Success {
                     println("Err: \(data.statusMessage)")
                 } else {

--- a/ClientTests/TestHistoryTable.swift
+++ b/ClientTests/TestHistoryTable.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+class TestHistoryTable : AccountTest {
+    var db: SwiftData!
+
+    private func addSite(history: HistoryTable<Site>, url: String, title: String, s: Bool = true) {
+        var inserted = -1;
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            let site = Site(url: url, title: title)
+            var err: NSError? = nil
+            inserted = history.insert(connection, item: site, err: &err)
+            return err
+        }
+        if s {
+            XCTAssert(inserted >= 0, "Inserted succeeded")
+        } else {
+            XCTAssert(inserted == -1, "Inserted failed")
+        }
+    }
+
+    private func updateSite(history: HistoryTable<Site>, url: String, title: String, s: Bool = true) {
+        var updated = -1;
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            let site = Site(url: url, title: title)
+            var err: NSError? = nil
+            updated = history.update(connection, item: site, err: &err)
+            return err
+        }
+
+        if s {
+            XCTAssert(updated >= 0, "Update succeeded")
+        } else {
+            XCTAssert(updated == -1, "Update failed")
+        }
+    }
+
+    private func checkSites(history: HistoryTable<Site>, options: QueryOptions?, urls: [String], titles: [String], s: Bool = true) {
+        db.withConnection(.ReadOnly) { connection -> NSError? in
+            var cursor = history.query(connection, options: options)
+            XCTAssertEqual(cursor.status, CursorStatus.Success, "returned success \(cursor.statusMessage)")
+            XCTAssertEqual(cursor.count, urls.count, "cursor has right num of entries")
+
+            for index in 0..<cursor.count {
+                if let s = cursor[index] as? Site {
+                    XCTAssertNotNil(s, "cursor has a site for entry")
+                    XCTAssertEqual(s.url, urls[index], "Found right url")
+                    XCTAssertEqual(s.title, titles[index], "Found right title")
+                } else {
+                    XCTAssertFalse(true, "Should not be nil...")
+                }
+            }
+            return nil
+        }
+    }
+
+    private func clear(history: HistoryTable<Site>, site: Site? = nil, s: Bool = true) {
+        var deleted = -1;
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError? = nil
+            deleted = history.delete(connection, item: site, err: &err)
+            return nil
+        }
+        if s {
+            XCTAssert(deleted >= 0, "Delete worked")
+        } else {
+            XCTAssert(deleted == -1, "Delete failed")
+        }
+    }
+
+    // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
+    func testHistoryTable() {
+        withTestAccount { account -> Void in
+            self.db = SwiftData(filename: account.files.get("test.db")!)
+            let h = HistoryTable<Site>()
+
+            self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
+                h.create(db, version: 1)
+                return nil
+            })
+
+            self.addSite(h, url: "url", title: "title")
+            self.addSite(h, url: "url", title: "title", s: false)
+            self.updateSite(h, url: "url", title: "title 2")
+            self.addSite(h, url: "url2", title: "title")
+            self.addSite(h, url: "url2", title: "title", s: false)
+
+            self.checkSites(h, options: nil, urls: ["url", "url2"], titles: ["title 2", "title"])
+
+            let options = QueryOptions()
+            options.filter = "url2"
+            self.checkSites(h, options: options, urls: ["url2"], titles: ["title"])
+
+            var site = Site(url: "url", title: "title 2")
+            self.clear(h, site: site, s: true)
+            self.checkSites(h, options: nil, urls: ["url2"], titles: ["title"])
+            self.clear(h)
+            self.checkSites(h, options: nil, urls: [], titles: [])
+
+            account.files.remove("test.db")
+        }
+    }
+}

--- a/ClientTests/TestJoinedHistoryVisits.swift
+++ b/ClientTests/TestJoinedHistoryVisits.swift
@@ -1,0 +1,116 @@
+import Foundation
+import XCTest
+
+class TestJoinedHistoryVisits : AccountTest {
+    var db: SwiftData!
+
+    private func addSite(history: JoinedHistoryVisitsTable, url: String, title: String, s: Bool = true) -> Site {
+        var inserted = -1;
+        let site = Site(url: url, title: title)
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError? = nil
+            inserted = history.insert(connection, item: site, err: &err)
+            return err
+        }
+
+        if s {
+            XCTAssert(inserted >= 0, "Inserted succeeded")
+        } else {
+            XCTAssert(inserted == -1, "Inserted failed")
+        }
+        return site
+    }
+
+    private func addVisit(history: JoinedHistoryVisitsTable, site: Site, s: Bool = true) -> Visit {
+        var inserted = -1;
+        let visit = Visit(site: site, date: NSDate())
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError? = nil
+            inserted = history.insert(connection, item: visit, err: &err)
+            return err
+        }
+
+        if s {
+            XCTAssert(inserted >= 0, "Inserted succeeded")
+        } else {
+            XCTAssert(inserted == -1, "Inserted failed")
+        }
+        return visit
+    }
+
+    private func checkSites(history: JoinedHistoryVisitsTable, options: QueryOptions?, urls: [String: String], s: Bool = true) {
+        db.withConnection(.ReadOnly) { connection -> NSError? in
+            var cursor = history.query(connection, options: options)
+            XCTAssertEqual(cursor.status, CursorStatus.Success, "returned success \(cursor.statusMessage)")
+            XCTAssertEqual(cursor.count, urls.count, "cursor has right num of entries")
+
+            for index in 0..<cursor.count {
+                if let s = cursor[index] as? Site {
+                    XCTAssertNotNil(s, "cursor has a site for entry")
+                    let title = urls[s.url]
+                    XCTAssertNotNil(title, "Found url")
+                    XCTAssertEqual(s.title, title!, "Found right title")
+                } else {
+                    XCTAssertFalse(true, "Should not be nil...")
+                }
+            }
+            return nil
+        }
+    }
+
+    private func clear(history: JoinedHistoryVisitsTable, item: AnyObject? = nil, s: Bool = true) {
+        var deleted = -1;
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError? = nil
+            deleted = history.delete(connection, item: item, err: &err)
+            return nil
+        }
+        if s {
+            XCTAssert(deleted >= 0, "Delete worked")
+        } else {
+            XCTAssert(deleted == -1, "Delete failed")
+        }
+    }
+
+    // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
+    func testJoinedHistoryVisitsTable() {
+        withTestAccount { account -> Void in
+            self.db = SwiftData(filename: account.files.get("test.db")!)
+            let h = JoinedHistoryVisitsTable()
+
+            self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
+                h.create(db, version: 2)
+                return nil
+            })
+
+            self.addSite(h, url: "url", title: "title")
+            let site = self.addSite(h, url: "url", title: "title")
+            self.addSite(h, url: "url2", title: "title")
+            self.addSite(h, url: "url2", title: "title")
+
+            self.checkSites(h, options: nil, urls: ["url": "title", "url2": "title"])
+
+            self.addSite(h, url: "url", title: "title 2")
+            self.checkSites(h, options: nil, urls: ["url": "title 2", "url2": "title"])
+
+            site.title = "title 3"
+            let visit = self.addVisit(h, site: site)
+            self.checkSites(h, options: nil, urls: ["url": "title 3", "url2": "title"])
+
+            let options = QueryOptions()
+            options.filter = "url2"
+            self.checkSites(h, options: options, urls: ["url2": "title"])
+
+            self.clear(h, item: site)
+            self.checkSites(h, options: nil, urls: ["url2": "title"])
+
+            self.clear(h, item: visit)
+            self.checkSites(h, options: nil, urls: ["url2": "title"])
+
+            self.clear(h)
+            self.checkSites(h, options: nil, urls: [String: String]())
+            
+            account.files.remove("test.db")
+        }
+    }
+}

--- a/ClientTests/TestVisitsTable.swift
+++ b/ClientTests/TestVisitsTable.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+
+class TestVisitsTable : AccountTest {
+    var db: SwiftData!
+
+    private func addVisit(visits: VisitsTable<Visit>, site: Site, s: Bool = true) -> Visit {
+        var inserted = -1;
+        var visit : Visit!
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            visit = Visit(site: site, date: NSDate())
+            var err: NSError? = nil
+            inserted = visits.insert(connection, item: visit, err: &err)
+            return nil
+        }
+
+        if s {
+            XCTAssert(inserted >= 0, "Inserted succeeded")
+        } else {
+            XCTAssert(inserted == -1, "Inserted failed")
+        }
+        return visit
+    }
+
+    private func checkVisits(visits: VisitsTable<Visit>, options: QueryOptions? = nil, vs: [Visit], s: Bool = true) {
+        db.withConnection(.ReadOnly) { connection -> NSError? in
+            var cursor = visits.query(connection, options: options)
+            XCTAssertEqual(cursor.status, CursorStatus.Success, "returned success \(cursor.statusMessage)")
+            XCTAssertEqual(cursor.count, vs.count, "cursor has right num of entries")
+
+            for index in 0..<cursor.count {
+                if let s = cursor[index] as? Visit {
+                    XCTAssertNotNil(s, "cursor has a site for entry")
+                    // These aren't currently filled in for the model results. Yeah, that kinda sucks :(
+                    // XCTAssertEqual(s.site.url, vs[index].site.url, "Found right url")
+                    // XCTAssertEqual(s.site.title, vs[index].site.title, "Found right title")
+                    XCTAssertEqual(s.date.timeIntervalSince1970, vs[index].date.timeIntervalSince1970, "Found right date")
+                } else {
+                    XCTAssertFalse(true, "Should not be nil...")
+                }
+            }
+            return nil
+        }
+    }
+
+    private func clear(visits: VisitsTable<Visit>, visit: Visit? = nil, s: Bool = true) {
+        var deleted = -1;
+        db.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError? = nil
+            deleted = visits.delete(connection, item: visit, err: &err)
+            return nil
+        }
+
+        if s {
+            XCTAssert(deleted >= 0, "Delete worked")
+        } else {
+            XCTAssert(deleted == -1, "Delete failed")
+        }
+    }
+
+    // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
+    func testVisitsTable() {
+        withTestAccount { account -> Void in
+            self.db = SwiftData(filename: account.files.get("test.db")!)
+            let h = VisitsTable<Visit>()
+
+            self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
+                h.create(db, version: 2)
+                return nil
+            })
+
+            let site = Site(url: "url", title: "title")
+            site.guid = "myguid"
+
+            let site2 = Site(url: "url 2", title: "title 2")
+            site2.guid = "myguid 2"
+
+            let v1 = self.addVisit(h, site: site)
+            let v2 = self.addVisit(h, site: site)
+            let v3 = self.addVisit(h, site: site2)
+            let v4 = self.addVisit(h, site: site2)
+
+            self.checkVisits(h, options: nil, vs: [v1, v2, v3, v4])
+            let options = QueryOptions()
+            options.filter = v1.site.guid!
+            self.checkVisits(h, options: options, vs: [v1, v2])
+
+            self.clear(h, visit: v1, s: true)
+            self.checkVisits(h, options: options, vs: [v2])
+            self.clear(h, s: true)
+            self.checkVisits(h, options: nil, vs: [])
+
+            account.files.remove("test.db")
+        }
+    }
+}

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -109,7 +109,9 @@ public class RESTAccountProfile: Profile, AccountProfile {
     func onLocationChange(notification: NSNotification) {
         if let url = notification.userInfo!["url"] as? NSURL {
             if let title = notification.userInfo!["title"] as? NSString {
-                history.addVisit(Site(url: url.absoluteString!, title: title), options: nil, complete: { (success) -> Void in
+                let site = Site(url: url.absoluteString!, title: title)
+                let visit = Visit(site: site, date: NSDate())
+                history.addVisit(visit, complete: { (success) -> Void in
                     // nothing to do
                 })
             }

--- a/Providers/Site.swift
+++ b/Providers/Site.swift
@@ -5,12 +5,11 @@
 import UIKit
 
 public class Site {
-    var guid: String
+    var guid: String? = nil
     var url: String
     var title: String
 
     init(url: String, title: String) {
-        self.guid = NSUUID().UUIDString
         self.url = url
         self.title = title
     }

--- a/Providers/Visit.swift
+++ b/Providers/Visit.swift
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+public class Visit {
+    var guid: String
+    let site: Site
+    let date: NSDate
+    // TODO: Store other info about the visit. i.e. Previous visit, reason for visit
+    //       (clicking link, typing url, search), device, etc.
+
+    init(site: Site, date: NSDate) {
+        self.guid = NSUUID().UUIDString
+        self.site = site
+        self.date = date
+    }
+}

--- a/SwiftData.swift
+++ b/SwiftData.swift
@@ -245,21 +245,22 @@ public class SQLiteDBConnection {
         for (index, obj) in enumerate(objects) {
             var status: Int32 = SQLITE_OK
 
-            if let i = obj as? Int {
-                status = sqlite3_bind_int(stmt, Int32(index+1), Int32(i))
-            } else if let i = obj as? Double {
-                status = sqlite3_bind_double(stmt, Int32(index+1), i)
-            } else if let i = obj as? Bool {
-                status = sqlite3_bind_int(stmt, Int32(index+1), i ? 1 : 0)
-            } else if let i = obj as? String {
+            // Double's also pass obj is Int, so order is important here
+            if obj is Double {
+                status = sqlite3_bind_double(stmt, Int32(index+1), obj as Double)
+            } else if obj is Int {
+                status = sqlite3_bind_int(stmt, Int32(index+1), Int32(obj as Int))
+            } else if obj is Bool {
+                status = sqlite3_bind_int(stmt, Int32(index+1), (obj as Bool) ? 1 : 0)
+            } else if obj is String {
                 let negativeOne = UnsafeMutablePointer<Int>(bitPattern: -1)
                 let opaquePointer = COpaquePointer(negativeOne)
                 let transient = CFunctionPointer<((UnsafeMutablePointer<()>) -> Void)>(opaquePointer)
-                status = sqlite3_bind_text(stmt, Int32(index+1), i.cStringUsingEncoding(NSUTF8StringEncoding)!, -1, transient)
-            } else if let i = obj as? NSData {
-                status = sqlite3_bind_blob(stmt, Int32(index+1), i.bytes, -1, nil)
-            } else if let i = obj as? NSDate {
-                var timestamp = Double(i.timeIntervalSince1970)
+                status = sqlite3_bind_text(stmt, Int32(index+1), (obj as String).cStringUsingEncoding(NSUTF8StringEncoding)!, -1, transient)
+            } else if obj is NSData {
+                status = sqlite3_bind_blob(stmt, Int32(index+1), (obj as NSData).bytes, -1, nil)
+            } else if obj is NSDate {
+                var timestamp = (obj as NSDate).timeIntervalSince1970
                 status = sqlite3_bind_double(stmt, Int32(index+1), timestamp)
             } else if obj === nil {
                 status = sqlite3_bind_null(stmt, Int32(index+1))
@@ -482,7 +483,7 @@ private struct SDError {
 public class SDCursor<T> : Cursor {
     private let stmt: COpaquePointer
     // Function for generating objects of type T from a row.
-    private let factory: (SDRow) -> T?
+    private let factory: (SDRow) -> T
     // Status of the previous fetch request.
     private var sqlStatus: Int32 = 0
     // Hold a reference to the connection so that it isn't closed
@@ -496,7 +497,6 @@ public class SDCursor<T> : Cursor {
     override var count: Int {
         get { return _count }
     }
-
 
     private var _position = -1
     private var position: Int {
@@ -568,14 +568,13 @@ public class SDCursor<T> : Cursor {
                 return row
             }
 
-            var res: T? = nil
             self.position = index
             if self.sqlStatus != SQLITE_ROW {
-                return res
+                return nil
             }
 
             let row = SDRow(connection: db, stmt: self.stmt, columns: self.columns)
-            res = self.factory(row)
+            let res = self.factory(row)
             self.cache[index] = res
             sqlite3_reset(self.stmt)
             self._position = -1


### PR DESCRIPTION
This implements a Visits table (it also abstracts the current History table to do that in order to avoid a lot of repeated code). I'm using the guid to link the two tables, but I'd rather use an id, but now that I write that, url's should be just as good as guids. Maybe we should use that? I'm not sure what the sync world thinks? There are lots of options here, so I partly just wanted some feedback.