### PR TITLE
Bug 1129514 - Context menu doesn't appear on some pages

### DIFF
--- a/Client/Frontend/Browser/LongPressGestureRecognizer.swift
+++ b/Client/Frontend/Browser/LongPressGestureRecognizer.swift
@@ -18,6 +18,8 @@ protocol LongPressGestureDelegate: class {
 class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecognizerDelegate {
     private weak var webView: WKWebView!
     weak var longPressGestureDelegate: LongPressGestureDelegate?
+    private let URLCharacterSet =
+        NSCharacterSet(charactersInString: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%")
 
     override init(target: AnyObject, action: Selector) {
         super.init(target: target, action: action)
@@ -71,14 +73,16 @@ class LongPressGestureRecognizer: UILongPressGestureRecognizer, UIGestureRecogni
         var elements = [LongPressElementType: NSURL]()
         if let hrefElement = elementsDict["hrefElement"] as? [String: String] {
             if let hrefStr: String = hrefElement["hrefLink"] {
-                if let linkURL = NSURL(string: hrefStr) {
+                let encodedString = hrefStr.stringByAddingPercentEncodingWithAllowedCharacters(URLCharacterSet)
+                if let linkURL = NSURL(string: encodedString!) {
                     elements[LongPressElementType.Link] = linkURL
                 }
             }
         }
         if let imageElement = elementsDict["imageElement"] as? [String: String] {
             if let imageSrcStr: String = imageElement["imageSrc"] {
-                if let imageURL = NSURL(string: imageSrcStr) {
+                let encodedString = imageSrcStr.stringByAddingPercentEncodingWithAllowedCharacters(URLCharacterSet)
+                if let imageURL = NSURL(string: encodedString!) {
                     elements[LongPressElementType.Image] = imageURL
                 }
             }


### PR DESCRIPTION
The `NSURL` initializer  returns `nil` when given a URL string that is missing percent-encodings, which is why the context menu wasn't appearing after long-pressing certain links (see the [STR](https://bugzilla.mozilla.org/show_bug.cgi?id=1129514#c0)).  `NSURLComponents` will automatically add percent-encodings, so I added it as a fail over when creating an `NSURL` fails.  To avoid having valid uses of reserved characters escaped e.g., `#` in the fragment and `?` in the query string, I had to break the URL into its individual components instead of passing the entire URL to the `NSURLComponents` initializer.