### PR TITLE
Bug 1130609 - Scroll urlbar (and toolbar) with the page

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -23,6 +23,10 @@ class Browser: NSObject, WKScriptMessageHandler {
         super.init()
     }
 
+    var loading: Bool {
+        return webView.loading
+    }
+
     var backList: [WKBackForwardListItem]? {
         return webView.backForwardList.backList as? [WKBackForwardListItem]
     }

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -65,6 +65,9 @@ class BrowserToolbar: UIView {
         bookmarkButton = UIButton()
 
         super.init(frame: frame)
+
+        longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBack:")
+        longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressForward:")
     }
 
     required init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Here's a first draft at this. It will likely need to be changed. I wanted the views themselves to handle the scrolling so that it would be easy to (someday) do things like have the urlbar just grow smaller when its scrolled, but there's some strangeness there.

For instance, the background behind the views is actually the container that holds them. It needs to scroll as well (but it doesn't know anything about whats inside it). To fix that I let the views know about their background, so they could scroll it.

It would also be nice if the views knew about each other so that you didn't wind up in a state where the urlbar was hidden, but the toolbar shown. I didn't see a clear way to do that here. I'd also like to add some "slop" so that dragging down just a little (or very slowly?) doesn't necessarily show the urlbar. I'm leaving that for a follow up.