### PR TITLE
Bug 1128595 - Sqlite db for favicons

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		0BE108361A1B1EC700D4B712 /* TestLocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE108351A1B1EC700D4B712 /* TestLocking.swift */; };
 		0BE1083A1A1B1ED200D4B712 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE108391A1B1ED200D4B712 /* Locking.swift */; };
 		0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF0DB931A8545800039F300 /* URLBarView.swift */; };
+		0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */; };
+		0BF42D391A7C0E8900889E28 /* Favicons.js in Resources */ = {isa = PBXBuildFile; fileRef = 0BF42D381A7C0E8900889E28 /* Favicons.js */; };
+		0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */; };
 		0BF9F8BC1A3A82CA0049A0FA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
 		282DA4691A68C13400A406E2 /* Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42CCDE21A23A6F900B794D3 /* Clients.swift */; };
 		282DA46D1A68C15100A406E2 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -408,6 +411,9 @@
 		0BE108351A1B1EC700D4B712 /* TestLocking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLocking.swift; sourceTree = "<group>"; };
 		0BE108391A1B1ED200D4B712 /* Locking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Locking.swift; sourceTree = "<group>"; };
 		0BF0DB931A8545800039F300 /* URLBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLBarView.swift; sourceTree = "<group>"; };
+		0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaviconManager.swift; sourceTree = "<group>"; };
+		0BF42D381A7C0E8900889E28 /* Favicons.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = Favicons.js; sourceTree = "<group>"; };
+		0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFavicons.swift; sourceTree = "<group>"; };
 		282DA4B11A699E0300A406E2 /* Storage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Storage.xcodeproj; path = Storage/Storage.xcodeproj; sourceTree = "<group>"; };
 		28C077971A3B064000834FE5 /* CryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		28C077991A3B064F00834FE5 /* FxAClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAClientTests.swift; sourceTree = "<group>"; };
@@ -760,6 +766,7 @@
 				9B9AE2231A48B9A500AF2C23 /* LongPressGestureRecognizer.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -908,6 +915,8 @@
 				0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
+				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
+				0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -935,6 +944,7 @@
 			children = (
 				F84B22391A0914A300AAB793 /* Fonts */,
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
+				0BF42D381A7C0E8900889E28 /* Favicons.js */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -1416,6 +1426,7 @@
 				F84B22291A0912C500AAB793 /* Settings.xcassets in Resources */,
 				E4B7B7781A793CF20022C5E0 /* FiraSans-Italic.ttf in Resources */,
 				E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */,
+				0BF42D391A7C0E8900889E28 /* Favicons.js in Resources */,
 				F84B221A1A0911B500AAB793 /* BookmarksViewController.xib in Resources */,
 				E4B7B7691A793CF20022C5E0 /* FiraSans-BoldItalic.ttf in Resources */,
 				F84B22151A0910F600AAB793 /* TabsViewControllerFooter.xib in Resources */,
@@ -1511,6 +1522,7 @@
 				E4CD9F141A6D9B0900318571 /* GCDWebServerStreamedResponse.m in Sources */,
 				E4CD9F081A6D9B0900318571 /* GCDWebServerFileRequest.m in Sources */,
 				E4CD9F121A6D9B0900318571 /* GCDWebServerFileResponse.m in Sources */,
+				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
 				E42CCDE31A23A6F900B794D3 /* Clients.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
@@ -1592,6 +1604,7 @@
 				2F834D151A80629A006A0B7B /* FxAGetStartedViewController.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
 				0BE108361A1B1EC700D4B712 /* TestLocking.swift in Sources */,
+				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				28C0779A1A3B064F00834FE5 /* FxAClientTests.swift in Sources */,
 				0BD19A6F1A2530D30084FBA7 /* TabsViewController.swift in Sources */,

--- a/Client/Assets/Favicons.js
+++ b/Client/Assets/Favicons.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+ // These integers should be kept in sync with the IconType raw-values
+ var ICON = 0;
+ var APPLE = 1;
+ var APPLE_PRECOMPOSED = 2;
+ var GUESS = 3;
+
+ var Favicons = {
+  selectors: { "link[rel~='icon']": ICON,
+              "link[rel='apple-touch-icon']": APPLE,
+              "link[rel='apple-touch-icon-precomposed']": APPLE_PRECOMPOSED },
+
+ getAll: function() {
+    var res = {}
+    var foundIcons = false
+
+    for (selector in this.selectors) {
+      var icons = document.querySelectorAll(selector)
+      for (var i = 0; i < icons.length; i++) {
+        var href = icons[i].href;
+        res[href] = this.selectors[selector];
+        if (!foundIcons && this.selectors[selector] == ICON) {
+          foundIcons = true
+        }
+      }
+    }
+
+    // If we didn't find anything in the page, look to see if a favicon.ico file exists for the domain
+    if (res) {
+      var href = document.location.origin + "/favicon.ico";
+      res[href] = GUESS;
+    }
+
+    return res;
+  }
+}
+
+window.addEventListener("load", function() {
+  var favicons = Favicons.getAll();
+  webkit.messageHandlers.faviconsMessageHandler.postMessage(favicons);
+});
+
+})()

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -6,7 +6,6 @@ import Foundation
 import WebKit
 
 protocol BrowserHelper {
-    init?(browser: Browser)
     class func name() -> String
     func scriptMessageHandlerName() -> String?
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -205,6 +205,10 @@ extension BrowserViewController: TabManagerDelegate {
             gestureRecognizer.numberOfTapsRequired = 3
             tab.webView.addGestureRecognizer(gestureRecognizer)
         }
+
+        let favicons = FaviconManager(browser: tab, profile: profile)
+        favicons.profile = profile
+        tab.addHelper(favicons, name: FaviconManager.name())
     }
 
     func didAddTab(tab: Browser) {

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+import Storage
+
+class FaviconManager : BrowserHelper {
+    var profile: Profile!
+    weak var browser: Browser?
+
+    init(browser: Browser, profile: Profile) {
+        self.profile = profile
+        self.browser = browser
+
+        if let path = NSBundle.mainBundle().pathForResource("Favicons", ofType: "js") {
+            if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) {
+                var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
+                browser.webView.configuration.userContentController.addUserScript(userScript)
+            }
+        }
+    }
+
+    class func name() -> String {
+        return "FaviconsManager"
+    }
+
+    func scriptMessageHandlerName() -> String? {
+        return "faviconsMessageHandler"
+    }
+
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        println("DEBUG: faviconsMessageHandler message: \(message.body)")
+
+        if let url = browser?.webView.URL?.absoluteString {
+            let site = Site(url: url, title: "")
+            if let icons = message.body as? [String: Int] {
+                for icon in icons {
+                    let fav = Favicon(url: icon.0, date: NSDate(), type: IconType(rawValue: icon.1)!)
+                    profile.favicons.add(fav, site: site, complete: { (success) -> Void in
+                        return
+                    })
+                }
+            }
+        }
+    }
+}

