### PR TITLE
Bug 1127989 - Fixes to BackForwardListViewController

### DIFF
--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 import WebKit
 
 class BackForwardListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
     private let StatusBarHeight = 20
     var listData: [WKBackForwardListItem]?
     var tabManager: TabManager!
@@ -43,16 +42,13 @@ class BackForwardListViewController: UIViewController, UITableViewDelegate, UITa
     // MARK: - Table view
 
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if listData != nil {
-            return listData!.count
-        }
-        return 0
+        return listData?.count ?? 0
     }
-
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = UITableViewCell()
-        cell.textLabel?.text = listData![indexPath.item].title
+        let item = listData![indexPath.item]
+        cell.textLabel?.text = item.title ?? item.URL.absoluteString
         return cell
     }
 
@@ -60,5 +56,4 @@ class BackForwardListViewController: UIViewController, UITableViewDelegate, UITa
         tabManager.selectedTab?.goToBackForwardListItem(listData![indexPath.item])
         dismissViewControllerAnimated(true, completion: nil)
     }
-
 }

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -53,7 +53,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate, BrowserLocationViewDelegate {
         backButton.setTitle("<", forState: UIControlState.Normal)
         backButton.accessibilityLabel = NSLocalizedString("Back", comment: "")
         backButton.addTarget(self, action: "SELdidClickBack", forControlEvents: UIControlEvents.TouchUpInside)
-        longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBack")
+        longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBack:")
         backButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
         backButton.addGestureRecognizer(longPressGestureBackButton)
         self.addSubview(backButton)
@@ -64,7 +64,7 @@ class BrowserToolbar: UIView, UITextFieldDelegate, BrowserLocationViewDelegate {
         forwardButton.setTitle(">", forState: UIControlState.Normal)
         forwardButton.accessibilityLabel = NSLocalizedString("Forward", comment: "")
         forwardButton.addTarget(self, action: "SELdidClickForward", forControlEvents: UIControlEvents.TouchUpInside)
-        longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressForward")
+        longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressForward:")
         forwardButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
         forwardButton.addGestureRecognizer(longPressGestureForwardButton)
         self.addSubview(forwardButton)
@@ -150,16 +150,20 @@ class BrowserToolbar: UIView, UITextFieldDelegate, BrowserLocationViewDelegate {
         browserToolbarDelegate?.didClickBack()
     }
 
-    func SELdidLongPressBack() {
-        browserToolbarDelegate?.didLongPressBack()
+    func SELdidLongPressBack(recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.Began {
+            browserToolbarDelegate?.didLongPressBack()
+        }
     }
 
     func SELdidClickForward() {
         browserToolbarDelegate?.didClickForward()
     }
 
-    func SELdidLongPressForward() {
-        browserToolbarDelegate?.didLongPressForward()
+    func SELdidLongPressForward(recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.Began {
+            browserToolbarDelegate?.didLongPressForward()
+        }
     }
 
     func SELdidClickAddTab() {


### PR DESCRIPTION
Playing around with our back/forward list, I've run across a few problems:
* Entries in the list are empty if the page doesn't have a title
* Whenever long pressing the back/forward buttons, the following warning appears in the console:
```
2015-01-30 10:44:11.324 Client[36645:1389340] Warning: Attempt to present 
<Client.BackForwardListViewController: 0x7fe7b2279400> on <Client.BrowserViewController: 
0x7fe7b2229130> whose view is not in the window hierarchy!
```
This happens because UIGestureRecognizer callbacks are fired multiple times in different states (Possible, Began, Changed, Ended, etc.), and we're firing the delegate multiple times. Whenever handling a UIGestureRecognizer event, we need to check its state. I have a feeling we're doing this wrong in other places we use UIGestureRecognizer, so I'll file more bugs for any I find.