### PR TITLE
Bug 1128363 - Remove table upgrade code until it works

### DIFF
--- a/Storage/Storage/SQL/GenericTable.swift
+++ b/Storage/Storage/SQL/GenericTable.swift
@@ -14,6 +14,17 @@ class GenericTable<T>: Table {
         return nil
     }
 
+    func exists(db: SQLiteDBConnection) -> Bool {
+        let sqlStr = "SELECT name FROM sqlite_master WHERE type = 'table' AND name=?"
+        let res = db.executeQuery(sqlStr, factory: StringFactory, withArgs: [name])
+        return res.count > 0
+    }
+
+    func drop(db: SQLiteDBConnection) -> Bool {
+        let err = db.executeChange("DROP TABLE IF EXISTS ?", withArgs: [name])
+        return err != nil
+    }
+
     // These methods take an inout object to avoid some runtime crashes that seem to be due
     // to using generics. Yay Swift!
     func getInsertAndArgs(inout item: Type) -> (String, [AnyObject?])? {

--- a/Storage/Storage/SQL/JoinedHistoryVisitsTable.swift
+++ b/Storage/Storage/SQL/JoinedHistoryVisitsTable.swift
@@ -30,6 +30,20 @@ class JoinedHistoryVisitsTable: Table {
         return (cursor[0] as Site).id
     }
 
+    func exists(db: SQLiteDBConnection) -> Bool {
+        var found = false
+        let sqlStr = "SELECT name FROM sqlite_master WHERE type = 'table' AND name=? OR name=?"
+        let res = db.executeQuery(sqlStr, factory: StringFactory, withArgs: [visits.name, history.name])
+        // If either of the tables is missing here, something has gone terribly wrong
+        return res.count > 1
+    }
+
+    func drop(db: SQLiteDBConnection) -> Bool {
+        let err = db.executeChange("DROP TABLE IF EXISTS \(visits.name)")
+        let err2 = db.executeChange("DROP TABLE IF EXISTS \(history.name)")
+        return err != nil && err2 != nil
+    }
+
     func create(db: SQLiteDBConnection, version: Int) -> Bool {
         return history.create(db, version: version) && visits.create(db, version: version)
     }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -118,7 +118,10 @@ public class SQLiteDBConnection {
         }
 
         set {
-            executeChange("PRAGMA user_version = \(newValue)")
+            let err = executeChange("PRAGMA user_version = \(newValue)")
+            if err != nil {
+                println("Err updating version \(newValue)  --  \(err!)")
+            }
         }
     }
 
@@ -278,18 +281,12 @@ public class SQLiteDBConnection {
 
 // Helper for queries that return a single integer result
 func IntFactory(row: SDRow) -> Int {
-    for val in row {
-        return val as Int
-    }
-    return 0
+    return row[0] as Int
 }
 
 // Helper for queries that return a single String result
 func StringFactory(row: SDRow) -> String {
-    for val in row {
-        return val as String
-    }
-    return ""
+    return row[0] as String
 }
 
 // Wrapper around a statment for getting data from a row. This provides accessors for subscript indexing


### PR DESCRIPTION
This is a fallback while I wait for bug 1128363 to be reviewed. This basically gives up on upgrades (since we don't support any right now. If they're required, it drops the table and recreates it. If that fails it deletes (moves) the db file.

Since you can theoretically create tables in lots of places, this is error prone. The other patch is a better fix, but this should get people's history working again. It also includes some nice fixes I want anyway that I'm going to port to the other patch.