### PR TITLE
Fixes 1125849 - Reader Mode button disappears after orientation change

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -73,6 +73,10 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
         readerModeButton.snp_remakeConstraints { make in
             make.centerY.equalTo(container).centerY
             make.right.equalTo(container.snp_right).with.offset(-4)
+            // We fix the width of the button (to the height of the view) to prevent content
+            // compression when the locationLabel has more text contents than will fit. It
+            // would be nice to do this with a content compression priority but that does
+            // not seem to work.
             make.width.equalTo(container.snp_height)
         }
     }

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -49,7 +49,6 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
 
     private func makeConstraints() {
         let container = self
-        let padding = UIEdgeInsetsMake(4, 8, 4, 8)
 
         lockImageView.snp_remakeConstraints { make in
             make.centerY.equalTo(container).centerY
@@ -74,6 +73,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
         readerModeButton.snp_remakeConstraints { make in
             make.centerY.equalTo(container).centerY
             make.right.equalTo(container.snp_right).with.offset(-4)
+            make.width.equalTo(container.snp_height)
         }
     }
 


### PR DESCRIPTION
Fixed by giving the button a width constraint so that it is not 'compressed' by the label when more space is needed.