### PR TITLE
Fixes 1123408 - Include reader mode assets as real resources

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		E4CD9F1B1A6D9B8E00318571 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E4CD9F191A6D9B7B00318571 /* libz.dylib */; };
 		E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */; };
 		E4CD9F2D1A6DC91200318571 /* BrowserLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */; };
+		E4CD9F541A71506400318571 /* Reader.html in Resources */ = {isa = PBXBuildFile; fileRef = E4CD9F531A71506400318571 /* Reader.html */; };
+		E4CD9F5B1A71506C00318571 /* Reader.css in Resources */ = {isa = PBXBuildFile; fileRef = E4CD9F5A1A71506C00318571 /* Reader.css */; };
 		E4D6BEA61A092A4700F538BD /* Login.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEA51A092A4700F538BD /* Login.xcassets */; };
 		E4D6BEB21A092D5700F538BD /* Snappy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E4D6BEAD1A092AD300F538BD /* Snappy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
@@ -425,6 +427,8 @@
 		E4CD9F191A6D9B7B00318571 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServerTests.swift; sourceTree = "<group>"; };
 		E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserLocationView.swift; sourceTree = "<group>"; };
+		E4CD9F531A71506400318571 /* Reader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Reader.html; sourceTree = "<group>"; };
+		E4CD9F5A1A71506C00318571 /* Reader.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = Reader.css; sourceTree = "<group>"; };
 		E4D6BEA51A092A4700F538BD /* Login.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Login.xcassets; sourceTree = "<group>"; };
 		E4D6BEA71A092AD300F538BD /* Snappy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Snappy.xcodeproj; path = ThirdParty/Snappy/Snappy.xcodeproj; sourceTree = "<group>"; };
 		E4D6BEB51A092E0300F538BD /* Client.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Client.entitlements; sourceTree = "<group>"; };
@@ -857,6 +861,8 @@
 				F84B21F61A0910F600AAB793 /* Readability.js */,
 				E4CD9E901A6897FB00318571 /* ReaderMode.swift */,
 				E4CD9E991A68980A00318571 /* ReaderMode.js */,
+				E4CD9F531A71506400318571 /* Reader.html */,
+				E4CD9F5A1A71506C00318571 /* Reader.css */,
 				F84B21F71A0910F600AAB793 /* ReaderViewController.swift */,
 				F84B21F81A0910F600AAB793 /* ReaderViewController.xib */,
 				F84B21FA1A0910F600AAB793 /* SiteTableViewController.swift */,
@@ -1183,11 +1189,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */,
+				E4CD9F541A71506400318571 /* Reader.html in Resources */,
 				F84B223D1A0914A300AAB793 /* FiraSans-Light.ttf in Resources */,
 				F84B223E1A0914A300AAB793 /* FiraSans-SemiBold.ttf in Resources */,
 				F84B22161A0910F600AAB793 /* TabsViewControllerHeader.xib in Resources */,
 				F84B220C1A0910F600AAB793 /* Readability.js in Resources */,
 				D3FA77C41A44F9A80010CD32 /* Locales in Resources */,
+				E4CD9F5B1A71506C00318571 /* Reader.css in Resources */,
 				F84B221E1A0911BF00AAB793 /* HistoryViewController.xib in Resources */,
 				E4D6BEA61A092A4700F538BD /* Login.xcassets in Resources */,
 				F84B22271A09127C00AAB793 /* TabBar.xcassets in Resources */,

--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -10,7 +10,6 @@ body {
   padding: 20px;
   transition-property: background-color, color;
   transition-duration: 0.4s;
-  max-width: 35em;
   margin-left: auto;
   margin-right: auto;
 }

