### PR TITLE
Fixes 1123387 - Reader Mode UI

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		E4CD9F2D1A6DC91200318571 /* BrowserLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */; };
 		E4CD9F541A71506400318571 /* Reader.html in Resources */ = {isa = PBXBuildFile; fileRef = E4CD9F531A71506400318571 /* Reader.html */; };
 		E4CD9F5B1A71506C00318571 /* Reader.css in Resources */ = {isa = PBXBuildFile; fileRef = E4CD9F5A1A71506C00318571 /* Reader.css */; };
+		E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CD9F6C1A77DD2800318571 /* ReaderModeStyleViewController.swift */; };
 		E4D6BEA61A092A4700F538BD /* Login.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEA51A092A4700F538BD /* Login.xcassets */; };
 		E4D6BEB21A092D5700F538BD /* Snappy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E4D6BEAD1A092AD300F538BD /* Snappy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
@@ -429,6 +430,7 @@
 		E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserLocationView.swift; sourceTree = "<group>"; };
 		E4CD9F531A71506400318571 /* Reader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Reader.html; sourceTree = "<group>"; };
 		E4CD9F5A1A71506C00318571 /* Reader.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = Reader.css; sourceTree = "<group>"; };
+		E4CD9F6C1A77DD2800318571 /* ReaderModeStyleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeStyleViewController.swift; sourceTree = "<group>"; };
 		E4D6BEA51A092A4700F538BD /* Login.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Login.xcassets; sourceTree = "<group>"; };
 		E4D6BEA71A092AD300F538BD /* Snappy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Snappy.xcodeproj; path = ThirdParty/Snappy/Snappy.xcodeproj; sourceTree = "<group>"; };
 		E4D6BEB51A092E0300F538BD /* Client.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Client.entitlements; sourceTree = "<group>"; };
@@ -863,6 +865,7 @@
 				E4CD9E991A68980A00318571 /* ReaderMode.js */,
 				E4CD9F531A71506400318571 /* Reader.html */,
 				E4CD9F5A1A71506C00318571 /* Reader.css */,
+				E4CD9F6C1A77DD2800318571 /* ReaderModeStyleViewController.swift */,
 				F84B21F71A0910F600AAB793 /* ReaderViewController.swift */,
 				F84B21F81A0910F600AAB793 /* ReaderViewController.xib */,
 				F84B21FA1A0910F600AAB793 /* SiteTableViewController.swift */,