--- a/Client/Frontend/History/HistoryViewController.swift
+++ b/Client/Frontend/History/HistoryViewController.swift
@@ -61,14 +61,26 @@ class HistoryViewController: UITableViewController, UrlViewController {
             textLabel?.font = UIFont(name: "FiraSans-SemiBold", size: 13)
             textLabel?.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkGrayColor()
             indentationWidth = 0
+
             detailTextLabel?.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGrayColor() : UIColor.lightGrayColor()
-            imageView?.bounds = CGRectMake(0, 0, 24, 24)
-            // imageView?
+            imageView?.frame = CGRectMake(0, 0, 24, 24)
         }
 
         required init(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
+    }
+
+    func createSizedFavicon(icon: UIImage) -> UIImage {
+        let size = CGSize(width: 30, height: 30)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        var context = UIGraphicsGetCurrentContext()
+
+        icon.drawInRect(CGRectInset(CGRect(origin: CGPointZero, size: size), 1.0, 1.0))
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
     }
 
     private let FAVICON_SIZE = 32
@@ -79,8 +91,11 @@ class HistoryViewController: UITableViewController, UrlViewController {
             if let site = hist[indexPath.row] as? Site {
                 cell.textLabel?.text = site.title
                 cell.detailTextLabel?.text = site.url
-                // cell.imageView?.image = UIImage(named: "leaf")
-
+                if let img = site.icon?.getImage(profile.files) {
+                    cell.imageView?.image = createSizedFavicon(img)
+                } else {
+                    cell.imageView?.image = UIImage(named: "defaultFavicon")
+                }
                 let opts = QueryOptions()
                 opts.filter = site.url
             }

--- a/ClientTests/TestHistory.swift
+++ b/ClientTests/TestHistory.swift
@@ -94,7 +94,7 @@ class TestHistory : AccountTest {
             self.checkVisits(h, url: "url1")
             self.checkVisits(h, url: "url2")
             self.clear(h)
-            account.files.remove("browser.db")
+            account.files.remove("browser.db", basePath: nil)
         }
     }
 
@@ -113,7 +113,7 @@ class TestHistory : AccountTest {
                 }
                 self.clear(h)
             })
-            account.files.remove("browser.db")
+            account.files.remove("browser.db", basePath: nil)
         }
     }
 
@@ -136,7 +136,7 @@ class TestHistory : AccountTest {
             })
 
             self.clear(h)
-            account.files.remove("browser.db")
+            account.files.remove("browser.db", basePath: nil)
         }
     }
 
@@ -160,7 +160,7 @@ class TestHistory : AccountTest {
             }
             self.waitForExpectationsWithTimeout(10, handler: nil)
 
-            account.files.remove("browser.db")
+            account.files.remove("browser.db", basePath: nil)
         }
     }
 
@@ -182,7 +182,7 @@ class TestHistory : AccountTest {
             }
             self.waitForExpectationsWithTimeout(10, handler: nil)
 
-            account.files.remove("browser.db")
+            account.files.remove("browser.db", basePath: nil)
         }
     }
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -13,10 +13,7 @@ class ProfileFileAccessor : FileAccessor {
         self.profile = profile
     }
 
