### PR TITLE
Bug 1134480 - Show sections in history list

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -53,12 +53,8 @@ class BookmarksPanel: SiteTableViewController {
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let cell = super.tableView(tableView, viewForHeaderInSection: section)
-
-        if let label = cell?.viewWithTag(1) as? UILabel {
-            label.text = "Recent Bookmarks"
-        }
-
+        let cell = super.tableView(tableView, viewForHeaderInSection: section) as SiteTableViewHeader
+        cell.textLabel.text = "Recent Bookmarks"
         return cell
     }
 

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -7,11 +7,15 @@ import UIKit
 import Storage
 
 class HistoryPanel: SiteTableViewController {
+    private let NumSections = 4
+    private var sectionStart = [Int: Int]()
+
     override func reloadData() {
         let opts = QueryOptions()
         opts.sort = .LastVisit
         profile.history.get(opts, complete: { (data: Cursor) -> Void in
             self.refreshControl?.endRefreshing()
+            self.sectionStart = [Int: Int]()
             self.data = data
             self.tableView.reloadData()
         })
@@ -19,7 +23,8 @@ class HistoryPanel: SiteTableViewController {
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
-        if let site = data[indexPath.row] as? Site {
+        let offset = sectionStart[indexPath.section]!
+        if let site = data[indexPath.row + offset] as? Site {
             cell.textLabel?.text = site.title
             cell.detailTextLabel?.text = site.url
             if let img = site.icon? {
@@ -34,7 +39,8 @@ class HistoryPanel: SiteTableViewController {
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        if let site = data[indexPath.row] as? Site {
+        let offset = sectionStart[indexPath.section]!
+        if let site = data[indexPath.row + offset] as? Site {
             if let url = NSURL(string: site.url) {
                 homePanelDelegate?.homePanel(didSubmitURL: url)
                 return
@@ -43,7 +49,113 @@ class HistoryPanel: SiteTableViewController {
         println("Could not click on history row")
     }
 
+    // Functions that deal with showing header rows
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return NumSections
+    }
+
+    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let cell = super.tableView(tableView, viewForHeaderInSection: section) as UITableViewHeaderFooterView!
+        switch section {
+        case 0: cell.textLabel.text = "Today"
+        case 1: cell.textLabel.text = "Yesterday"
+        case 2: cell.textLabel.text = "Last week"
+        case 3: cell.textLabel.text = "Last month"
+        default:
+            assertionFailure("Invalid history section \(section)")
+        }
+
+        return cell
+    }
+
+    lazy private var today: NSDate = {
+        var today = NSDate()
+        var calendar = NSCalendar(calendarIdentifier: NSGregorianCalendar)!
+        let nowComponents = calendar.components(NSCalendarUnit.YearCalendarUnit | NSCalendarUnit.MonthCalendarUnit | NSCalendarUnit.DayCalendarUnit, fromDate:today)
+        return calendar.dateFromComponents(nowComponents)!
+    }()
+
+    lazy private var yesterday: NSDate = {
+        var today = NSDate()
+        var calendar = NSCalendar(calendarIdentifier: NSGregorianCalendar)!
+        let nowComponents = calendar.components(NSCalendarUnit.YearCalendarUnit | NSCalendarUnit.MonthCalendarUnit | NSCalendarUnit.DayCalendarUnit, fromDate:today)
+        nowComponents.day--
+        return calendar.dateFromComponents(nowComponents)!
+    }()
+
+    lazy private var thisweek: NSDate = {
+        var today = NSDate()
+        var calendar = NSCalendar(calendarIdentifier: NSGregorianCalendar)!
+        let nowComponents = calendar.components(NSCalendarUnit.YearCalendarUnit | NSCalendarUnit.MonthCalendarUnit | NSCalendarUnit.DayCalendarUnit, fromDate:today)
+        nowComponents.day -= 7
+        return calendar.dateFromComponents(nowComponents)!
+    }()
+
+    private func isInSection(date: NSDate, section: Int) -> Bool {
+        let now = NSDate()
+        switch section {
+        case 0:
+            return date.timeIntervalSince1970 > today.timeIntervalSince1970
+        case 1:
+            return date.timeIntervalSince1970 > yesterday.timeIntervalSince1970
+        case 2:
+            return date.timeIntervalSince1970 > thisweek.timeIntervalSince1970
+        default:
+            return true
+        }
+    }
+
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
+        if let current = sectionStart[section] {
+            if let next = sectionStart[section+1] {
+                if current == next {
+                    // If this points to the same element as the next one, its empty. Don't show it.
+                    return 0
+                }
+            }
+        } else {
+            // This may not be filled in yet (for instance, if the number of rows in data is zero). If it is,
+            // just return zero.
+            return 0
+        }
+
+        // Return the default height for header rows
+        return super.tableView(tableView, heightForHeaderInSection: section)
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if let size = sectionStart[section] {
+            if let nextSize = sectionStart[section+1] {
+                return nextSize - size
+            }
+        }
+
+        var searchingSection = 0
+        sectionStart[searchingSection] = 0
+
+        // Loop over all the data. Record the start of each "section" of our list.
+        for i in 0..<data.count {
+            if var site = data[i] as? Site {
+                if !isInSection(site.latestVisit!.date, section: searchingSection) {
+                    searchingSection++
+                    sectionStart[searchingSection] = i
+                }
+
+                if searchingSection == NumSections {
+                    break
+                }
+            }
+        }
+
+        // Now fill in any sections that weren't found with data.count.
+        // Note, we actually fill in one past the end of the list to make finding the length
+        // of a section easier.
+        searchingSection++
+        for i in searchingSection...NumSections {
+            sectionStart[i] = data.count
+        }
+
+        // This function wants the size of a section, so return the distance between two adjacent ones
+        return sectionStart[section+1]! - sectionStart[section]!
     }
 }

--- a/Client/Frontend/Home/SiteTableViewController.swift
+++ b/Client/Frontend/Home/SiteTableViewController.swift
@@ -8,6 +8,50 @@ import Storage
 /** Provides some base shared functionality for home view panels for shared
  * row and header types.
  */
+public class SiteTableViewHeader : UITableViewHeaderFooterView {
+    // I can't get drawRect to play nicely with the glass background. As a fallback
+    // we just use view's for the top and bottom borders.
+    let topBorder = UIView()
+    let bottomBorder = UIView()
+    override init() {
+        super.init()
+        didLoad()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        didLoad()
+    }
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        didLoad()
+    }
+
+    private func didLoad() {
+        addSubview(topBorder)
+        addSubview(bottomBorder)
+        backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .Light))
+    }
+
+    required public init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func layoutSubviews() {
+        topBorder.frame = CGRect(x: 0, y: 0, width: frame.width, height: 1)
+        bottomBorder.frame = CGRect(x: 0, y: frame.height - 1, width: frame.width, height: 1)
+        topBorder.backgroundColor = UIColor.lightGrayColor()
+        bottomBorder.backgroundColor = UIColor.lightGrayColor()
+        super.layoutSubviews()
+
+        textLabel.font = UIFont(name: "FiraSans-SemiBold", size: 13)
+        textLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkTextColor()
+        textLabel.textAlignment = .Center
+        contentView.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.05)
+    }
+}
+
 class SiteTableViewController: UITableViewController, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate? = nil
     private let CellIdentifier = "CellIdentifier"
@@ -23,8 +67,7 @@ class SiteTableViewController: UITableViewController, HomePanel {
         super.viewDidLoad()
 
         tableView.registerClass(TwoLineCell.self, forCellReuseIdentifier: CellIdentifier)
-        let nib = UINib(nibName: "TabsViewControllerHeader", bundle: nil)
-        tableView.registerNib(nib, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
+        tableView.registerClass(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
 
         tableView.keyboardDismissMode = UIScrollViewKeyboardDismissMode.OnDrag
 
@@ -56,6 +99,6 @@ class SiteTableViewController: UITableViewController, HomePanel {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 44
+        return 25
     }
 }

--- a/Storage/Storage/SQL/JoinedHistoryVisitsTable.swift
+++ b/Storage/Storage/SQL/JoinedHistoryVisitsTable.swift
@@ -123,6 +123,8 @@ class JoinedHistoryVisitsTable: Table {
         let visit = Visit(site: site, date: d, type: type!)
         visit.id = result["visitId"] as? Int
 
+        site.latestVisit = visit
+
         if let iconurl = result["iconUrl"] as? String {
             let icon = Favicon(url: iconurl, date: NSDate(timeIntervalSince1970: result["iconDate"] as Double), type: IconType(rawValue: result["iconType"] as Int)!)
             icon.id = result["faviconId"] as? Int

--- a/Storage/Storage/Site.swift
+++ b/Storage/Storage/Site.swift
@@ -40,6 +40,7 @@ public class Site : Identifiable {
     public let title: String
      // Sites may have multiple favicons. We'll return the largest.
     public var icon: Favicon?
+    public var latestVisit: Visit?
 
     public init(url: String, title: String) {
         self.url = url


### PR DESCRIPTION
This styles the dividers we have to match the mockups better (still needs tweaking) and adds them in history. The glass effect shows some of its "optimizations" here (i.e. you can see it do some strange things). Lets see what UX thinks.