### PR TITLE
Fixes 1128774 - Reader Mode fails hard on initial Gmail loading

### DIFF
--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -10,7 +10,7 @@ var _firefox_ReaderMode = {
     readabilityResult: null,
 
     checkReadability: function() {
-        if ((document.location.protocol === "http:" || document.location.protocol === "https:") && document.location.pathname !== "/") {
+        if ((document.location.protocol === "http:" || document.location.protocol === "https:") && document.location.pathname !== "/" && document.body.childElementCount != 0) {
             // Short circuit in case we already ran Readability. This mostly happens when going
             // back/forward: the page will be cached and the result will still be there.
             if (_firefox_ReaderMode.readabilityResult && _firefox_ReaderMode.readabilityResult.content) {


### PR DESCRIPTION
This patch adds an extra check to `checkReadability` to find out of the body of the document actually has child elements. If it has not then we can already say that the page is most likely an empty page used to redirect to another page. The redirection is certainly what GMail is doing.

Unfortunately I don't yet fully understand the underlying issue. My gut feeling says it is  a race condition in the WKWebView code where it executes a User Script while the page is suddenly being reloaded. I think it could be worthwhile to write an isolated test case so that we can submit this to Apple if this guess is correct.