-    private func getDir() -> String? {
-        let basePath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as String
-        let path = basePath.stringByAppendingPathComponent("profile.\(profile.localName())")
-
+    private func createDir(path: String) -> String? {
         if !NSFileManager.defaultManager().fileExistsAtPath(path) {
             var err: NSError? = nil
             if !NSFileManager.defaultManager().createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil, error: &err) {
@@ -24,13 +21,26 @@ class ProfileFileAccessor : FileAccessor {
                 return nil
             }
         }
-
         return path
     }
 
-    func move(src: String, dest: String) -> Bool {
-        if let f = get(src) {
-            if let f2 = get(dest) {
+    func getDir(name: String?, basePath: String? = nil) -> String? {
+        var path = basePath
+        if path == nil {
+        	path = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
+            path = createDir(path!.stringByAppendingPathComponent(profileDirName))
+
+        }
+
+        if let name = name {
+            path = createDir(path!.stringByAppendingPathComponent(name))
+        }
+        return path!
+    }
+
+    func move(src: String, srcBasePath: String? = nil, dest: String, destBasePath: String? = nil) -> Bool {
+        if let f = self.get(src, basePath: nil) {
+            if let f2 = self.get(dest) {
                 return NSFileManager.defaultManager().moveItemAtPath(f, toPath: f2, error: nil)
             }
         }
@@ -38,19 +48,24 @@ class ProfileFileAccessor : FileAccessor {
         return false
     }
 
-    func get(filename: String) -> String? {
-        return getDir()?.stringByAppendingPathComponent(filename)
+    private var profileDirName: String {
+        return "profile.\(profile.localName())"
     }
 
-    func remove(filename: String) {
+    func get(filename: String, basePath: String? = nil) -> String? {
+        return getDir(nil, basePath: basePath)?.stringByAppendingPathComponent(filename)
+    }
+
+
+    func remove(filename: String, basePath: String? = nil) {
         let fileManager = NSFileManager.defaultManager()
-        if var file = get(filename) {
+        if var file = self.get(filename) {
             fileManager.removeItemAtPath(file, error: nil)
         }
     }
 
-    func exists(filename: String) -> Bool {
-        if var file = get(filename) {
+    func exists(filename: String, basePath: String? = nil) -> Bool {
+        if var file = self.get(filename, basePath: basePath) {
             return NSFileManager.defaultManager().fileExistsAtPath(file)
         }
         return false
@@ -68,6 +83,7 @@ protocol Profile {
     var searchEngines: SearchEngines { get }
     var files: FileAccessor { get }
     var history: History { get }
+    var favicons: Favicons { get }
 
     // Because we can't test for whether this is an AccountProfile.
     // TODO: probably Profile should own an Account.
@@ -129,6 +145,10 @@ public class MockAccountProfile: Profile, AccountProfile {
 
     func logout() {
     }
+
+    lazy var favicons: Favicons = {
+        return SQLiteFavicons(files: self.files)
+    }()
 
     lazy var history: History = {
         return SQLiteHistory(files: self.files)
@@ -231,6 +251,10 @@ public class RESTAccountProfile: Profile, AccountProfile {
         }
         return _clients!
     }
+
+    lazy var favicons: Favicons = {
+        return SQLiteFavicons(files: self.files)
+    }()
 
     // lazy var ReadingList readingList
 

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -21,6 +21,16 @@
 		0BCFBBB81A776A200087E26D /* MockFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCFBBB71A776A200087E26D /* MockFiles.swift */; };
 		0BF42D471A7C558000889E28 /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497811A7B094B004C8E17 /* Visit.swift */; };
 		0BF42D481A7C55D200889E28 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D61A69A28000A406E2 /* Site.swift */; };
+		0BF42D3E1A7C148F00889E28 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D3D1A7C148F00889E28 /* Favicons.swift */; };
+		0BF42D401A7C18CD00889E28 /* SQLFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */; };
+		0BF42D421A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */; };
+		0BF42D441A7C31EE00889E28 /* FaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */; };
+		0BF42D461A7C52C800889E28 /* TestFaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */; };
+		0BF42D471A7C558000889E28 /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497811A7B094B004C8E17 /* Visit.swift */; };
+		0BF42D481A7C55D200889E28 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D61A69A28000A406E2 /* Site.swift */; };
+		0BF42D4A1A7C55F000889E28 /* FaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */; };
+		0BF42D4B1A7C55F300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */; };
+		0BF42D4D1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */; };
 		282DA49B1A699E0300A406E2 /* Storage.h in Headers */ = {isa = PBXBuildFile; fileRef = 282DA49A1A699E0300A406E2 /* Storage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		282DA4A11A699E0300A406E2 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 282DA4951A699E0300A406E2 /* Storage.framework */; };
 		282DA4A81A699E0300A406E2 /* StorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4A71A699E0300A406E2 /* StorageTests.swift */; };
@@ -61,6 +71,12 @@
 		0BAE69551A7E1FD100B3609D /* SchemaTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaTable.swift; sourceTree = "<group>"; };
 		0BAE69581A7EEF8E00B3609D /* TestTableTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTableTable.swift; sourceTree = "<group>"; };
 		0BCFBBB71A776A200087E26D /* MockFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFiles.swift; sourceTree = "<group>"; };
+		0BF42D3D1A7C148F00889E28 /* Favicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Favicons.swift; sourceTree = "<group>"; };
+		0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLFavicons.swift; sourceTree = "<group>"; };
+		0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinedFaviconsHistoryTable.swift; sourceTree = "<group>"; };
+		0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaviconsTable.swift; sourceTree = "<group>"; };
+		0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFaviconsTable.swift; sourceTree = "<group>"; };
+		0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJoinedFaviconTable.swift; sourceTree = "<group>"; };
 		282DA4951A699E0300A406E2 /* Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		282DA4991A699E0300A406E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		282DA49A1A699E0300A406E2 /* Storage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
@@ -137,6 +153,7 @@
 				282DA4C01A699EF200A406E2 /* Cursor.swift */,
 				282DA49A1A699E0300A406E2 /* Storage.h */,
 				282DA4981A699E0300A406E2 /* Supporting Files */,