@@ -1250,6 +1253,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4CD9F0A1A6D9B0900318571 /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				F84B22191A0911B500AAB793 /* BookmarksViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -153,6 +153,12 @@ extension BrowserViewController: TabManagerDelegate {
         if let readerMode = ReaderMode(browser: tab) {
             readerMode.delegate = self
             tab.addHelper(readerMode, name: ReaderMode.name())
+
+            // TODO: This is a *temporary* way to trigger the reader mode style dialog via 3 taps in the webview. When
+            // we know where the Aa button needs to go, all code below can be refactored properly.
+            let gestureRecognizer = UITapGestureRecognizer(target: self, action: "SELshowReaderModeStyle:")
+            gestureRecognizer.numberOfTapsRequired = 3
+            tab.webView.addGestureRecognizer(gestureRecognizer)
         }
     }
 
@@ -277,36 +283,24 @@ extension BrowserViewController: ReaderModeDelegate, UIPopoverPresentationContro
             println("DEBUG: New readerModeState: \(state.rawValue)")
             toolbar.updateReaderModeState(state)
         }
-
-        // TODO: This is a *temporary* way to trigger the reader mode style dialog via 3 taps in the webview. When
-        // we know where the Aa button needs to go, all code below can be refactored properly.
-        if state == ReaderModeState.Active {
-            let gestureRecognizer = UITapGestureRecognizer(target: self, action: "SELshowReaderModeStyle:")
-            gestureRecognizer.numberOfTapsRequired = 3
-            browser.webView.addGestureRecognizer(gestureRecognizer)
-        } else {
-            if let gestureRecognizers = browser.webView.gestureRecognizers {
-                if gestureRecognizers.count == 1 {
-                    browser.webView.removeGestureRecognizer(gestureRecognizers[0] as UIGestureRecognizer)
-                }
-            }
-        }
     }
 
     func SELshowReaderModeStyle(recognizer: UITapGestureRecognizer) {
         if let readerMode = tabManager.selectedTab?.getHelper(name: "ReaderMode") as? ReaderMode {
-            let readerModeStyleViewController = ReaderModeStyleViewController()
-            readerModeStyleViewController.delegate = readerMode
-            readerModeStyleViewController.readerModeStyle = readerMode.style
-            readerModeStyleViewController.modalPresentationStyle = UIModalPresentationStyle.Popover
+            if readerMode.state == ReaderModeState.Active {
+                let readerModeStyleViewController = ReaderModeStyleViewController()
+                readerModeStyleViewController.delegate = readerMode
+                readerModeStyleViewController.readerModeStyle = readerMode.style
+                readerModeStyleViewController.modalPresentationStyle = UIModalPresentationStyle.Popover
 
-            let popoverPresentationController = readerModeStyleViewController.popoverPresentationController
-            popoverPresentationController?.backgroundColor = UIColor.whiteColor()
-            popoverPresentationController?.delegate = self
-            popoverPresentationController?.sourceView = self.view
-            popoverPresentationController?.sourceRect = CGRect(x: self.view.frame.width/2, y: self.view.frame.height-4, width: 4, height: 4)
+                let popoverPresentationController = readerModeStyleViewController.popoverPresentationController
+                popoverPresentationController?.backgroundColor = UIColor.whiteColor()
+                popoverPresentationController?.delegate = self
+                popoverPresentationController?.sourceView = self.view
+                popoverPresentationController?.sourceRect = CGRect(x: self.view.frame.width/2, y: self.view.frame.height-4, width: 4, height: 4)
 
-            self.presentViewController(readerModeStyleViewController, animated: true, completion: nil)
+                self.presentViewController(readerModeStyleViewController, animated: true, completion: nil)
+            }
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -298,7 +298,6 @@ extension BrowserViewController: ReaderModeDelegate, UIPopoverPresentationContro
             let readerModeStyleViewController = ReaderModeStyleViewController()
             readerModeStyleViewController.delegate = readerMode
             readerModeStyleViewController.readerModeStyle = readerMode.style
-            //readerModeStyleViewController.preferredContentSize = CGSize(width: 260, height: 211)
             readerModeStyleViewController.modalPresentationStyle = UIModalPresentationStyle.Popover
 
             let popoverPresentationController = readerModeStyleViewController.popoverPresentationController

--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -55,13 +55,13 @@ var _firefox_ReaderMode = {
         
         // Configure the font size (1-5)
         if (_firefox_ReaderMode.currentStyle != null) {
-            document.body.classList.remove("font-size" + currentStyle.fontSize);
+            document.body.classList.remove("font-size" + _firefox_ReaderMode.currentStyle.fontSize);
         }
         document.body.classList.add("font-size" + style.fontSize);
 
         // Configure the font type
         if (_firefox_ReaderMode.currentStyle != null) {
-            document.body.classList.remove(currentStyle.fontType);
+            document.body.classList.remove(_firefox_ReaderMode.currentStyle.fontType);
         }
         document.body.classList.add(style.fontType);
         

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -14,6 +14,7 @@ enum ReaderModeState: String {
 enum ReaderModeTheme: String {
     case Light = "light"
     case Dark = "dark"
+    case Print = "print"
 }
 
 enum ReaderModeFontType: String {
@@ -92,7 +93,7 @@ protocol ReaderModeDelegate {
 
 private let ReaderModeNamespace = "_firefox_ReaderMode"
 
-class ReaderMode: BrowserHelper {
+class ReaderMode: BrowserHelper, ReaderModeStyleViewControllerDelegate {
     var delegate: ReaderModeDelegate?
 
     private weak var browser: Browser?
@@ -216,5 +217,9 @@ class ReaderMode: BrowserHelper {
             }
         }
         return nil
+    }
+
+    func readerModeStyleViewController(readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle) {
+        self.style = style
     }
 }

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+
+protocol ReaderModeStyleViewControllerDelegate {
+    func readerModeStyleViewController(readerModeStyleViewController: ReaderModeStyleViewController, didConfigureStyle style: ReaderModeStyle)
+}
+
+class ReaderModeStyleViewController: UIViewController {
+    var delegate: ReaderModeStyleViewControllerDelegate?
+    var readerModeStyle: ReaderModeStyle = DefaultReaderModeStyle
+
+    private let rowHeights = [72, 44, 44, 52]
+    private let width = 260
+
+    private var rows: [UIView] = []
+    private var fontTypeButtons: [FontTypeButton]!
+    private var fontSizeButtons: [FontSizeButton]!
+    private var themeButtons: [ThemeButton]!
+
+    override func viewDidLoad() {
+        view.backgroundColor = UIColor.grayColor()
+
+        // Our preferred content size has a fixed width and height based on the rows + padding
+
+        let height = rowHeights.reduce(0, combine: +) + (rowHeights.count - 1)
+        preferredContentSize = CGSize(width: width, height: height)
+
+        // Setup the rows. It is easier to setup a layout like this when we organize the buttons into rows.
+
+        for idx in 0...3 {
+            let row = UIView()
+            rows.append(row)
+            view.addSubview(row)
+
+            // The only row with a full white background is the one with the slider. The others are the default
+            // clear color so that the gray dividers are visible between buttons in a row.
+            if idx == 3 {
+                row.backgroundColor = UIColor.whiteColor()
+            }
+
+            row.snp_makeConstraints { make in
+                make.left.equalTo(self.view.snp_left)
+                make.right.equalTo(self.view.snp_right)
+                if idx == 0 {
+                    make.top.equalTo(self.view.snp_top)
+                } else {
+                    make.top.equalTo(self.rows[idx-1].snp_bottom).offset(1)
+                }
+                make.height.equalTo(self.rowHeights[idx])
+            }
+        }
+
+        // Setup the font type buttons
+
+        fontTypeButtons = [
+            FontTypeButton(fontType: ReaderModeFontType.SansSerif),
+            FontTypeButton(fontType: ReaderModeFontType.Serif)
+        ]
+        
+        setupButtons(fontTypeButtons, inRow: rows[0], action: "SELchangeFontType:")
+
+        // Setup the font size buttons
+
+        fontSizeButtons = [
+            FontSizeButton(fontSize: ReaderModeFontSize.Smallest),
+            FontSizeButton(fontSize: ReaderModeFontSize.Small),
+            FontSizeButton(fontSize: ReaderModeFontSize.Normal),
+            FontSizeButton(fontSize: ReaderModeFontSize.Large),
+            FontSizeButton(fontSize: ReaderModeFontSize.Largest),
+        ]
+
+        setupButtons(fontSizeButtons, inRow: rows[1], action: "SELchangeFontSize:")
+
+        // Setup the theme buttons
+
+        themeButtons = [
+            ThemeButton(theme: ReaderModeTheme.Light),
+            ThemeButton(theme: ReaderModeTheme.Dark),
+            ThemeButton(theme: ReaderModeTheme.Print)
+        ]
+
+        setupButtons(themeButtons, inRow: rows[2], action: "SELchangeTheme:")
+
+        // Setup the brightness slider
+
+        let slider = UISlider()
+        slider.tintColor = UIColor.orangeColor()
+        rows[3].addSubview(slider)
+        slider.addTarget(self, action: "SELchangeBrightness:", forControlEvents: UIControlEvents.ValueChanged)
+
+        slider.snp_makeConstraints { make in
+            make.center.equalTo(self.rows[3].center)
+            make.width.equalTo(180)
+        }
+
+        // Setup initial values
+
+        selectFontType(readerModeStyle.fontType)
+        selectFontSize(readerModeStyle.fontSize)
+        selectTheme(readerModeStyle.theme)
+        slider.value = Float(UIScreen.mainScreen().brightness)
+    }
+
+    /// Setup constraints for a row of buttons. Left to right. They are all given the same width.
+    private func setupButtons(buttons: [UIButton], inRow row: UIView, action: Selector) {
+        for (idx, button) in enumerate(buttons) {
+            row.addSubview(button)
+            button.addTarget(self, action: action, forControlEvents: UIControlEvents.TouchUpInside)
+            button.snp_makeConstraints { make in
+                make.top.equalTo(row.snp_top)
+                if idx == 0 {
+                    make.left.equalTo(row.snp_left)
+                } else {
+                    make.left.equalTo(buttons[idx-1].snp_right).offset(1)
+                }
+                make.bottom.equalTo(row.snp_bottom)
+                make.width.equalTo(self.preferredContentSize.width/CGFloat(buttons.count))
+            }
+        }
+    }
+
+    func SELchangeFontType(button: FontTypeButton) {
+        selectFontType(button.fontType)
+        delegate?.readerModeStyleViewController(self, didConfigureStyle: readerModeStyle)
+    }
+
+    private func selectFontType(fontType: ReaderModeFontType) {
+        readerModeStyle.fontType = fontType
+        for button in fontTypeButtons {
+            button.selected = (button.fontType == fontType)
+        }
+    }
+
+    func SELchangeFontSize(button: FontSizeButton) {
+        selectFontSize(button.fontSize)
+        delegate?.readerModeStyleViewController(self, didConfigureStyle: readerModeStyle)
+    }
+
+    private func selectFontSize(fontSize: ReaderModeFontSize) {
+        readerModeStyle.fontSize = fontSize
+        for button in fontSizeButtons {
+            button.selected = (button.fontSize == fontSize)
+        }
+    }
+
+    func SELchangeTheme(button: ThemeButton) {
+        selectTheme(button.theme)
+        delegate?.readerModeStyleViewController(self, didConfigureStyle: readerModeStyle)
+    }
+
+    private func selectTheme(theme: ReaderModeTheme) {
+        readerModeStyle.theme = theme
+        for button in themeButtons {
+            button.selected = (button.theme == theme)
+        }
+    }
+
+    func SELchangeBrightness(slider: UISlider) {
+        UIScreen.mainScreen().brightness = CGFloat(slider.value)
+    }
+}
+
+/// Custom button that knows how to show the right image and selection style for a ReaderModeFontType
+/// value. Very generic now, which will change when we have more final UX assets.
+class FontTypeButton: UIButton {
+    var fontType: ReaderModeFontType!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    convenience init(fontType: ReaderModeFontType) {
+        self.init(frame: CGRectZero)
+        self.fontType = fontType
+        setTitle(fontType.rawValue, forState: UIControlState.Normal)
+        setTitleColor(UIColor.blackColor(), forState: UIControlState.Selected)
+        setTitleColor(UIColor.lightGrayColor(), forState: UIControlState.Normal)
+        backgroundColor = UIColor.whiteColor()
+    }
+}
+
+/// Custom button that knows how to show the right image and selection style for a ReaderModeFontSize
+/// value. Very generic now, which will change when we have more final UX assets.
+class FontSizeButton: UIButton {
+    var fontSize: ReaderModeFontSize!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    convenience init(fontSize: ReaderModeFontSize) {
+        self.init(frame: CGRectZero)
+        self.fontSize = fontSize
+        setTitle("\(fontSize.rawValue)", forState: UIControlState.Normal)
+        setTitleColor(UIColor.blackColor(), forState: UIControlState.Selected)
+        setTitleColor(UIColor.lightGrayColor(), forState: UIControlState.Normal)
+        backgroundColor = UIColor.whiteColor()
+    }
+}
+
+/// Custom button that knows how to show the right image and selection style for a ReaderModeTheme
+/// value. Very generic now, which will change when we have more final UX assets.
+class ThemeButton: UIButton {
+    var theme: ReaderModeTheme!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    convenience init(theme: ReaderModeTheme) {
+        self.init(frame: CGRectZero)
+        self.theme = theme
+        setTitle(theme.rawValue, forState: UIControlState.Normal)
+        setTitleColor(UIColor.blackColor(), forState: UIControlState.Selected)
+        setTitleColor(UIColor.lightGrayColor(), forState: UIControlState.Normal)
+        backgroundColor = UIColor.whiteColor()
+    }
+}

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -49,7 +49,7 @@ class ReaderModeStyleViewController: UIViewController {
                 if idx == 0 {
                     make.top.equalTo(self.view.snp_top)
                 } else {
-                    make.top.equalTo(self.rows[idx-1].snp_bottom).offset(1)
+                    make.top.equalTo(self.rows[idx - 1].snp_bottom).offset(1)
                 }
                 make.height.equalTo(self.rowHeights[idx])
             }
@@ -116,10 +116,10 @@ class ReaderModeStyleViewController: UIViewController {
                 if idx == 0 {
                     make.left.equalTo(row.snp_left)
                 } else {
-                    make.left.equalTo(buttons[idx-1].snp_right).offset(1)
+                    make.left.equalTo(buttons[idx - 1].snp_right).offset(1)
                 }
                 make.bottom.equalTo(row.snp_bottom)
-                make.width.equalTo(self.preferredContentSize.width/CGFloat(buttons.count))
+                make.width.equalTo(self.preferredContentSize.width / CGFloat(buttons.count))
             }
         }
     }

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -31,14 +31,15 @@ class ReaderModeStyleViewController: UIViewController {
 
         // Setup the rows. It is easier to setup a layout like this when we organize the buttons into rows.
 
-        for idx in 0...3 {
-            let row = UIView()
-            rows.append(row)
+        let fontTypeRow = UIView(), fontSizeRow = UIView(), themeRow = UIView(), sliderRow = UIView()
+        rows = [fontTypeRow, fontSizeRow, themeRow, sliderRow]
+
+        for (idx, row) in enumerate(rows) {
             view.addSubview(row)
 
             // The only row with a full white background is the one with the slider. The others are the default
             // clear color so that the gray dividers are visible between buttons in a row.
-            if idx == 3 {
+            if row == sliderRow {
                 row.backgroundColor = UIColor.whiteColor()
             }
 
@@ -61,7 +62,7 @@ class ReaderModeStyleViewController: UIViewController {
             FontTypeButton(fontType: ReaderModeFontType.Serif)
         ]
         
-        setupButtons(fontTypeButtons, inRow: rows[0], action: "SELchangeFontType:")
+        setupButtons(fontTypeButtons, inRow: fontTypeRow, action: "SELchangeFontType:")
 
         // Setup the font size buttons
 
@@ -73,7 +74,7 @@ class ReaderModeStyleViewController: UIViewController {
             FontSizeButton(fontSize: ReaderModeFontSize.Largest),
         ]
 
-        setupButtons(fontSizeButtons, inRow: rows[1], action: "SELchangeFontSize:")
+        setupButtons(fontSizeButtons, inRow: fontSizeRow, action: "SELchangeFontSize:")
 
         // Setup the theme buttons
 
@@ -83,17 +84,17 @@ class ReaderModeStyleViewController: UIViewController {
             ThemeButton(theme: ReaderModeTheme.Print)
         ]
 
-        setupButtons(themeButtons, inRow: rows[2], action: "SELchangeTheme:")
+        setupButtons(themeButtons, inRow: themeRow, action: "SELchangeTheme:")
 
         // Setup the brightness slider
 
         let slider = UISlider()
         slider.tintColor = UIColor.orangeColor()
-        rows[3].addSubview(slider)
+        sliderRow.addSubview(slider)
         slider.addTarget(self, action: "SELchangeBrightness:", forControlEvents: UIControlEvents.ValueChanged)
 
         slider.snp_makeConstraints { make in
-            make.center.equalTo(self.rows[3].center)
+            make.center.equalTo(sliderRow.center)
             make.width.equalTo(180)
         }
 


### PR DESCRIPTION
This patch includes a first iteration of a UI for Reader Mode that allows you to change the font type, font size and theme.

Because it is unclear how this UI should be activated, it is currently behind a triple-tap in content while in Reader Mode. This will obviously change.

There are a couple more things missing, like persisting these changes to the profile, but to keep this simple I am going to file followup bugs for those issues.

Note that the buttons on the UI are all text for now. Waiting for more final artwork.