### PR TITLE
Fixes 1132456 - Update notification for Aurora Channel

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import Alamofire
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -25,6 +26,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window.rootViewController = controller
         self.window.makeKeyAndVisible()
 
+        checkForAuroraUpdate()
+
         return true
     }
 
@@ -38,5 +41,61 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // TODO: In the future let other modules register specific resources here. Unfortunately you cannot add
         // more handlers after start() has been called, so we need to organize it all here at app startup time.
         server.start()
+    }
+}
+
+/// Everything below is for the Aurora version check. There is no conditional compilation in Swift so this code is only
+/// executed when our bundle identifier is FennecAurora.
+
+private let AuroraBundleIdentifier = "org.mozilla.ios.FennecAurora"
+private let AuroraPropertyListURL = "https://pvtbuilds.mozilla.org/ios/FennecAurora.plist"
+private let AuroraDownloadPageURL = "https://pvtbuilds.mozilla.org/ios/index.html"
+
+extension AppDelegate: UIAlertViewDelegate {
+    private func checkForAuroraUpdate() {
+        if isAuroraChannel() {
+            if let localVersion = localVersion() {
+                fetchLatestAuroraVersion() { version in
+                    if let remoteVersion = version {
+                        if localVersion.compare(remoteVersion, options: NSStringCompareOptions.NumericSearch) == NSComparisonResult.OrderedAscending {
+                            let alert = UIAlertView(title: "New version available", message: "There is a new version available of Firefox Aurora. Tap OK to go to the download page.", delegate: self, cancelButtonTitle: "Not Now", otherButtonTitles: "OK")
+                            alert.show()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func isAuroraChannel() -> Bool {
+        return NSBundle.mainBundle().bundleIdentifier == AuroraBundleIdentifier
+    }
+
+    private func localVersion() -> NSString? {
+        return NSBundle.mainBundle().objectForInfoDictionaryKey(kCFBundleVersionKey) as? String
+    }
+
+    private func fetchLatestAuroraVersion(completionHandler: NSString? -> Void) {
+        Alamofire.request(.GET, AuroraPropertyListURL).responsePropertyList({ (_, _, object, _) -> Void in
+            if let plist = object as? NSDictionary {
+                if let items = plist["items"] as? NSArray {
+                    if let item = items[0] as? NSDictionary {
+                        if let metadata = item["metadata"] as? NSDictionary {
+                            if let remoteVersion = metadata["bundle-version"] as? String {
+                                completionHandler(remoteVersion)
+                                return
+                            }
+                        }
+                    }
+                }
+            }
+            completionHandler(nil)
+        })
+    }
+
+    func alertView(alertView: UIAlertView, clickedButtonAtIndex buttonIndex: Int) {
+        if buttonIndex == 1 {
+            UIApplication.sharedApplication().openURL(NSURL(string: AuroraDownloadPageURL)!)
+        }
     }
 }


### PR DESCRIPTION
This patch fetches the last build number available from our distribution server and compares it with the local build number. If there is a newer version available then it shows a dialog that opens Safari to the download page when confirmed.