+				0BF42D3D1A7C148F00889E28 /* Favicons.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -155,7 +172,9 @@
 				282DA4A71A699E0300A406E2 /* StorageTests.swift */,
 				282DA4A51A699E0300A406E2 /* Supporting Files */,
 				4A59B6E9AB0A08F28227C050 /* TestHistoryTable.swift */,
+				0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */,
 				4A59B33FF96A39A59CBBBBD7 /* TestJoinedHistoryVisits.swift */,
+				0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */,
 				4A59BE48DBF43989C51D3F98 /* TestVisitsTable.swift */,
 				0BCFBBB71A776A200087E26D /* MockFiles.swift */,
 				0BAE69581A7EEF8E00B3609D /* TestTableTable.swift */,
@@ -189,6 +208,9 @@
 				4A59B3F1AAD619686DB9450C /* GenericTable.swift */,
 				4A59BCB8D38CE6E6F5F5F2DE /* JoinedHistoryVisitsTable.swift */,
 				0BAE69551A7E1FD100B3609D /* SchemaTable.swift */,
+				0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */,
+				0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */,
+				0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */,
 			);
 			name = SQL;
 			sourceTree = "<group>";
@@ -313,12 +335,16 @@
 				0BA4977E1A7B0941004C8E17 /* SQLiteHistory.swift in Sources */,
 				282DA5211A69BCB700A406E2 /* module.modulemap in Sources */,
 				0BA4978C1A7B0E44004C8E17 /* Cursor.swift in Sources */,
+				0BF42D401A7C18CD00889E28 /* SQLFavicons.swift in Sources */,
 				282DA4D71A69A28000A406E2 /* Site.swift in Sources */,
 				282DA4D41A69A24300A406E2 /* History.swift in Sources */,
 				0BA497831A7B094B004C8E17 /* Visit.swift in Sources */,
 				0BAE69561A7E1FD100B3609D /* SchemaTable.swift in Sources */,
 				4A59BB4F36A20F30229034C6 /* VisitsTable.swift in Sources */,
+				0BF42D421A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */,
+				0BF42D441A7C31EE00889E28 /* FaviconsTable.swift in Sources */,
 				4A59B21913DCFA81C7CD9C91 /* GenericTable.swift in Sources */,
+				0BF42D3E1A7C148F00889E28 /* Favicons.swift in Sources */,
 				0BA4978D1A7B0E55004C8E17 /* FileAccessor.swift in Sources */,
 				4A59BD24F6210866F59EF0F6 /* JoinedHistoryVisitsTable.swift in Sources */,
 				4A59BFF7C37812C7955B9E79 /* HistoryTable.swift in Sources */,
@@ -332,9 +358,11 @@
 			files = (
 				282DA4D21A69A14500A406E2 /* FileAccessor.swift in Sources */,
 				0BCFBBB81A776A200087E26D /* MockFiles.swift in Sources */,
+				0BF42D4B1A7C55F300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */,
 				0BCFBBB51A7769B70087E26D /* VisitsTable.swift in Sources */,
 				282DA4A81A699E0300A406E2 /* StorageTests.swift in Sources */,
 				0BCFBBB41A7769A30087E26D /* JoinedHistoryVisitsTable.swift in Sources */,
+				0BF42D461A7C52C800889E28 /* TestFaviconsTable.swift in Sources */,
 				0BCFBBAF1A77650E0087E26D /* GenericTable.swift in Sources */,
 				282DA4C61A699F8A00A406E2 /* SwiftData.swift in Sources */,
 				0BF42D471A7C558000889E28 /* Visit.swift in Sources */,
@@ -345,6 +373,8 @@
 				4A59BF0BBF50FC218A6D1143 /* BrowserDB.swift in Sources */,
 				4A59B334A243792894D6E614 /* TestHistoryTable.swift in Sources */,
 				4A59BC6033BD93D1DC36E18F /* TestJoinedHistoryVisits.swift in Sources */,
+				0BF42D4D1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift in Sources */,
+				0BF42D4A1A7C55F000889E28 /* FaviconsTable.swift in Sources */,
 				4A59BF2F408CDEF8D50AF9D3 /* TestVisitsTable.swift in Sources */,
 				0BAE69591A7EEF8E00B3609D /* TestTableTable.swift in Sources */,
 			);

--- a/Storage/Storage/Favicons.swift
+++ b/Storage/Storage/Favicons.swift
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* The base favicons protocol */
+public protocol Favicons {
+    init(files: FileAccessor)
+
+    func clear(options: QueryOptions?, complete: (success: Bool) -> Void)
+    func get(options: QueryOptions?, complete: (data: Cursor) -> Void)
+    func add(icon: Favicon, site: Site, complete: (success: Bool) -> Void)
+}

