### PR TITLE
Show history in the search view

### DIFF
--- a/Client/Frontend/TabBar/SearchViewController.swift
+++ b/Client/Frontend/TabBar/SearchViewController.swift
@@ -8,6 +8,12 @@ import UIKit
 private let ReuseIdentifier = "cell"
 private let SuggestionsLimitCount = 3
 
+private enum SearchListSection: Int{
+    case SuggestedSites = 0
+    case Search
+    case BookmarksAndHistory
+}
+
 // A delegate to support clicking on rows in the view controller
 // This needs to be accessible to objc for UIViewControllers to call it
 @objc
@@ -120,17 +126,19 @@ extension SearchViewController: UITableViewDataSource {
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier(ReuseIdentifier, forIndexPath: indexPath) as SearchTableViewCell
 
-        if indexPath.row < searchSuggestions.count {
+        if indexPath.section == SearchListSection.SuggestedSites.rawValue {
             cell.textLabel?.text = searchSuggestions[indexPath.row]
             cell.imageView?.image = nil
             cell.isAccessibilityElement = false
             cell.accessibilityLabel = nil
-        } else {
-            let searchEngine = sortedEngines[indexPath.row - searchSuggestions.count]
+        } else if indexPath.section == SearchListSection.Search.rawValue {
+            let searchEngine = sortedEngines[indexPath.row]
             cell.textLabel?.text = searchQuery
             cell.imageView?.image = searchEngine.image
             cell.isAccessibilityElement = true
             cell.accessibilityLabel = NSString(format: NSLocalizedString("%@ search for %@", comment: "E.g. \"Google search for Mars\". Please keep the first \"%@\" (which contains the search engine name) as close to the beginning of the translated phrase as possible (it is best to have it as the very first word). This is because the phrase is an accessibility label and VoiceOver users need to hear the search engine name first as that is the key information in the whole phrase (they know the search term because they typed it and from previous rows of the table)."), searchEngine.shortName, searchQuery)
+        } else {
+            //Bookmarks&History
         }
 
         // Make the row separators span the width of the entire table.
@@ -140,7 +148,43 @@ extension SearchViewController: UITableViewDataSource {
     }
 
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return searchSuggestions.count + sortedEngines.count
+        if let currentSection = SearchListSection(rawValue: section) {
+            switch(currentSection) {
+            case .SuggestedSites:
+                return searchSuggestions.count
+            case .Search:
+                return sortedEngines.count
+            case .BookmarksAndHistory:
+                return 0
+            }
+        }
+        return 0
+    }
+    
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if let currentSection = SearchListSection(rawValue: section) {
+            switch(currentSection) {
+            case .SuggestedSites:
+                return "Suggested Sites"
+            case .Search:
+                return "Search"
+            case .BookmarksAndHistory:
+                return "Bookmarks&History"
+            }
+        }
+        return ""
+    }
+    
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        var sectionNum = 0
+        if searchSuggestions.count > 0 {
+            sectionNum++
+        }
+        if sortedEngines.count > 0{
+            sectionNum++
+        }
+        //TODO: maybe we need + bookmark&history.count
+        return sectionNum
     }
 }
 

--- a/Client/Frontend/TabBar/TabBarViewController.swift
+++ b/Client/Frontend/TabBar/TabBarViewController.swift
@@ -101,6 +101,7 @@ class TabBarViewController: UIViewController, UITextFieldDelegate, UrlViewContro
         searchController = SearchViewController()
         searchController!.searchEngines = profile.searchEngines
         searchController!.delegate = self
+        searchController!.profile = profile
 
         view.addSubview(searchController!.view)
         searchController!.view.snp_makeConstraints { make in


### PR DESCRIPTION
I'm going to obsolete https://github.com/mozilla/firefox-ios/pull/104 with this. It builds on https://github.com/mozilla/firefox-ios/pull/127. We can let the platform do this for us.

It precludes us from intermixing types, but I think I'm fine with that.