### PR TITLE
Bug 1128774 - Serialize and parse document instead of cloning the document node

### DIFF
--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -23,7 +23,12 @@ var _firefox_ReaderMode = {
                     scheme: document.location.protocol.substr(0, document.location.protocol.indexOf(":")),
                     pathBase: document.location.protocol + "//" + document.location.host + location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1)
                 }
-                var readability = new Readability(uri, document.cloneNode(true));
+
+                // document.cloneNode() can cause the webview to break (bug 1128774).
+                // Serialize and then parse the document instead.
+                var docStr = new XMLSerializer().serializeToString(document);
+                var doc = new DOMParser().parseFromString(docStr, "text/html");
+                var readability = new Readability(uri, doc);
                 _firefox_ReaderMode.readabilityResult = readability.parse();
                 webkit.messageHandlers.readerModeMessageHandler.postMessage(_firefox_ReaderMode.readabilityResult !== null ? "Available" : "Unavailable");
             }


### PR DESCRIPTION
New theory: something is busted with document.cloneNode(). After spending 10+ minutes trying to reproduce with this PR, I haven't hit the bug. Maybe their cloneNode implementation leaks references from the original nodes to the cloned ones, causing things to break when we manipulate them?