--- a/Storage/Storage/FaviconsTable.swift
+++ b/Storage/Storage/FaviconsTable.swift
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let TableNameFavicons = "favicons"
+
+// NOTE: If you add a new Table, make sure you update the version number in BrowserDB.swift!
+
+// This is our default favicons store.
+class FaviconsTable<T>: GenericTable<Favicon> {
+    private var files: FileAccessor
+    override var name: String { return TableNameFavicons }
+    override var rows: String { return "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                       "url TEXT NOT NULL UNIQUE, " +
+                       "width INTEGER, " +
+                       "height INTEGER, " +
+                       "type INTEGER NOT NULL, " +
+                       "date REAL NOT NULL" }
+
+    init(files: FileAccessor) {
+        self.files = files
+    }
+
+    override func getInsertAndArgs(inout item: Favicon) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        args.append(item.url)
+        // XXX - This will force the download of the icon.
+        if let img = item.getImage(files) {
+            args.append(img.size.width)
+            args.append(img.size.height)
+        } else {
+            args.append(-1)
+            args.append(-1)
+        }
+        args.append(item.date)
+        args.append(item.type.rawValue)
+        return ("INSERT INTO \(TableNameFavicons) (url, width, height, date, type) VALUES (?,?,?,?,?)", args)
+    }
+
+    override func getUpdateAndArgs(inout item: Favicon) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        if let img = item.getImage(files) {
+            args.append(img.size.width)
+            args.append(img.size.height)
+        } else {
+            args.append(-1)
+            args.append(-1)
+        }
+        args.append(item.date)
+        args.append(item.type.rawValue)
+        args.append(item.url)
+        return ("UPDATE \(TableNameFavicons) SET width = ?, height = ?, date = ?, type = ? WHERE url = ?", args)
+    }
+
+    override func getDeleteAndArgs(inout item: Favicon?) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        if let icon = item {
+            args.append(icon.url)
+            return ("DELETE FROM \(TableNameFavicons) WHERE url = ?", args)
+        }
+        return ("DELETE FROM \(TableNameFavicons)", args)
+    }
+
+    override var factory: ((row: SDRow) -> Favicon)? {
+        return { row -> Favicon in
+            let icon = Favicon(url: row["url"] as String, date: NSDate(timeIntervalSince1970: row["date"] as Double), type: IconType(rawValue: row["type"] as Int)!)
+            icon.id = row["id"] as? Int
+            return icon
+        }
+    }
+
+    override func getQueryAndArgs(options: QueryOptions?) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        if let filter: AnyObject = options?.filter {
+            args.append("%\(filter)%")
+            return ("SELECT id, url, date, type FROM \(TableNameFavicons) WHERE url LIKE ?", args)
+        }
+        return ("SELECT id, url, date, type FROM \(TableNameFavicons)", args)
+    }
+
+    func getIDFor(db: SQLiteDBConnection, obj: Favicon) -> Int? {
+        let opts = QueryOptions()
+        opts.filter = obj.url
+
+        let cursor = query(db, options: opts)
+        if (cursor.count != 1) {
+            return nil
+        }
+        return (cursor[0] as Favicon).id
+    }
+
+    func insertOrUpdate(db: SQLiteDBConnection, obj: Favicon) {
+        var err: NSError? = nil
+        let id = self.insert(db, item: obj, err: &err)
+        if id >= 0 {
+            obj.id = id
+            return
+        }
+
+        if obj.id == nil {
+            obj.id = getIDFor(db, obj: obj)
+        }
+    }
+}

--- a/Storage/Storage/FileAccessor.swift
+++ b/Storage/Storage/FileAccessor.swift
@@ -5,8 +5,9 @@
 import Foundation
 
 public protocol FileAccessor {
-    func get(filename: String) -> String?
-    func remove(filename: String)
-    func move(src: String, dest: String) -> Bool
-    func exists(filename: String) -> Bool
+    func getDir(name: String?, basePath: String?) -> String?
+    func get(path: String, basePath: String?) -> String?
+    func remove(filename: String, basePath: String?)
+    func move(src: String, srcBasePath: String?, dest: String, destBasePath: String?) -> Bool
+    func exists(filename: String, basePath: String?) -> Bool
 }