--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -255,6 +255,7 @@ body {
 .content pre {
   white-space: pre-wrap !important;
   margin-bottom: 20px !important;
+  word-break: break-all;
 }
 
 .content blockquote {

--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -1,0 +1,588 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+html {
+  -moz-text-size-adjust: none;
+}
+
+body {
+  padding: 20px;
+  transition-property: background-color, color;
+  transition-duration: 0.4s;
+  max-width: 35em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.light {
+  background-color: #ffffff;
+  color: #222222;
+}
+
+.dark {
+  background-color: #000000;
+  color: #eeeeee;
+}
+
+.sans-serif {
+  font-family: sans-serif;
+}
+
+.serif {
+  font-family: serif;
+}
+
+.message {
+  margin-top: 40px;
+  display: none;
+  text-align: center;
+  width: 100%;
+  font-size: 16px;
+}
+
+.header {
+  text-align: start;
+  display: none;
+}
+
+.domain,
+.credits {
+  font-family: sans-serif;
+}
+
+.domain {
+  margin-top: 10px;
+  padding-bottom: 10px;
+  color: #00acff !important;
+  text-decoration: none;
+}
+
+.domain-border {
+  margin-top: 15px;
+  border-bottom: 1.5px solid #777777;
+  width: 50%;
+}
+
+.header > h1 {
+  font-size: 2.625em;
+  font-weight: 700;
+  line-height: 1.1em;
+  width: 100%;
+  margin: 0px;
+  margin-top: 32px;
+  margin-bottom: 16px;
+  padding: 0px;
+}
+
+.header > .credits {
+  padding: 0px;
+  margin: 0px;
+  margin-bottom: 32px;
+}
+
+.light > .header > .domain {
+  color: #ee7600;
+  border-bottom-color: #d0d0d0; 
+}
+
+.light > .header > h1 {
+  color: #222222;
+}
+
+.light > .header > .credits {
+  color: #898989;
+}
+
+.dark > .header > .domain {
+  color: #ff9400;
+  border-bottom-color: #777777; 
+}
+
+.dark > .header > h1 {
+  color: #eeeeee;
+}
+
+.dark > .header > .credits {
+  color: #aaaaaa;
+}
+
+.font-size1 > .header > h1 {
+  font-size: 27px;
+}
+
+.font-size2 > .header > h1 {
+  font-size: 29px;
+}
+
+.font-size3 > .header > h1 {
+  font-size: 31px;
+}
+
+.font-size4 > .header > h1 {
+  font-size: 33px;
+}
+
+.font-size5 > .header > h1 {
+  font-size: 35px;
+}
+
+/* This covers caption, domain, and credits
+   texts in the reader UI */
+
+.font-size1 > .content .wp-caption-text,
+.font-size1 > .content figcaption,
+.font-size1 > .header > .domain,
+.font-size1 > .header > .credits {
+  font-size: 10px;
+}
+
+.font-size2 > .content .wp-caption-text,
+.font-size2 > .content figcaption,
+.font-size2 > .header > .domain,
+.font-size2 > .header > .credits {
+  font-size: 13px;
+}
+
+.font-size3 > .content .wp-caption-text,
+.font-size3 > .content figcaption,
+.font-size3 > .header > .domain,
+.font-size3 > .header > .credits {
+  font-size: 15px;
+}
+
+.font-size4 > .content .wp-caption-text,
+.font-size4 > .content figcaption,
+.font-size4 > .header > .domain,
+.font-size4 > .header > .credits {
+  font-size: 17px;
+}
+
+.font-size5 > .content .wp-caption-text,
+.font-size5 > .content figcaption,
+.font-size5 > .header > .domain,
+.font-size5 > .header > .credits {
+  font-size: 19px;
+}
+
+.content {
+  display: none;
+}
+
+.content a {
+  text-decoration: underline !important;
+  font-weight: normal;
+}
+
+.light > .content a,
+.light > .content a:visited,
+.light > .content a:hover,
+.light > .content a:active {
+  color: #00acff !important;
+}
+
+.dark > .content a,
+.dark > .content a:visited,
+.dark > .content a:hover,
+.dark > .content a:active {
+  color: #00acff !important;
+}
+
+.content * {
+  max-width: 100% !important;
+  height: auto !important;
+}
+
+.content p {
+  line-height: 1.4em !important;
+  margin: 0px !important;
+  margin-bottom: 20px !important;
+}
+
+/* Covers all images showing edge-to-edge using a 
+   an optional caption text */
+.content .wp-caption,
+.content figure {
+  display: block !important;
+  width: 100% !important;
+  margin: 0px !important;
+  margin-bottom: 32px !important;
+}
+
+/* Images marked to be shown edge-to-edge with an
+   optional captio ntext */
+.content p > img:only-child,
+.content p > a:only-child > img:only-child,
+.content .wp-caption img,
+.content figure img {
+  max-width: none !important;
+  height: auto !important;
+  display: block !important;
+  margin-top: 0px !important;
+  margin-bottom: 32px !important;
+}
+
+/* If image is place inside one of these blocks
+   there's no need to add margin at the bottom */
+.content .wp-caption img,
+.content figure img {
+  margin-bottom: 0px !important;
+}
+
+/* Image caption text */
+.content .caption,
+.content .wp-caption-text,
+.content figcaption {
+  font-family: sans-serif;
+  margin: 0px !important;
+  padding-top: 4px !important;
+}
+
+.light > .content .caption,
+.light > .content .wp-caption-text,
+.light > .content figcaption {
+  color: #898989;
+}
+
+.dark > .content .caption,
+.dark > .content .wp-caption-text,
+.dark > .content figcaption {
+  color: #aaaaaa;
+}
+
+/* Ensure all pre-formatted code inside the reader content
+   are properly wrapped inside content width */
+.content code,
+.content pre {
+  white-space: pre-wrap !important;
+  margin-bottom: 20px !important;
+}
+
+.content blockquote {
+  margin: 0px !important;
+  margin-bottom: 20px !important;
+  padding: 0px !important;
+  -moz-padding-start: 16px !important;
+  border: 0px !important;
+  border-left: 2px solid !important;
+}
+
+.light > .content blockquote {
+  color: #898989 !important;
+  border-left-color: #d0d0d0 !important;
+}
+
+.dark > .content blockquote {
+  color: #aaaaaa !important;
+  border-left-color: #777777 !important;
+}
+
+.content ul,
+.content ol {
+  margin: 0px !important;
+  margin-bottom: 20px !important;
+  padding: 0px !important;
+  line-height: 1.5em;
+}
+
+.content ul {
+  -moz-padding-start: 30px !important;
+  list-style: disk !important;
+}
+
+.content ol {
+  -moz-padding-start: 35px !important;
+  list-style: decimal !important;
+}
+
+.font-size1-sample,
+.font-size1 > .content {
+  font-size: 14px !important;
+}
+
+.font-size2-sample,
+.font-size2 > .content {
+  font-size: 16px !important;
+}
+
+.font-size3-sample,
+.font-size3 > .content {
+  font-size: 18px !important;
+}
+
+.font-size4-sample,
+.font-size4 > .content {
+  font-size: 20px !important;
+}
+
+.font-size5-sample,
+.font-size5 > .content {
+  font-size: 22px !important;
+}
+
+.toolbar {
+  font-family: "Clear Sans",sans-serif;
+  transition-property: visibility, opacity;
+  transition-duration: 0.7s;
+  visibility: visible;
+  opacity: 1.0;
+  position: fixed;
+  width: 100%;
+  bottom: 0px;
+  left: 0px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background-color: #EBEBF0;
+  -moz-user-select: none;
+}
+
+.toolbar-hidden {
+  transition-property: visibility, opacity;
+  transition-duration: 0.7s;
+  visibility: hidden;
+  opacity: 0.0;
+}
+
+.toolbar > * {
+  float: right;
+  width: 33%;
+}
+
+.button {
+  color: white;
+  display: block;
+  background-position: center;
+  background-size: 30px 24px;
+  background-repeat: no-repeat;
+}
+
+.dropdown {
+  text-align: center;
+  display: inline-block;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+}
+
+.dropdown li {
+  margin: 0px;
+  padding: 0px;
+}
+
+.dropdown-toggle {
+  margin: 0px;
+  padding: 0px;
+}
+
+.dropdown-popup {
+  text-align: start;
+  position: absolute;
+  left: 0px;
+  z-index: 1000;
+  float: left;
+  background: #EBEBF0;
+  margin-top: 12px;
+  margin-bottom: 10px;
+  padding-top: 4px;
+  padding-bottom: 8px;
+  font-size: 14px;
+  box-shadow: 0px -1px 12px #333;
+  border-radius: 3px;
+  visibility: hidden;
+}
+
+.dropdown-popup > hr {
+  width: 100%;
+  height: 0px;
+  border: 0px;
+  border-top: 1px solid #B5B5B5;
+  margin: 0;
+}
+
+.open > .dropdown-popup {
+  margin-top: 0px;
+  margin-bottom: 6px;
+  bottom: 100%;
+  visibility: visible;
+}
+
+.dropdown-arrow {
+  position: absolute;
+  width: 40px;
+  height: 18px;
+  bottom: -18px;
+  background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-mdpi.png');
+  background-size: 40px 18px;
+  background-position: center;
+  display: block;
+}
+
+#font-type-buttons,
+.segmented-button {
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  padding: 10px 5px;
+  white-space: nowrap;
+}
+
+#font-type-buttons > li,
+.segmented-button > li {
+  width: 50px; /* combined with flex, this acts as a minimum width */
+  flex: 1 0 auto;
+  text-align: center;
+  line-height: 20px;
+}
+
+#font-type-buttons > li {
+  padding: 10px 0;
+}
+
+.segmented-button > li {
+  border-left: 1px solid #B5B5B5;
+}
+
+.segmented-button > li:first-child {
+  border-left: 0px;
+}
+
+#font-type-buttons > li > a,
+.segmented-button > li > a {
+  vertical-align: middle;
+  text-decoration: none;
+  color: black;
+}
+
+#font-type-buttons > li > a {
+  display: inline-block;
+  font-size: 48px;
+  line-height: 50px;
+  margin-bottom: 5px;
+  border-bottom: 3px solid transparent;
+}
+
+.segmented-button > li > a {
+  display: block;
+  padding: 5px 0;
+  font-family: "Clear Sans",sans-serif;
+  font-weight: lighter;
+}
+
+#font-type-buttons > li > a:active,
+#font-type-buttons > li.selected > a {
+  border-color: #ff9400;
+}
+
+.segmented-button > li > a:active,
+.segmented-button > li.selected > a {
+  font-weight: bold;
+}
+
+#font-type-buttons > li > .sans-serif {
+  font-weight: lighter;
+}
+
+#font-type-buttons > li > div {
+  color: #666;
+  font-size: 12px;
+}
+
+.toggle-button.on {
+  background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-mdpi.png');
+}
+
+.toggle-button {
+  background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-mdpi.png');
+}
+
+.share-button {
+  background-image: url('chrome://browser/skin/images/reader-share-icon-mdpi.png');
+}
+
+.style-button {
+  background-image: url('chrome://browser/skin/images/reader-style-icon-mdpi.png');
+}
+
+@media screen and (min-resolution: 1.25dppx) {
+  .dropdown-arrow {
+    background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-hdpi.png');
+  }
+
+  .step-control > .plus-button {
+    background-image: url('chrome://browser/skin/images/reader-plus-icon-hdpi.png');
+  }
+
+  .step-control > .minus-button {
+    background-image: url('chrome://browser/skin/images/reader-minus-icon-hdpi.png');
+  }
+
+  .toggle-button.on {
+    background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-hdpi.png');
+  }
+
+  .toggle-button {
+    background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-hdpi.png');
+  }
+
+  .share-button {
+    background-image: url('chrome://browser/skin/images/reader-share-icon-hdpi.png');
+  }
+
+  .style-button {
+    background-image: url('chrome://browser/skin/images/reader-style-icon-hdpi.png');
+  }
+}
+
+@media screen and (min-resolution: 2dppx) {
+  .dropdown-arrow {
+    background-image: url('chrome://browser/skin/images/reader-dropdown-arrow-xhdpi.png');
+  }
+
+  .step-control > .plus-button {
+    background-image: url('chrome://browser/skin/images/reader-plus-icon-xhdpi.png');
+  }
+
+  .step-control > .minus-button {
+    background-image: url('chrome://browser/skin/images/reader-minus-icon-xhdpi.png');
+  }
+
+  .toggle-button.on {
+    background-image: url('chrome://browser/skin/images/reader-toggle-on-icon-xhdpi.png');
+  }
+
+  .toggle-button {
+    background-image: url('chrome://browser/skin/images/reader-toggle-off-icon-xhdpi.png');
+  }
+
+  .share-button {
+    background-image: url('chrome://browser/skin/images/reader-share-icon-xhdpi.png');
+  }
+
+  .style-button {
+    background-image: url('chrome://browser/skin/images/reader-style-icon-xhdpi.png');
+  }
+}
+
+@media screen and (orientation: portrait) {
+  .button {
+    height: 48px;
+  }
+}
+
+@media screen and (orientation: landscape) {
+  .button {
+    height: 40px;
+  }
+}
+
+@media screen and (min-width: 960px) {
+  .button {
+    width: 56px;
+    height: 56px;
+  }
+
+  .toolbar > * {
+    width: 56px;
+  }
+}

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="content-type">
+  <meta name="viewport" content="width=device-width, user-scalable=no" />
+  <style type="text/css">
+    %READER-CSS%
+  </style>
+  <script type="">var _firefox_ReaderPage = { style: %READER-STYLE% };</script>
+</head>
+
+<body>
+  <div id="reader-header" class="header">
+    <a id="reader-domain" class="domain" href="%READER-URL%">%READER-DOMAIN%</a>
+    <div class="domain-border"></div>
+    <h1 id="reader-title">%READER-TITLE%</h1>
+    <div id="reader-credits" class="credits">%READER-CREDITS%</div>
+  </div>
+
+  <div id="reader-content" class="content">
+    %READER-CONTENT%
+  </div>
+
+  <div id="reader-message" class="message">
+    %READER-MESSAGE%
+  </div>
+
+  <ul id="reader-toolbar" class="toolbar toolbar-hidden">
+    <li><a id="share-button" class="button share-button" href="#"></a></li>
+    <ul class="dropdown">
+      <li><a class="dropdown-toggle button style-button" href="#"></a></li>
+      <li class="dropdown-popup">
+        <ul id="font-type-buttons"></ul>
+        <hr></hr>
+        <ul id="font-size-buttons" class="segmented-button"></ul>
+        <hr></hr>
+        <ul id="color-scheme-buttons" class="segmented-button"></ul>
+      </li>
+    </ul>
+    <li><a id="toggle-button" class="button toggle-button" href="#"></a></li>
+  </ul>
+
+</body>
+
+</html>

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
 
 <head>

