### PR TITLE
Fixes 1127331 - Include a local web server to serve local assets

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FA77971A43B5390010CD32 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D3FA77C41A44F9A80010CD32 /* Locales in Resources */ = {isa = PBXBuildFile; fileRef = D3FA77C31A44F9A80010CD32 /* Locales */; };
+		E40FAAF11A7A868F009CB80D /* WebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40FAAF01A7A868F009CB80D /* WebServer.swift */; };
 		E418D0D91A251B3200CAE47A /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		E418D0DA1A251B3200CAE47A /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84E1A16C40C00D49B7B /* AccountManager.swift */; };
 		E418D0DB1A251B3200CAE47A /* BookmarksREST.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84F1A16C40C00D49B7B /* BookmarksREST.swift */; };
@@ -390,6 +391,7 @@
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FA77C31A44F9A80010CD32 /* Locales */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Locales; sourceTree = "<group>"; };
+		E40FAAF01A7A868F009CB80D /* WebServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServer.swift; sourceTree = "<group>"; };
 		E41A7D421A1BDFD800245963 /* FiraSans-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Regular.ttf"; sourceTree = "<group>"; };
 		E41A7D471A1BE00100245963 /* FiraMono-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraMono-Medium.ttf"; sourceTree = "<group>"; };
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
@@ -798,6 +800,7 @@
 			isa = PBXGroup;
 			children = (
 				F84B21E51A0910F600AAB793 /* AppDelegate.swift */,
+				E40FAAF01A7A868F009CB80D /* WebServer.swift */,
 				E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */,
 			);
 			path = Application;
@@ -1297,6 +1300,7 @@
 				28CE83C71A1D1D3200576538 /* Records.swift in Sources */,
 				F84B22111A0910F600AAB793 /* SettingsViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
+				E40FAAF11A7A868F009CB80D /* WebServer.swift in Sources */,
 				282DA47D1A68C45C00A406E2 /* SearchViewController.swift in Sources */,
 				D34F86DB1A1AC35B00331EC4 /* LoginView.swift in Sources */,
 				D34DC8551A16C40C00D49B7B /* BookmarksREST.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -10,6 +10,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var profile: Profile!
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Setup a web server that serves us static content. Do this early so that it is ready when the UI is presented.
+        setupWebServer()
+
         profile = RESTAccountProfile(localName: "profile", credential: NSURLCredential(), logoutCallback: { (profile) -> () in
             // Nothing to do
         })
@@ -26,5 +29,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(application: UIApplication, applicationWillTerminate app: UIApplication) {
+    }
+
+    private func setupWebServer() {
+        let server = WebServer.sharedInstance
+        // Register our fonts, which we want to expose to web content that we present in the WebView
+        server.registerMainBundleResourcesOfType("ttf", module: "fonts")
+        // TODO: In the future let other modules register specific resources here. Unfortunately you cannot add
+        // more handlers after start() has been called, so we need to organize it all here at app startup time.
+        server.start()
     }
 }

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let WebServerSharedInstance = WebServer()
+
+class WebServer {
+    class var sharedInstance: WebServer {
+        return WebServerSharedInstance
+    }
+
+    let server: GCDWebServer = GCDWebServer()
+
+    var base: String {
+        return "http://localhost:\(server.port)"
+    }
+
+    func start() -> Bool {
+        return server.running || server.startWithPort(0, bonjourName: nil)
+    }
+
+    /// Convenience method to register a resource in the main bundle. Will be mounted at $base/$module/$resource
+    func registerMainBundleResource(resource: String, module: String) {
+        if let path = NSBundle.mainBundle().pathForResource(resource, ofType: nil) {
+            server.addGETHandlerForPath("/\(module)/\(resource)", filePath: path, isAttachment: false, cacheAge: UInt.max, allowRangeRequests: true)
+        }
+    }
+
+    /// Convenience method to register all resources in the main bundle of a specific type. Will be mounted at $base/$module/$resource
+    func registerMainBundleResourcesOfType(type: String, module: String) {
+        for path in NSBundle.pathsForResourcesOfType(type, inDirectory: NSBundle.mainBundle().bundlePath) as [String] {
+            let resource = path.lastPathComponent
+            server.addGETHandlerForPath("/\(module)/\(resource)", filePath: path, isAttachment: false, cacheAge: UInt.max, allowRangeRequests: true)
+        }
+    }
+
+    /// Return a full url, as a string, for a resource in a module. No check is done to find out if the resource actually exist.
+    func URLForResource(resource: String, module: String) -> String {
+        return "\(base)/\(module)/\(resource)"
+    }
+
+    /// Return a full url, as an NSURL, for a resource in a module. No check is done to find out if the resource actually exist.
+    func URLForResource(resource: String, module: String) -> NSURL {
+        return NSURL(string: "\(base)/\(module)/\(resource)")!
+    }
+}


### PR DESCRIPTION
This patch starts a local web server when the application is started. It also registers all the embedded fonts in the application so that web content can reference those from CSS.