### PR TITLE
Bug 1125996 - Fudge the location bar hit area for misses

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -21,7 +21,6 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = UIColor.whiteColor()
-        self.clipsToBounds = true
         self.layer.cornerRadius = 5
 
         lockImageView = UIImageView(image: UIImage(named: "lock_verified.png"))
@@ -49,7 +48,6 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
 
     private func makeConstraints() {
         let container = self
-        let padding = UIEdgeInsetsMake(4, 8, 4, 8)
 
         lockImageView.snp_remakeConstraints { make in
             make.centerY.equalTo(container).centerY
@@ -128,6 +126,28 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
                 })
             }
         }
+    }
+
+    override func hitTest(point: CGPoint, withEvent event: UIEvent?) -> UIView? {
+        if let hitView = super.hitTest(point, withEvent: event) {
+            return hitView
+        }
+
+        // If the hit test failed, offset it by moving it up and try again.
+        var fuzzPoint = point
+        fuzzPoint.y -= 20
+        if let hitView = super.hitTest(fuzzPoint, withEvent: event) {
+            return hitView
+        }
+
+        // If the hit test failed, offset it by moving it down and try again.
+        fuzzPoint = point
+        fuzzPoint.y += 20
+        if let hitView = super.hitTest(fuzzPoint, withEvent: event) {
+            return hitView
+        }
+
+        return nil
     }
 }
 


### PR DESCRIPTION
Here's a quick fix that vertically offsets the touch amount by a 20px fudge factor for hit misses.