--- a/Storage/Storage/JoinedFaviconsHistoryTable.swift
+++ b/Storage/Storage/JoinedFaviconsHistoryTable.swift
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let FaviconVisits = "faviconSiteMapping"
+
+// This isn't a real table. Its an abstraction around the history and visits table
+// to simpify queries that should join both tables. It also handles making sure that
+// inserts/updates/delete update both tables appropriately. i.e.
+// 1.) Deleteing a history entry here will also remove all visits to it
+// 2.) Adding a visit here will ensure that a site exists for the visit
+// 3.) Updates currently only update site information.
+class JoinedFaviconsHistoryTable<T>: GenericTable<(site: Site?, icon: Favicon?)> {
+    private let favicons: FaviconsTable<Favicon>
+    private let history: HistoryTable<Site>
+
+    init(files: FileAccessor) {
+        self.favicons = FaviconsTable<Favicon>(files: files)
+        self.history = HistoryTable<Site>()
+    }
+
+    override var name: String { return FaviconVisits }
+    override var rows: String { return "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+        "siteId INTEGER NOT NULL, " +
+        "faviconId INTEGER NOT NULL" }
+
+    override func getInsertAndArgs(inout item: Type) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        args.append(item.site!.id)
+        args.append(item.icon!.id)
+        return ("INSERT INTO \(name) (siteId, faviconId) VALUES (?,?)", args)
+    }
+
+    override func getUpdateAndArgs(inout item: Type) -> (String, [AnyObject?])? {
+        // We don't support updates here...
+        return nil
+    }
+
+    override func getDeleteAndArgs(inout item: Type?) -> (String, [AnyObject?])? {
+        var args = [AnyObject?]()
+        var sql = "DELETE FROM \(FaviconVisits)"
+        if let item = item {
+            sql += " WHERE"
+            if let site = item.site {
+                args.append(site.id!)
+                sql += " siteId = ?"
+            }
+
+            if let icon = item.icon {
+                args.append(icon.id!)
+                sql += " faviconId = ?"
+            }
+        }
+        println("Delete \(sql) \(args)")
+        return (sql, args)
+    }
+
+    override func create(db: SQLiteDBConnection, version: Int) -> Bool {
+        history.create(db, version: version)
+        favicons.create(db, version: version)
+        return super.create(db, version: version)
+    }
+
+    override func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
+        if history.updateTable(db, from: from, to: to) && favicons.updateTable(db, from: from, to: to) {
+            return super.updateTable(db, from: from, to: to)
+        }
+        return false
+    }
+
+    override func insert(db: SQLiteDBConnection, item: Type?, inout err: NSError?) -> Int {
+        if let (site, favicon) = item {
+            if let site = site {
+                history.insertOrUpdate(db, obj: site)
+            } else {
+                println("Must have a site to insert in \(name)")
+                return -1
+            }
+
+            if let icon = favicon {
+                favicons.insertOrUpdate(db, obj: icon)
+            } else {
+                println("Must have an icon to insert in \(name)")
+                return -1
+            }
+
+            let args: [AnyObject?] = [item?.icon?.id, item?.site?.id]
+            let c = db.executeQuery("SELECT * FROM \(FaviconVisits) WHERE faviconId = ? AND siteId = ?", factory: {
+                (row) -> Type in return (nil, nil)
+            }, withArgs: args)
+            if c.count > 0 {
+                return -1
+            }
+
+            return super.insert(db, item: item, err: &err)
+        }
+
+        return -1
+    }
+
+    override func update(db: SQLiteDBConnection, item: Type?, inout err: NSError?) -> Int {
+        if let (site, favicon) = item {
+            history.update(db, item: site, err: &err)
+            favicons.update(db, item: favicon, err: &err)
+            return super.update(db, item: item, err: &err)
+        }
+
+        return -1
+    }
+
+    func factory(result: SDRow) -> (Site, Favicon) {
+        let site = Site(url: result["siteUrl"] as String, title: result["title"] as String)
+        site.guid = result["guid"] as? String
+        site.id = result["historyId"] as? Int
+
+        let favicon = Favicon(url: result["iconUrl"] as String,
+            date: NSDate(timeIntervalSince1970: result["date"] as Double),
+            type: IconType(rawValue: result["iconType"] as Int)!)
+        favicon.id = result["iconId"] as? Int
+
+        return (site, favicon)
+    }
+
+    override func query(db: SQLiteDBConnection, options: QueryOptions?) -> Cursor {
+        var args = [AnyObject?]()
+        var sql = "SELECT \(history.name).id as historyId, \(history.name).url as siteUrl, title, guid, " +
+                  "\(favicons.name).id as iconId, \(favicons.name).url as iconUrl, date, \(favicons.name).type as iconType FROM \(history.name) " +
+                  "INNER JOIN \(FaviconVisits) ON \(history.name).id = \(FaviconVisits).siteId " +
+                  "INNER JOIN \(favicons.name) ON \(favicons.name).id = \(FaviconVisits).faviconId";
+
+        if let filter: AnyObject = options?.filter {
+            sql += " WHERE siteUrl LIKE ?"
+            args.append("%\(filter)%")
+        }
+
+        println("\(sql) \(args)")
+        return db.executeQuery(sql, factory: factory, withArgs: args)
+    }
+}

--- a/Storage/Storage/SQL/BrowserDB.swift
+++ b/Storage/Storage/SQL/BrowserDB.swift
@@ -47,7 +47,7 @@ class BrowserDB {
 
     init?(files: FileAccessor) {
         self.files = files
-        db = SwiftData(filename: files.get(FileName)!)
+        db = SwiftData(filename: files.get(FileName, basePath: nil)!)
         self.schemaTable = SchemaTable()
         self.createOrUpdate(self.schemaTable)
     }
@@ -121,10 +121,9 @@ class BrowserDB {
             // attached and expecting a working DB, but at least we should be able to restart
             if !success {
                 println("Couldn't create or update \(table.name)")
-                self.files.move(self.FileName, dest: "\(self.FileName).bak")
+                self.files.move(self.FileName, srcBasePath: nil, dest: "\(self.FileName).bak", destBasePath: nil)
                 success = self.createTable(connection, table: table)
             }
-
             return success
         })
 

--- a/Storage/Storage/SQL/GenericTable.swift
+++ b/Storage/Storage/SQL/GenericTable.swift
@@ -41,8 +41,11 @@ class GenericTable<T>: Table {
     }
 
     func create(db: SQLiteDBConnection, version: Int) -> Bool {
-        let err = db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(rows))")
-        return err == nil
+        if let err = db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(rows))") {
+            println("Error creating \(name) - \(err)")
+            return false
+        }
+        return true
     }
 
     func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
@@ -57,7 +60,7 @@ class GenericTable<T>: Table {
 
     func drop(db: SQLiteDBConnection) -> Bool {
         let sqlStr = "DROP TABLE IF EXISTS ?"
-        let args: [AnyObject] = [name]
+        let args: [AnyObject?] = [name]
         let err = db.executeChange(sqlStr, withArgs: args)
         return err == nil
     }
@@ -71,6 +74,7 @@ class GenericTable<T>: Table {
                     return -1
                 }
 
+                debug("Insert \(query) \(args) = \(db.lastInsertedRowID)")
                 return db.lastInsertedRowID
             }
         }

