### PR TITLE
Fixes 1125960 - Reader Mode WebView Orientation Change Failure

### DIFF
--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -3,7 +3,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 html {
-  -moz-text-size-adjust: none;
+    -moz-text-size-adjust: none;
+    -webkit-text-size-adjust: none;
 }
 
 body {

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -6,7 +6,7 @@
 
 <head>
   <meta content="text/html; charset=UTF-8" http-equiv="content-type">
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.6;">
+  <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=.25, maximum-scale=1.6, initial-scale=1.0">
   <style type="text/css">
     %READER-CSS%
   </style>


### PR DESCRIPTION
Two additional changes that I missed in the previous PR, which I unfortunately already merged:

* Added  `html {-webkit-text-size-adjust: none; }` to Reader.css
* Added `user-scalable=no` to Reader.html's viewport
