### PR TITLE
Bug 1131280 - Add placeholder text for about:home

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -132,6 +132,9 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
                 locationLabel.text = t!.substringFromIndex(advance(t!.startIndex, 7))
             } else if t?.hasPrefix("https://") ?? false {
                 locationLabel.text = t!.substringFromIndex(advance(t!.startIndex, 8))
+            } else if t == "about:home" {
+                let placeholderText = NSLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home")
+                locationLabel.attributedText = NSAttributedString(string: placeholderText, attributes: [NSForegroundColorAttributeName: UIColor.grayColor()])
             } else {
                 locationLabel.text = t
             }


### PR DESCRIPTION
WKWebView still allows us to go to (and create back/forward entries for) pages it can't handle -- should have remembered that since we already have about:reader. So this can simply be about creating the placeholder text when the user goes there.