--- a/Storage/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/Storage/SQL/SQLiteHistory.swift
@@ -10,11 +10,12 @@ import Foundation
 public class SQLiteHistory : History {
     let files: FileAccessor
     let db: BrowserDB
-    let table = JoinedHistoryVisitsTable()
+    let table: JoinedHistoryVisitsTable
 
     required public init(files: FileAccessor) {
         self.files = files
         self.db = BrowserDB(files: files)!
+        self.table = JoinedHistoryVisitsTable(files: files)
         db.createOrUpdate(table)
     }
 

--- a/Storage/Storage/SQL/VisitsTable.swift
+++ b/Storage/Storage/SQL/VisitsTable.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-let TableNameVisits = "visits"
+private let TableNameVisits = "visits"
 
 // NOTE: If you add a new Table, make sure you update the version number in BrowserDB.swift!
 // This is our default visits store.

--- a/Storage/Storage/SQLFavicons.swift
+++ b/Storage/Storage/SQLFavicons.swift
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+* The sqlite-backed implementation of the favicons protocol.
+*/
+public class SQLiteFavicons : Favicons {
+    let files: FileAccessor
+    let db: BrowserDB
+    let table: JoinedFaviconsHistoryTable<(Site, Favicon)>
+
+    required public init(files: FileAccessor) {
+        self.files = files
+        self.db = BrowserDB(files: files)!
+        self.table = JoinedFaviconsHistoryTable<(Site, Favicon)>(files: files)
+        db.createOrUpdate(table)
+    }
+
+    public func clear(options: QueryOptions?, complete: (success: Bool) -> Void) {
+        var err: NSError? = nil
+        let res = db.delete(&err) { connection, err in
+            return self.table.delete(connection, item: nil, err: &err)
+        }
+
+        files.remove("favicons", basePath: nil)
+
+        dispatch_async(dispatch_get_main_queue()) {
+            complete(success: err == nil)
+        }
+    }
+
+    public func get(options: QueryOptions?, complete: (data: Cursor) -> Void) {
+        var err: NSError? = nil
+        let res = db.query(&err) { connection, err in
+            return self.table.query(connection, options: options)
+        }
+
+        dispatch_async(dispatch_get_main_queue()) {
+            complete(data: res)
+        }
+    }
+
+    public func add(icon: Favicon, site: Site, complete: (success: Bool) -> Void) {
+        var err: NSError? = nil
+        let res = db.insert(&err) { connection, err in
+            return self.table.insert(connection, item: (icon: icon, site: site), err: &err)
+        }
+
+        dispatch_async(dispatch_get_main_queue()) {
+            complete(success: err == nil)
+        }
+    }
+
+    private let debug_enabled = false
+    private func debug(msg: String) {
+        if debug_enabled {
+            println("FaviconsSqlite: " + msg)
+        }
+    }
+}

--- a/Storage/Storage/Site.swift
+++ b/Storage/Storage/Site.swift
@@ -4,12 +4,81 @@
 
 import UIKit
 
-public class Site {
+protocol Identifiable {
+    var id: Int? { get set }
+}
+
+public enum IconType: Int {
+    case Icon = 0
+    case AppleIcon = 1
+    case AppleIconPrecomposed = 2
+    case Guess = 3
+}
+
+public class Favicon : Identifiable {
+    var id: Int? = nil
+    var img: UIImage? = nil
+    var filename: String {
+        if let url = NSURL(string: self.url) {
+            if let ext = url.pathExtension {
+                return "\(url.hash).\(ext)"
+            }
+        }
+        return "\(url.hash)"
+    }
+
+    public let url: String
+    public let date: NSDate
+    public let width: Int?
+    public let height: Int?
+    public let type: IconType
+
+    public func getImage(files: FileAccessor) -> UIImage? {
+        if img == nil {
+            // If there's a file for this url, try to load it
+            if let dir = files.getDir("favicons", basePath: nil) {
+                if files.exists(filename, basePath: dir) {
+                    if let file = files.get(filename, basePath: dir) {
+                        img = UIImage(contentsOfFile: file)
+                    } else {
+                        println("Can't get file \(filename)")
+                    }
+                } else if let url = NSURL(string: self.url) {
+                    // Otherwise, we'll pull from the net
+                    if let data = NSData(contentsOfURL: url) {
+                        if let path = files.get(self.filename, basePath: dir) {
+                            data.writeToFile(path, atomically: true)
+                        }
+                        img = UIImage(data: data)
+                    } else {
+                        println("Can't get data \(url)")
+                    }
+                } else {
+                    println("Invalid url \(self.url)")
+                }
+            } else {
+                println("couldn't get favicons dir")
+            }
+        }
+
+        return img
+    }
+
+    public init(url: String, date: NSDate = NSDate(), type: IconType) {
+        self.url = url
+        self.date = date
+        self.type = type
+    }
+}
+
+public class Site : Identifiable {
     var id: Int? = nil
     var guid: String? = nil
 
     public let url: String
     public let title: String
+     // Sites may have multiple favicons. We'll return the largest.
+    public var icon: Favicon?
 
     public init(url: String, title: String) {
         self.url = url

--- a/Storage/StorageTests/MockFiles.swift
+++ b/Storage/StorageTests/MockFiles.swift
@@ -2,16 +2,23 @@ import Foundation
 import XCTest
 
 class MockFiles : FileAccessor {
-    func getDir(name: String) -> String? {
-        let dir = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
-        let path = dir?.stringByAppendingPathComponent(name)
-        NSFileManager.defaultManager().createDirectoryAtPath(path!, withIntermediateDirectories: false, attributes: nil, error: nil)
+    func getDir(name: String?, basePath: String? = nil) -> String? {
+        var path = basePath
+        if path == nil {
+            path = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
+            path?.stringByAppendingPathExtension("testing")
+        }
+
+        if let name = name {
+            path = path?.stringByAppendingPathExtension(name)
+        }
+
         return path
     }
 
-    func move(src: String, dest: String) -> Bool {
-        if let f = get(src) {
-            if let f2 = get(dest) {
+    func move(src: String, srcBasePath: String? = nil, dest: String, destBasePath: String? = nil) -> Bool {
+        if let f = get(src, basePath: srcBasePath) {
+            if let f2 = get(dest, basePath: destBasePath) {
                 return NSFileManager.defaultManager().moveItemAtPath(f, toPath: f2, error: nil)
             }
         }
@@ -19,19 +26,19 @@ class MockFiles : FileAccessor {
         return false
     }
 
-    func get(filename: String) -> String? {
-        return getDir("testing")?.stringByAppendingPathComponent(filename)
+    func get(path: String, basePath: String? = nil) -> String? {
+        return getDir(nil, basePath: basePath)?.stringByAppendingPathComponent(path)
     }
 
-    func remove(filename: String) {
+    func remove(filename: String, basePath: String? = nil) {
         let fileManager = NSFileManager.defaultManager()
-        if var file = get(filename) {
+        if var file = get(filename, basePath: nil) {
             fileManager.removeItemAtPath(file, error: nil)
         }
     }
 
-    func exists(filename: String) -> Bool {
-        if var file = get(filename) {
+    func exists(filename: String, basePath: String? = nil) -> Bool {
+        if var file = get(filename, basePath: nil) {
             return NSFileManager.defaultManager().fileExistsAtPath(file)
         }
         return false

--- a/Storage/StorageTests/TestHistoryTable.swift
+++ b/Storage/StorageTests/TestHistoryTable.swift
@@ -73,7 +73,7 @@ class TestHistoryTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testHistoryTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db")!)
+        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
         let h = HistoryTable<Site>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -99,6 +99,6 @@ class TestHistoryTable : XCTestCase {
         self.clear(h)
         self.checkSites(h, options: nil, urls: [String: String]())
 
-        files.remove("test.db")
+        files.remove("test.db", basePath: nil)
     }
 }

--- a/Storage/StorageTests/TestJoinedHistoryVisits.swift
+++ b/Storage/StorageTests/TestJoinedHistoryVisits.swift
@@ -94,8 +94,8 @@ class TestJoinedHistoryVisits : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testJoinedHistoryVisitsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db")!)
-        let h = JoinedHistoryVisitsTable()
+        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        let h = JoinedHistoryVisitsTable(files: files)
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
             h.create(db, version: 2)
@@ -120,7 +120,6 @@ class TestJoinedHistoryVisits : XCTestCase {
         self.addSite(h, url: "url1", title: "title1 alt")
         self.checkSites(h, options: nil, urls: ["url1": "title1 alt", "url2": "title2"])
 
-        
         // Adding an visit with an existing site should update the title
         let site2 = Site(url: site.url, title: "title1 second alt")
         let visit = self.addVisit(h, site: site2)
@@ -143,6 +142,6 @@ class TestJoinedHistoryVisits : XCTestCase {
         self.clear(h)
         self.checkSites(h, options: nil, urls: [String: String]())
         
-        files.remove("test.db")
+        files.remove("test.db", basePath: nil)
     }
 }

--- a/Storage/StorageTests/TestTableTable.swift
+++ b/Storage/StorageTests/TestTableTable.swift
@@ -5,7 +5,7 @@
 import UIKit
 import XCTest
 
-class TestTableTable: XCTestCase {
+class TestSchemaTable: XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testTable() {
         let files = MockFiles()
@@ -17,7 +17,7 @@ class TestTableTable: XCTestCase {
 
         // Now make sure the item is in the table-table
         var err: NSError? = nil
-        let table = TableTable<TableInfo>()
+        let table = SchemaTable<TableInfo>()
         var cursor = db.query(&err, callback: { (connection, err) -> Cursor in
             return table.query(connection, options: QueryOptions(filter: testTable.name))
         })

--- a/Storage/StorageTests/TestVisitsTable.swift
+++ b/Storage/StorageTests/TestVisitsTable.swift
@@ -58,7 +58,7 @@ class TestVisitsTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testVisitsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db")!)
+        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
         let h = VisitsTable<Visit>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -89,6 +89,6 @@ class TestVisitsTable : XCTestCase {
         self.clear(h, s: true)
         self.checkVisits(h, options: nil, vs: [])
 
-        files.remove("test.db")
+        files.remove("test.db", basePath: nil)
     }
 }


### PR DESCRIPTION
This gets favicons using a JS shim. They're then stored locally (on disk), and the url -> site mapping is stored in a local database. The disk cache is just stored as a hash of the filename.fileExtension. That means if we can lookup the url in the database, we can load the local file. I also added a join on the history table for the history API to do that lookup simultaneously.

The schema for the favicons table is
url -> String
date -> Double // date this was saved. I need to update this as you browse I guess
width -> Int
height -> Int
type -> Int // What type of tag this came from. I'm storing things like apple-touch-icon right now, and wanted to make sure we could disambiguate those

That has speed tradeoffs I'm sure. This doesn't handle loading them asynchronously into the table.