--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -34,84 +34,13 @@ var _firefox_ReaderMode = {
         }
     },
 
-    simplifyReaderDomain: function(domain) {
-        domain = domain.toLowerCase();
-        if (domain.indexOf("www.") == 0) {
-            domain = domain.substring(4);
-        } else if (domain.indexOf("m.") == 0) {
-            domain = domain.substring(2);
-        } else if (domain.indexOf("mobile.") == 0) {
-            domain = domain.substring(7);
-        }
-        return domain;
+    // Readerize the document. Since we did the actual readerization already in checkReadability, we
+    // can simply return the results we already have.
+
+    readerize: function() {
+        return _firefox_ReaderMode.readabilityResult;
     },
 
-    readerize: function(style) {
-        if (_firefox_ReaderMode.readabilityResult) {
-            var template = _firefox_ReaderMode.readerModeTemplate();
-            template = template.replace("%READER-STYLE%", JSON.stringify(style));
-            template = template.replace("%READER-DOMAIN%", _firefox_ReaderMode.simplifyReaderDomain(_firefox_ReaderMode.readabilityResult.uri.host));
-            template = template.replace("%READER-URL%", _firefox_ReaderMode.readabilityResult.uri.spec || "");
-            template = template.replace("%READER-CONTENT%", _firefox_ReaderMode.readabilityResult.content || "");
-            template = template.replace("%READER-TITLE%", _firefox_ReaderMode.readabilityResult.title || "");
-            template = template.replace("%READER-CREDITS%", _firefox_ReaderMode.readabilityResult.byline || "");
-            return template;
-        }
-    },
-
-    // This is inline here because I don't have a good answer just yet about loading non-js content into
-    // the sandboxed javascript world. This is far from ideal but will be addressed in a next iteration.
-    // The CSS is currently linked to a remote site. This will be fixed as part of bug 1123408.
-
-    readerModeTemplate: function() {
-        var template = '';
-        template += '<!DOCTYPE html>\n';
-        template += '<html>\n';
-        template += '\n';
-        template += '<head>\n';
-        template += '  <meta content="text/html; charset=UTF-8" http-equiv="content-type">\n';
-        template += '  <meta name="viewport" content="width=device-width, user-scalable=no" />\n';
-        template += '  <link rel="stylesheet" href="http://wopr.norad.org/~stefan/Reader.css" type="text/css"/>\n';
-        template += '  <script type="">var _firefox_ReaderPage = { style: %READER-STYLE% };</script>\n';
-        template += '</head>\n';
-        template += '\n';
-        template += '<body>\n';
-        template += '  <div id="reader-header" class="header">\n';
-        template += '    <a id="reader-domain" class="domain" href="%READER-URL%">%READER-DOMAIN%</a>\n';
-        template += '    <div class="domain-border"></div>\n';
-        template += '    <h1 id="reader-title">%READER-TITLE%</h1>\n';
-        template += '    <div id="reader-credits" class="credits">%READER-CREDITS%</div>\n';
-        template += '  </div>\n';
-        template += '\n';
-        template += '  <div id="reader-content" class="content">\n';
-        template += '    %READER-CONTENT%\n';
-        template += '  </div>\n';
-        template += '\n';
-        template += '  <div id="reader-message" class="message">\n';
-        template += '    %READER-MESSAGE%\n';
-        template += '  </div>\n';
-        template += '\n';
-        template += '  <ul id="reader-toolbar" class="toolbar toolbar-hidden">\n';
-        template += '    <li><a id="share-button" class="button share-button" href="#"></a></li>\n';
-        template += '    <ul class="dropdown">\n';
-        template += '      <li><a class="dropdown-toggle button style-button" href="#"></a></li>\n';
-        template += '      <li class="dropdown-popup">\n';
-        template += '        <ul id="font-type-buttons"></ul>\n';
-        template += '        <hr></hr>\n';
-        template += '        <ul id="font-size-buttons" class="segmented-button"></ul>\n';
-        template += '        <hr></hr>\n';
-        template += '        <ul id="color-scheme-buttons" class="segmented-button"></ul>\n';
-        template += '      </li>\n';
-        template += '    </ul>\n';
-        template += '    <li><a id="toggle-button" class="button toggle-button" href="#"></a></li>\n';
-        template += '  </ul>\n';
-        template += '\n';
-        template += '</body>\n';
-        template += '\n';
-        template += '</html>\n';
-        return template;
-    },
-    
     // TODO The following code only makes sense in about:reader context. It may be a good idea to move
     //   it out of this file and into for example a Reader.js.
     


### PR DESCRIPTION
This patch moves the Reader.html and Reader.css into the project as included resources. It also moves the template code from ReadetMode.js to ReaderMode.swift. It is a bit unfortunate that we cannot do DOM manipulation like the Android implementation of Reader Mode does, but this is a good and speedy alternative.

Also including a few small CSS tweaks to fix rendering issues.