### PR TITLE
Bug 1127547 - Follow-up fixes for custom context menu

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -177,10 +177,9 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func didCreateTab(tab: Browser) {
-        if let longPressGestureRecognizer = LongPressGestureRecognizer(browser: tab) {
+        if let longPressGestureRecognizer = LongPressGestureRecognizer(webView: tab.webView) {
             tab.webView.addGestureRecognizer(longPressGestureRecognizer)
             longPressGestureRecognizer.longPressGestureDelegate = self
-            tab.addHelper(longPressGestureRecognizer, name: LongPressGestureRecognizer.name())
         }
 
         if let readerMode = ReaderMode(browser: tab) {

--- a/Client/Frontend/Browser/LongPressGestureRecognizer.swift
+++ b/Client/Frontend/Browser/LongPressGestureRecognizer.swift
@@ -57,7 +57,7 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
             touchLocation.x /= self.webView.scrollView.zoomScale
             touchLocation.y /= self.webView.scrollView.zoomScale
 
-            self.webView.evaluateJavaScript("findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))") { (response: AnyObject!, error: NSError!) in
+            self.webView.evaluateJavaScript("__firefox__.LongPress.findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))") { (response: AnyObject!, error: NSError!) in
                 if error != nil {
                     println("Long press gesture recognizer error: \(error.description)")
                 } else {

--- a/Client/Frontend/Browser/LongPressGestureRecognizer.swift
+++ b/Client/Frontend/Browser/LongPressGestureRecognizer.swift
@@ -15,17 +15,17 @@ protocol LongPressGestureDelegate: class {
     func longPressRecognizer(longPressRecognizer: LongPressGestureRecognizer, didLongPressElements elements: [LongPressElementType: NSURL])
 }
 
-class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecognizerDelegate, BrowserHelper {
-    private weak var browser: Browser!
+class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecognizerDelegate {
+    private weak var webView: WKWebView!
     weak var longPressGestureDelegate: LongPressGestureDelegate?
 
     override init(target: AnyObject, action: Selector) {
         super.init(target: target, action: action)
     }
 
-    required init?(browser: Browser) {
+    required init?(webView: WKWebView) {
         super.init()
-        self.browser = browser
+        self.webView = webView
         delegate = self
         self.minimumPressDuration *= 0.9
         self.addTarget(self, action: "SELdidLongPress:")
@@ -33,7 +33,7 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
         if let path = NSBundle.mainBundle().pathForResource("LongPress", ofType: "js") {
             if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) {
                 var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentStart, forMainFrameOnly: false)
-                self.browser.webView.configuration.userContentController.addUserScript(userScript)
+                self.webView.configuration.userContentController.addUserScript(userScript)
             }
         }
     }
@@ -47,13 +47,19 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
     func SELdidLongPress(gestureRecognizer: UILongPressGestureRecognizer) {
         if gestureRecognizer.state == UIGestureRecognizerState.Began {
             //Finding actual touch location in webView
-            var touchLocation = gestureRecognizer.locationInView(self.browser.webView)
-            touchLocation.x -= self.browser.webView.scrollView.contentInset.left
-            touchLocation.y -= self.browser.webView.scrollView.contentInset.top
-            touchLocation.x /= self.browser.webView.scrollView.zoomScale
-            touchLocation.y /= self.browser.webView.scrollView.zoomScale
+            var touchLocation = gestureRecognizer.locationInView(self.webView)
+            touchLocation.x -= self.webView.scrollView.contentInset.left
+            touchLocation.y -= self.webView.scrollView.contentInset.top
+            touchLocation.x /= self.webView.scrollView.zoomScale
+            touchLocation.y /= self.webView.scrollView.zoomScale
 
-            self.browser.webView.evaluateJavaScript("findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))", completionHandler:nil)
+            self.webView.evaluateJavaScript("findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))") { (response: AnyObject!, error: NSError!) in
+                if error != nil {
+                    println("Long press gesture recognizer error: \(error.description)")
+                } else {
+                    self.handleTouchResult(response as [String: AnyObject])
+                }
+            }
         }
     }
 
@@ -63,44 +69,16 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
         mainView.subviews.map(){ self.recursiveBlockOnViewAndSubviews($0 as UIView, block) }
     }
 
-    /// Find location in screen corresponding to webview - in case it is zoomed or scrolled
-    private func rectLocationInWebView(webView:WKWebView,locationRect:CGRect) -> CGRect {
-        var rect = locationRect
-        var scale = self.browser.webView.scrollView.zoomScale
-        rect.origin.x *= scale
-        rect.origin.y *= scale
-        rect.size.width *= scale
-        rect.size.height *= scale
-        rect.origin.x += self.browser.webView.scrollView.contentInset.left;
-        rect.origin.y += self.browser.webView.scrollView.contentInset.top;
-
-        return rect
-    }
-
-    // MARK: - BrowserHelper Mehods
-    class func name() -> String {
-        return "BrowserLongPressGestureRecognizer"
-    }
-
-    func scriptMessageHandlerName() -> String? {
-        return "longPressMessageHandler"
-    }
-
-    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
-        var elementsDict: [String: AnyObject]? = message.body as? [String: AnyObject]
-        if elementsDict == nil {
-            return
-        }
-
+    private func handleTouchResult(elementsDict: [String: AnyObject]) {
         var elements = [LongPressElementType: NSURL]()
-        if let hrefElement = elementsDict!["hrefElement"] as? [String: String] {
+        if let hrefElement = elementsDict["hrefElement"] as? [String: String] {
             if let hrefStr: String = hrefElement["hrefLink"] {
                 if let linkURL = NSURL(string: hrefStr) {
                     elements[LongPressElementType.Link] = linkURL
                 }
             }
         }
-        if let imageElement = elementsDict!["imageElement"] as? [String: String] {
+        if let imageElement = elementsDict["imageElement"] as? [String: String] {
             if let imageSrcStr: String = imageElement["imageSrc"] {
                 if let imageURL = NSURL(string: imageSrcStr) {
                     elements[LongPressElementType.Image] = imageURL
@@ -110,7 +88,7 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
 
         if elements.count > 0 {
             var disableGestures: [UIGestureRecognizer] = []
-            self.recursiveBlockOnViewAndSubviews(self.browser.webView) { view in
+            self.recursiveBlockOnViewAndSubviews(self.webView) { view in
                 if let gestureRecognizers = view.gestureRecognizers as? [UIGestureRecognizer] {
                     for g in gestureRecognizers {
                         if g != self && g.enabled == true {

--- a/Client/JavaScripts/LongPress.js
+++ b/Client/JavaScripts/LongPress.js
@@ -9,7 +9,7 @@ function findImageSrcLinkAtPoint(x, y) {
         e = e.parentNode;
     }
     if (e && e.src) {
-        imageLink["imageSrc"] = e.src
+        imageLink["imageSrc"] = e.src;
     }
     return imageLink;
 }
@@ -21,7 +21,7 @@ function findHrefLinkAtPoint(x, y) {
         e = e.parentNode;
     }
     if (e && e.href) {
-        hrefLink["hrefLink"] = e.href
+        hrefLink["hrefLink"] = e.href;
     }
     return hrefLink;
 }
@@ -30,5 +30,5 @@ function findElementsAtPoint(x, y) {
     var jsonResult = {};
     jsonResult["hrefElement"] = findHrefLinkAtPoint(x, y);
     jsonResult["imageElement"] = findImageSrcLinkAtPoint(x, y);
-    webkit.messageHandlers.longPressMessageHandler.postMessage(jsonResult);
+    return jsonResult;
 }

--- a/Client/JavaScripts/LongPress.js
+++ b/Client/JavaScripts/LongPress.js
@@ -2,33 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-function findImageSrcLinkAtPoint(x, y) {
-    var  imageLink = {};
-    e = document.elementFromPoint(x, y);
-    while (e && ! e.src) {
-        e = e.parentNode;
-    }
-    if (e && e.src) {
-        imageLink["imageSrc"] = e.src;
-    }
-    return imageLink;
+if (!this.__firefox__) {
+    __firefox__ = {};
 }
 
-function findHrefLinkAtPoint(x, y) {
-    var  hrefLink = {};
-    e = document.elementFromPoint(x, y);
-    while (e && ! e.href) {
-        e = e.parentNode;
-    }
-    if (e && e.href) {
-        hrefLink["hrefLink"] = e.href;
-    }
-    return hrefLink;
-}
+__firefox__.LongPress = {
+    findImageSrcLinkAtPoint: function (x, y) {
+        var imageLink = {};
+        e = document.elementFromPoint(x, y);
+        while (e && ! e.src) {
+            e = e.parentNode;
+        }
+        if (e && e.src) {
+            imageLink["imageSrc"] = e.src;
+        }
+        return imageLink;
+    },
 
-function findElementsAtPoint(x, y) {
-    var jsonResult = {};
-    jsonResult["hrefElement"] = findHrefLinkAtPoint(x, y);
-    jsonResult["imageElement"] = findImageSrcLinkAtPoint(x, y);
-    return jsonResult;
-}
+    findHrefLinkAtPoint: function (x, y) {
+        var hrefLink = {};
+        e = document.elementFromPoint(x, y);
+        while (e && ! e.href) {
+            e = e.parentNode;
+        }
+        if (e && e.href) {
+            hrefLink["hrefLink"] = e.href;
+        }
+        return hrefLink;
+    },
+
+    findElementsAtPoint: function (x, y) {
+        var jsonResult = {};
+        jsonResult["hrefElement"] = this.findHrefLinkAtPoint(x, y);
+        jsonResult["imageElement"] = this.findImageSrcLinkAtPoint(x, y);
+        return jsonResult;
+    },
+};


### PR DESCRIPTION
Follow-up to #61. I had suggested we try making the gesture recognizer implement the BrowserHelper protocol, but that doesn't seem to buy us anything and just adds extra code, so I removed it. Also fixes the JS race by disabling only the built-in context menu gesture recognizer.