### PR TITLE
Bug 1135180 - Bookmark icons

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -198,7 +198,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func addBookmark(url: String, title: String?) {
-        let shareItem = ShareItem(url: url, title: title)
+        let shareItem = ShareItem(url: url, title: title, favicon: nil)
         profile.bookmarks.shareItem(shareItem)
 
         // Dispatch to the main thread to update the UI

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -41,8 +41,10 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
         if let source = source {
             let bookmark = source.current[indexPath.row]
-            cell.imageView?.image = bookmark.icon
-            cell.textLabel?.text = bookmark.title
+            if let favicon = bookmark?.favicon {
+                cell.imageView?.sd_setImageWithURL(NSURL(string: favicon.url)!, placeholderImage: profile.favicons.defaultIcon)
+            }
+            cell.textLabel?.text = bookmark?.title
         }
 
         return cell

--- a/ClientTests/TestBookmarks.swift
+++ b/ClientTests/TestBookmarks.swift
@@ -10,7 +10,7 @@ class TestBookmarks : ProfileTest {
     func testBookmarks() {
         withTestProfile { profile -> Void in
             for i in 0...10 {
-                let bookmark = ShareItem(url: "http://www.example.com/\(i)", title: "Example \(i)")
+                let bookmark = ShareItem(url: "http://www.example.com/\(i)", title: "Example \(i)", favicon: nil)
                 profile.bookmarks.shareItem(bookmark)
             }
 

--- a/Storage/SQL/FaviconsTable.swift
+++ b/Storage/SQL/FaviconsTable.swift
@@ -10,7 +10,6 @@ private let TableNameFavicons = "favicons"
 
 // This is our default favicons store.
 class FaviconsTable<T>: GenericTable<Favicon> {
-    private var files: FileAccessor
     override var name: String { return TableNameFavicons }
     override var rows: String { return "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
                        "url TEXT NOT NULL UNIQUE, " +
@@ -18,10 +17,6 @@ class FaviconsTable<T>: GenericTable<Favicon> {
                        "height INTEGER, " +
                        "type INTEGER NOT NULL, " +
                        "date REAL NOT NULL" }
-
-    init(files: FileAccessor) {
-        self.files = files
-    }
 
     override func getInsertAndArgs(inout item: Favicon) -> (String, [AnyObject?])? {
         var args = [AnyObject?]()

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -6,6 +6,7 @@ import Foundation
 
 class GenericTable<T>: Table {
     typealias Type = T
+
     // Implementors need override these methods
     let debug_enabled = false
     var name: String { return "" }
@@ -33,7 +34,6 @@ class GenericTable<T>: Table {
         return nil
     }
 
-    // Here's the real implementation
     func debug(msg: String) {
         if debug_enabled {
             println("GenericTable: \(msg)")
@@ -59,9 +59,12 @@ class GenericTable<T>: Table {
     }
 
     func drop(db: SQLiteDBConnection) -> Bool {
-        let sqlStr = "DROP TABLE IF EXISTS ?"
-        let args: [AnyObject?] = [name]
+        let sqlStr = "DROP TABLE IF EXISTS \(name)"
+        let args =  [AnyObject?]()
         let err = db.executeChange(sqlStr, withArgs: args)
+        if err != nil {
+            println("Err dropping \(err)")
+        }
         return err == nil
     }
 

--- a/Storage/SQL/JoinedFaviconsHistoryTable.swift
+++ b/Storage/SQL/JoinedFaviconsHistoryTable.swift
@@ -13,13 +13,8 @@ private let FaviconVisits = "faviconSiteMapping"
 // 2.) Adding a visit here will ensure that a site exists for the visit
 // 3.) Updates currently only update site information.
 class JoinedFaviconsHistoryTable<T>: GenericTable<(site: Site?, icon: Favicon?)> {
-    private let favicons: FaviconsTable<Favicon>
-    private let history: HistoryTable<Site>
-
-    init(files: FileAccessor) {
-        self.favicons = FaviconsTable<Favicon>(files: files)
-        self.history = HistoryTable<Site>()
-    }
+    private let favicons = FaviconsTable<Favicon>()
+    private let history = HistoryTable<Site>()
 
     override var name: String { return FaviconVisits }
     override var rows: String { return "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
@@ -135,7 +130,9 @@ class JoinedFaviconsHistoryTable<T>: GenericTable<(site: Site?, icon: Favicon?)>
             args.append("%\(filter)%")
         }
 
-        println("\(sql) \(args)")
+        // For now we always look for the biggest one
+        sql += " ORDER BY \(favicons.name).width DESC"
+
         return db.executeQuery(sql, factory: factory, withArgs: args)
     }
 }

--- a/Storage/SQL/JoinedHistoryVisitsTable.swift
+++ b/Storage/SQL/JoinedHistoryVisitsTable.swift
@@ -19,13 +19,8 @@ class JoinedHistoryVisitsTable: Table {
 
     private let visits = VisitsTable<Visit>()
     private let history = HistoryTable<Site>()
-    private let favicons: FaviconsTable<Favicon>
-    private let faviconSites: JoinedFaviconsHistoryTable<(Site, Favicon)>
-
-    init(files: FileAccessor) {
-        favicons = FaviconsTable<Favicon>(files: files)
-        faviconSites = JoinedFaviconsHistoryTable<(Site, Favicon)>(files: files)
-    }
+    private let favicons = FaviconsTable<Favicon>()
+    private let faviconSites = JoinedFaviconsHistoryTable<(Site, Favicon)>()
 
     private func getIDFor(db: SQLiteDBConnection, site: Site) -> Int? {
         let opts = QueryOptions()
@@ -39,11 +34,17 @@ class JoinedHistoryVisitsTable: Table {
     }
 
     func create(db: SQLiteDBConnection, version: Int) -> Bool {
-        return history.create(db, version: version) && visits.create(db, version: version) && faviconSites.create(db, version: version)
+        return history.create(db, version: version) &&
+            visits.create(db, version: version) &&
+            favicons.create(db, version: version) &&
+            faviconSites.create(db, version: version)
     }
 
     func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
-        return history.updateTable(db, from: from, to: to) && visits.updateTable(db, from: from, to: to)
+        return history.updateTable(db, from: from, to: to) &&
+            visits.updateTable(db, from: from, to: to) &&
+            favicons.updateTable(db, from: from, to: to) &&
+            faviconSites.updateTable(db, from: from, to: to)
     }
 
     func exists(db: SQLiteDBConnection) -> Bool {

--- a/Storage/SQL/SQLFavicons.swift
+++ b/Storage/SQL/SQLFavicons.swift
@@ -11,7 +11,7 @@ import UIKit
 public class SQLiteFavicons : Favicons {
     let files: FileAccessor
     let db: BrowserDB
-    let table: JoinedFaviconsHistoryTable<(Site, Favicon)>
+    let table = JoinedFaviconsHistoryTable<(Site, Favicon)>()
 
     lazy public var defaultIcon: UIImage = {
         return UIImage(named: "defaultFavicon")!
@@ -20,7 +20,6 @@ public class SQLiteFavicons : Favicons {
     required public init(files: FileAccessor) {
         self.files = files
         self.db = BrowserDB(files: files)!
-        self.table = JoinedFaviconsHistoryTable<(Site, Favicon)>(files: files)
         db.createOrUpdate(table)
     }
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -10,12 +10,11 @@ import Foundation
 public class SQLiteHistory : History {
     let files: FileAccessor
     let db: BrowserDB
-    let table: JoinedHistoryVisitsTable
+    private let table = JoinedHistoryVisitsTable()
 
     required public init(files: FileAccessor) {
         self.files = files
         self.db = BrowserDB(files: files)!
-        self.table = JoinedHistoryVisitsTable(files: files)
         db.createOrUpdate(table)
     }
 

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -13,6 +13,7 @@ public enum IconType: Int {
     case AppleIcon = 1
     case AppleIconPrecomposed = 2
     case Guess = 3
+    case Local = 4
 }
 
 public class Favicon : Identifiable {

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -1,0 +1,727 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0B2770451A89276900CE7692 /* BookmarksSqlite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2770441A89276900CE7692 /* BookmarksSqlite.swift */; };
+		0B2770471A893C2C00CE7692 /* TestBookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2770461A893C2C00CE7692 /* TestBookmarks.swift */; };
+		0B2770481A893C4700CE7692 /* BookmarksSqlite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2770441A89276900CE7692 /* BookmarksSqlite.swift */; };
+		0B2770491A893C9500CE7692 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497801A7B094B004C8E17 /* Bookmarks.swift */; };
+		0B2770DD1A8AD83200CE7692 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2770DC1A8AD83200CE7692 /* Bytes.swift */; };
+		0B2770E91A8AD85000CE7692 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2770DC1A8AD83200CE7692 /* Bytes.swift */; };
+		0B30602F1A80338F0085B8BC /* Passwords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B30602E1A80338F0085B8BC /* Passwords.swift */; };
+		0B3060311A8151B70085B8BC /* SQLitePasswords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3060301A8151B70085B8BC /* SQLitePasswords.swift */; };
+		0BA4977E1A7B0941004C8E17 /* SQLiteHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA4977A1A7B0941004C8E17 /* SQLiteHistory.swift */; };
+		0BA497821A7B094B004C8E17 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497801A7B094B004C8E17 /* Bookmarks.swift */; };
+		0BA497831A7B094B004C8E17 /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497811A7B094B004C8E17 /* Visit.swift */; };
+		0BA4978C1A7B0E44004C8E17 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4C01A699EF200A406E2 /* Cursor.swift */; };
+		0BA4978D1A7B0E55004C8E17 /* FileAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D01A69A14500A406E2 /* FileAccessor.swift */; };
+		0BAE69561A7E1FD100B3609D /* SchemaTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAE69551A7E1FD100B3609D /* SchemaTable.swift */; };
+		0BAE69571A7E209200B3609D /* SchemaTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAE69551A7E1FD100B3609D /* SchemaTable.swift */; };
+		0BAE69591A7EEF8E00B3609D /* TestTableTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAE69581A7EEF8E00B3609D /* TestTableTable.swift */; };
+		0BCFBBAF1A77650E0087E26D /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B3F1AAD619686DB9450C /* GenericTable.swift */; };
+		0BCFBBB41A7769A30087E26D /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BCB8D38CE6E6F5F5F2DE /* JoinedHistoryVisitsTable.swift */; };
+		0BCFBBB51A7769B70087E26D /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B22E909B6CAC95DBE879 /* VisitsTable.swift */; };
+		0BCFBBB81A776A200087E26D /* MockFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCFBBB71A776A200087E26D /* MockFiles.swift */; };
+		0BF42D3E1A7C148F00889E28 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D3D1A7C148F00889E28 /* Favicons.swift */; };
+		0BF42D401A7C18CD00889E28 /* SQLFavicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */; };
+		0BF42D421A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */; };
+		0BF42D441A7C31EE00889E28 /* FaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */; };
+		0BF42D461A7C52C800889E28 /* TestFaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */; };
+		0BF42D471A7C558000889E28 /* Visit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA497811A7B094B004C8E17 /* Visit.swift */; };
+		0BF42D481A7C55D200889E28 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D61A69A28000A406E2 /* Site.swift */; };
+		0BF42D4A1A7C55F000889E28 /* FaviconsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */; };
+		0BF42D4B1A7C55F300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */; };
+		0BF42D4D1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */; };
+		282DA49B1A699E0300A406E2 /* Storage.h in Headers */ = {isa = PBXBuildFile; fileRef = 282DA49A1A699E0300A406E2 /* Storage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		282DA4A11A699E0300A406E2 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 282DA4951A699E0300A406E2 /* Storage.framework */; };
+		282DA4A81A699E0300A406E2 /* StorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4A71A699E0300A406E2 /* StorageTests.swift */; };
+		282DA4C21A699EF200A406E2 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4C01A699EF200A406E2 /* Cursor.swift */; };
+		282DA4C51A699F8A00A406E2 /* SwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4C41A699F8A00A406E2 /* SwiftData.swift */; };
+		282DA4C61A699F8A00A406E2 /* SwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4C41A699F8A00A406E2 /* SwiftData.swift */; };
+		282DA4D21A69A14500A406E2 /* FileAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D01A69A14500A406E2 /* FileAccessor.swift */; };
+		282DA4D41A69A24300A406E2 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D31A69A24300A406E2 /* History.swift */; };
+		282DA4D71A69A28000A406E2 /* Site.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282DA4D61A69A28000A406E2 /* Site.swift */; };
+		282DA5211A69BCB700A406E2 /* module.modulemap in Sources */ = {isa = PBXBuildFile; fileRef = 282DA51F1A69BCB700A406E2 /* module.modulemap */; };
+		282DA5241A69BCBB00A406E2 /* libsqlite3.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 282DA5231A69BCBB00A406E2 /* libsqlite3.0.dylib */; };
+		4A59B21913DCFA81C7CD9C91 /* GenericTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B3F1AAD619686DB9450C /* GenericTable.swift */; };
+		4A59B334A243792894D6E614 /* TestHistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B6E9AB0A08F28227C050 /* TestHistoryTable.swift */; };
+		4A59BA1E93D5603E198EDCB9 /* HistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BB07A2812FE4B516FD30 /* HistoryTable.swift */; };
+		4A59BAEB154EA6E1B621E067 /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF61F0D956D2A1BDAE29 /* BrowserDB.swift */; };
+		4A59BB4F36A20F30229034C6 /* VisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B22E909B6CAC95DBE879 /* VisitsTable.swift */; };
+		4A59BC6033BD93D1DC36E18F /* TestJoinedHistoryVisits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B33FF96A39A59CBBBBD7 /* TestJoinedHistoryVisits.swift */; };
+		4A59BD24F6210866F59EF0F6 /* JoinedHistoryVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BCB8D38CE6E6F5F5F2DE /* JoinedHistoryVisitsTable.swift */; };
+		4A59BF0BBF50FC218A6D1143 /* BrowserDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF61F0D956D2A1BDAE29 /* BrowserDB.swift */; };
+		4A59BF2F408CDEF8D50AF9D3 /* TestVisitsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BE48DBF43989C51D3F98 /* TestVisitsTable.swift */; };
+		4A59BFF7C37812C7955B9E79 /* HistoryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BB07A2812FE4B516FD30 /* HistoryTable.swift */; };
+		E47726181A8A794B00FC058B /* ReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47726171A8A794B00FC058B /* ReadingList.swift */; };
+		E47726191A8A794B00FC058B /* ReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47726171A8A794B00FC058B /* ReadingList.swift */; };
+		E477261B1A8A7DE500FC058B /* SQLiteReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E477261A1A8A7DE500FC058B /* SQLiteReadingList.swift */; };
+		E477261C1A8A7DE500FC058B /* SQLiteReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E477261A1A8A7DE500FC058B /* SQLiteReadingList.swift */; };
+		E477261E1A8A7EDA00FC058B /* ReadingListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E477261D1A8A7EDA00FC058B /* ReadingListTable.swift */; };
+		E477261F1A8A7EDA00FC058B /* ReadingListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E477261D1A8A7EDA00FC058B /* ReadingListTable.swift */; };
+		E47726211A8A87F400FC058B /* TestReadingListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47726201A8A87F400FC058B /* TestReadingListTable.swift */; };
+		E4F43AC21A8CF9A200ACAC05 /* TestSQLiteReadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F43AC11A8CF9A200ACAC05 /* TestSQLiteReadingList.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		282DA4A21A699E0300A406E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 282DA48C1A699E0300A406E2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 282DA4941A699E0300A406E2;
+			remoteInfo = Storage;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0B2770441A89276900CE7692 /* BookmarksSqlite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksSqlite.swift; sourceTree = "<group>"; };
+		0B2770461A893C2C00CE7692 /* TestBookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBookmarks.swift; sourceTree = "<group>"; };
+		0B2770DC1A8AD83200CE7692 /* Bytes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bytes.swift; path = ../../Sync/Bytes.swift; sourceTree = "<group>"; };
+		0B30602E1A80338F0085B8BC /* Passwords.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Passwords.swift; sourceTree = "<group>"; };
+		0B3060301A8151B70085B8BC /* SQLitePasswords.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLitePasswords.swift; sourceTree = "<group>"; };
+		0BA4977A1A7B0941004C8E17 /* SQLiteHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SQLiteHistory.swift; path = SQL/SQLiteHistory.swift; sourceTree = "<group>"; };
+		0BA497801A7B094B004C8E17 /* Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bookmarks.swift; sourceTree = "<group>"; };
+		0BA497811A7B094B004C8E17 /* Visit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visit.swift; sourceTree = "<group>"; };
+		0BAE69551A7E1FD100B3609D /* SchemaTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaTable.swift; sourceTree = "<group>"; };
+		0BAE69581A7EEF8E00B3609D /* TestTableTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTableTable.swift; sourceTree = "<group>"; };
+		0BCFBBB71A776A200087E26D /* MockFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFiles.swift; sourceTree = "<group>"; };
+		0BF42D3D1A7C148F00889E28 /* Favicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Favicons.swift; sourceTree = "<group>"; };
+		0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLFavicons.swift; sourceTree = "<group>"; };
+		0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinedFaviconsHistoryTable.swift; sourceTree = "<group>"; };
+		0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaviconsTable.swift; sourceTree = "<group>"; };
+		0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFaviconsTable.swift; sourceTree = "<group>"; };
+		0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJoinedFaviconTable.swift; sourceTree = "<group>"; };
+		282DA4951A699E0300A406E2 /* Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		282DA4991A699E0300A406E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		282DA49A1A699E0300A406E2 /* Storage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		282DA4A01A699E0300A406E2 /* StorageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StorageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		282DA4A61A699E0300A406E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		282DA4A71A699E0300A406E2 /* StorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageTests.swift; sourceTree = "<group>"; };
+		282DA4C01A699EF200A406E2 /* Cursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cursor.swift; sourceTree = "<group>"; };
+		282DA4C41A699F8A00A406E2 /* SwiftData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftData.swift; path = ThirdParty/SwiftData.swift; sourceTree = "<group>"; };
+		282DA4D01A69A14500A406E2 /* FileAccessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessor.swift; sourceTree = "<group>"; };
+		282DA4D31A69A24300A406E2 /* History.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
+		282DA4D61A69A28000A406E2 /* Site.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Site.swift; sourceTree = "<group>"; };
+		282DA51F1A69BCB700A406E2 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		282DA5231A69BCBB00A406E2 /* libsqlite3.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.0.dylib; path = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.1.sdk/usr/lib/libsqlite3.0.dylib; sourceTree = "<absolute>"; };
+		4A59B22E909B6CAC95DBE879 /* VisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VisitsTable.swift; path = SQL/VisitsTable.swift; sourceTree = "<group>"; };
+		4A59B33FF96A39A59CBBBBD7 /* TestJoinedHistoryVisits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestJoinedHistoryVisits.swift; sourceTree = "<group>"; };
+		4A59B3F1AAD619686DB9450C /* GenericTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GenericTable.swift; path = SQL/GenericTable.swift; sourceTree = "<group>"; };
+		4A59B6E9AB0A08F28227C050 /* TestHistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHistoryTable.swift; sourceTree = "<group>"; };
+		4A59BB07A2812FE4B516FD30 /* HistoryTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HistoryTable.swift; path = SQL/HistoryTable.swift; sourceTree = "<group>"; };
+		4A59BCB8D38CE6E6F5F5F2DE /* JoinedHistoryVisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JoinedHistoryVisitsTable.swift; path = SQL/JoinedHistoryVisitsTable.swift; sourceTree = "<group>"; };
+		4A59BE48DBF43989C51D3F98 /* TestVisitsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestVisitsTable.swift; sourceTree = "<group>"; };
+		4A59BF61F0D956D2A1BDAE29 /* BrowserDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BrowserDB.swift; path = SQL/BrowserDB.swift; sourceTree = "<group>"; };
+		E47726171A8A794B00FC058B /* ReadingList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadingList.swift; sourceTree = "<group>"; };
+		E477261A1A8A7DE500FC058B /* SQLiteReadingList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SQLiteReadingList.swift; path = SQL/SQLiteReadingList.swift; sourceTree = "<group>"; };
+		E477261D1A8A7EDA00FC058B /* ReadingListTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadingListTable.swift; sourceTree = "<group>"; };
+		E47726201A8A87F400FC058B /* TestReadingListTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestReadingListTable.swift; sourceTree = "<group>"; };
+		E4F43AC11A8CF9A200ACAC05 /* TestSQLiteReadingList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSQLiteReadingList.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		282DA4911A699E0300A406E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				282DA5241A69BCBB00A406E2 /* libsqlite3.0.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		282DA49D1A699E0300A406E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				282DA4A11A699E0300A406E2 /* Storage.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		282DA48B1A699E0300A406E2 = {
+			isa = PBXGroup;
+			children = (
+				282DA5231A69BCBB00A406E2 /* libsqlite3.0.dylib */,
+				282DA5201A69BCB700A406E2 /* modules */,
+				282DA4971A699E0300A406E2 /* Storage */,
+				282DA4C31A699F5600A406E2 /* Third-Party Source */,
+				282DA4A41A699E0300A406E2 /* StorageTests */,
+				282DA4961A699E0300A406E2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		282DA4961A699E0300A406E2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				282DA4951A699E0300A406E2 /* Storage.framework */,
+				282DA4A01A699E0300A406E2 /* StorageTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		282DA4971A699E0300A406E2 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				0B2770DC1A8AD83200CE7692 /* Bytes.swift */,
+				0BA497801A7B094B004C8E17 /* Bookmarks.swift */,
+				E47726171A8A794B00FC058B /* ReadingList.swift */,
+				0BA497811A7B094B004C8E17 /* Visit.swift */,
+				282DA4D91A69A2C400A406E2 /* SQL */,
+				282DA4D01A69A14500A406E2 /* FileAccessor.swift */,
+				282DA4D61A69A28000A406E2 /* Site.swift */,
+				282DA4D31A69A24300A406E2 /* History.swift */,
+				282DA4C01A699EF200A406E2 /* Cursor.swift */,
+				282DA49A1A699E0300A406E2 /* Storage.h */,
+				282DA4981A699E0300A406E2 /* Supporting Files */,
+				0BF42D3D1A7C148F00889E28 /* Favicons.swift */,
+				0B30602E1A80338F0085B8BC /* Passwords.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
+		282DA4981A699E0300A406E2 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				282DA4991A699E0300A406E2 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		282DA4A41A699E0300A406E2 /* StorageTests */ = {
+			isa = PBXGroup;
+			children = (
+				282DA4A71A699E0300A406E2 /* StorageTests.swift */,
+				282DA4A51A699E0300A406E2 /* Supporting Files */,
+				4A59B6E9AB0A08F28227C050 /* TestHistoryTable.swift */,
+				0BF42D451A7C52C800889E28 /* TestFaviconsTable.swift */,
+				4A59B33FF96A39A59CBBBBD7 /* TestJoinedHistoryVisits.swift */,
+				0BF42D4C1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift */,
+				4A59BE48DBF43989C51D3F98 /* TestVisitsTable.swift */,
+				0BCFBBB71A776A200087E26D /* MockFiles.swift */,
+				0BAE69581A7EEF8E00B3609D /* TestTableTable.swift */,
+				0B2770461A893C2C00CE7692 /* TestBookmarks.swift */,
+				E47726201A8A87F400FC058B /* TestReadingListTable.swift */,
+				E4F43AC11A8CF9A200ACAC05 /* TestSQLiteReadingList.swift */,
+			);
+			path = StorageTests;
+			sourceTree = "<group>";
+		};
+		282DA4A51A699E0300A406E2 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				282DA4A61A699E0300A406E2 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		282DA4C31A699F5600A406E2 /* Third-Party Source */ = {
+			isa = PBXGroup;
+			children = (
+				282DA4C41A699F8A00A406E2 /* SwiftData.swift */,
+			);
+			name = "Third-Party Source";
+			sourceTree = "<group>";
+		};
+		282DA4D91A69A2C400A406E2 /* SQL */ = {
+			isa = PBXGroup;
+			children = (
+				0B2770441A89276900CE7692 /* BookmarksSqlite.swift */,
+				4A59BF61F0D956D2A1BDAE29 /* BrowserDB.swift */,
+				0BF42D431A7C31EE00889E28 /* FaviconsTable.swift */,
+				4A59B3F1AAD619686DB9450C /* GenericTable.swift */,
+				4A59BB07A2812FE4B516FD30 /* HistoryTable.swift */,
+				0BF42D411A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift */,
+				4A59BCB8D38CE6E6F5F5F2DE /* JoinedHistoryVisitsTable.swift */,
+				E477261D1A8A7EDA00FC058B /* ReadingListTable.swift */,
+				0BAE69551A7E1FD100B3609D /* SchemaTable.swift */,
+				0BF42D3F1A7C18CD00889E28 /* SQLFavicons.swift */,
+				0BA4977A1A7B0941004C8E17 /* SQLiteHistory.swift */,
+				0B3060301A8151B70085B8BC /* SQLitePasswords.swift */,
+				E477261A1A8A7DE500FC058B /* SQLiteReadingList.swift */,
+				4A59B22E909B6CAC95DBE879 /* VisitsTable.swift */,
+			);
+			name = SQL;
+			sourceTree = "<group>";
+		};
+		282DA5201A69BCB700A406E2 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				282DA51F1A69BCB700A406E2 /* module.modulemap */,
+			);
+			path = modules;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		282DA4921A699E0300A406E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				282DA49B1A699E0300A406E2 /* Storage.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		282DA4941A699E0300A406E2 /* Storage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 282DA4AB1A699E0300A406E2 /* Build configuration list for PBXNativeTarget "Storage" */;
+			buildPhases = (
+				282DA4901A699E0300A406E2 /* Sources */,
+				282DA4911A699E0300A406E2 /* Frameworks */,
+				282DA4921A699E0300A406E2 /* Headers */,
+				282DA4931A699E0300A406E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Storage;
+			productName = Storage;
+			productReference = 282DA4951A699E0300A406E2 /* Storage.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		282DA49F1A699E0300A406E2 /* StorageTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 282DA4AE1A699E0300A406E2 /* Build configuration list for PBXNativeTarget "StorageTests" */;
+			buildPhases = (
+				282DA49C1A699E0300A406E2 /* Sources */,
+				282DA49D1A699E0300A406E2 /* Frameworks */,
+				282DA49E1A699E0300A406E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				282DA4A31A699E0300A406E2 /* PBXTargetDependency */,
+			);
+			name = StorageTests;
+			productName = StorageTests;
+			productReference = 282DA4A01A699E0300A406E2 /* StorageTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		282DA48C1A699E0300A406E2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = Mozilla;
+				TargetAttributes = {
+					282DA4941A699E0300A406E2 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+					282DA49F1A699E0300A406E2 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 282DA48F1A699E0300A406E2 /* Build configuration list for PBXProject "Storage" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 282DA48B1A699E0300A406E2;
+			productRefGroup = 282DA4961A699E0300A406E2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				282DA4941A699E0300A406E2 /* Storage */,
+				282DA49F1A699E0300A406E2 /* StorageTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		282DA4931A699E0300A406E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		282DA49E1A699E0300A406E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		282DA4901A699E0300A406E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B30602F1A80338F0085B8BC /* Passwords.swift in Sources */,
+				0BA497821A7B094B004C8E17 /* Bookmarks.swift in Sources */,
+				282DA4C51A699F8A00A406E2 /* SwiftData.swift in Sources */,
+				E47726181A8A794B00FC058B /* ReadingList.swift in Sources */,
+				E477261E1A8A7EDA00FC058B /* ReadingListTable.swift in Sources */,
+				0BA4977E1A7B0941004C8E17 /* SQLiteHistory.swift in Sources */,
+				282DA5211A69BCB700A406E2 /* module.modulemap in Sources */,
+				0BA4978C1A7B0E44004C8E17 /* Cursor.swift in Sources */,
+				0BF42D401A7C18CD00889E28 /* SQLFavicons.swift in Sources */,
+				0B2770451A89276900CE7692 /* BookmarksSqlite.swift in Sources */,
+				282DA4D71A69A28000A406E2 /* Site.swift in Sources */,
+				0B2770DD1A8AD83200CE7692 /* Bytes.swift in Sources */,
+				282DA4D41A69A24300A406E2 /* History.swift in Sources */,
+				0BA497831A7B094B004C8E17 /* Visit.swift in Sources */,
+				0BAE69561A7E1FD100B3609D /* SchemaTable.swift in Sources */,
+				4A59BB4F36A20F30229034C6 /* VisitsTable.swift in Sources */,
+				0BF42D421A7C31E300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */,
+				0BF42D441A7C31EE00889E28 /* FaviconsTable.swift in Sources */,
+				E477261B1A8A7DE500FC058B /* SQLiteReadingList.swift in Sources */,
+				4A59B21913DCFA81C7CD9C91 /* GenericTable.swift in Sources */,
+				0BF42D3E1A7C148F00889E28 /* Favicons.swift in Sources */,
+				0BA4978D1A7B0E55004C8E17 /* FileAccessor.swift in Sources */,
+				4A59BD24F6210866F59EF0F6 /* JoinedHistoryVisitsTable.swift in Sources */,
+				0B3060311A8151B70085B8BC /* SQLitePasswords.swift in Sources */,
+				4A59BFF7C37812C7955B9E79 /* HistoryTable.swift in Sources */,
+				4A59BAEB154EA6E1B621E067 /* BrowserDB.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		282DA49C1A699E0300A406E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				282DA4D21A69A14500A406E2 /* FileAccessor.swift in Sources */,
+				0BCFBBB81A776A200087E26D /* MockFiles.swift in Sources */,
+				0BF42D4B1A7C55F300889E28 /* JoinedFaviconsHistoryTable.swift in Sources */,
+				E4F43AC21A8CF9A200ACAC05 /* TestSQLiteReadingList.swift in Sources */,
+				0BCFBBB51A7769B70087E26D /* VisitsTable.swift in Sources */,
+				282DA4A81A699E0300A406E2 /* StorageTests.swift in Sources */,
+				0BCFBBB41A7769A30087E26D /* JoinedHistoryVisitsTable.swift in Sources */,
+				0BF42D461A7C52C800889E28 /* TestFaviconsTable.swift in Sources */,
+				0BCFBBAF1A77650E0087E26D /* GenericTable.swift in Sources */,
+				E477261C1A8A7DE500FC058B /* SQLiteReadingList.swift in Sources */,
+				282DA4C61A699F8A00A406E2 /* SwiftData.swift in Sources */,
+				0B2770481A893C4700CE7692 /* BookmarksSqlite.swift in Sources */,
+				0B2770471A893C2C00CE7692 /* TestBookmarks.swift in Sources */,
+				0BF42D471A7C558000889E28 /* Visit.swift in Sources */,
+				E47726191A8A794B00FC058B /* ReadingList.swift in Sources */,
+				E47726211A8A87F400FC058B /* TestReadingListTable.swift in Sources */,
+				282DA4C21A699EF200A406E2 /* Cursor.swift in Sources */,
+				0B2770491A893C9500CE7692 /* Bookmarks.swift in Sources */,
+				0BF42D481A7C55D200889E28 /* Site.swift in Sources */,
+				0B2770E91A8AD85000CE7692 /* Bytes.swift in Sources */,
+				4A59BA1E93D5603E198EDCB9 /* HistoryTable.swift in Sources */,
+				0BAE69571A7E209200B3609D /* SchemaTable.swift in Sources */,
+				4A59BF0BBF50FC218A6D1143 /* BrowserDB.swift in Sources */,
+				E477261F1A8A7EDA00FC058B /* ReadingListTable.swift in Sources */,
+				4A59B334A243792894D6E614 /* TestHistoryTable.swift in Sources */,
+				4A59BC6033BD93D1DC36E18F /* TestJoinedHistoryVisits.swift in Sources */,
+				0BF42D4D1A7CC4ED00889E28 /* TestJoinedFaviconTable.swift in Sources */,
+				0BF42D4A1A7C55F000889E28 /* FaviconsTable.swift in Sources */,
+				4A59BF2F408CDEF8D50AF9D3 /* TestVisitsTable.swift in Sources */,
+				0BAE69591A7EEF8E00B3609D /* TestTableTable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		282DA4A31A699E0300A406E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 282DA4941A699E0300A406E2 /* Storage */;
+			targetProxy = 282DA4A21A699E0300A406E2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		282DA4A91A699E0300A406E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		282DA4AA1A699E0300A406E2 /* FennecAurora */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = FennecAurora;
+		};
+		282DA4AC1A699E0300A406E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"/Users/rnewman/moz/git/firefox-ios/SQLite/build/Debug-iphoneos",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Client-fhgufntxvuxtwfbmkckrmnagytst/Build/Products/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = Storage/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+			};
+			name = Debug;
+		};
+		282DA4AD1A699E0300A406E2 /* FennecAurora */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"/Users/rnewman/moz/git/firefox-ios/SQLite/build/Debug-iphoneos",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Client-fhgufntxvuxtwfbmkckrmnagytst/Build/Products/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = Storage/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+			};
+			name = FennecAurora;
+		};
+		282DA4AF1A699E0300A406E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StorageTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		282DA4B01A699E0300A406E2 /* FennecAurora */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StorageTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = FennecAurora;
+		};
+		E4D438F51A8D3197003FCF55 /* FennecNightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = FennecNightly;
+		};
+		E4D438F61A8D3197003FCF55 /* FennecNightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"/Users/rnewman/moz/git/firefox-ios/SQLite/build/Debug-iphoneos",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Client-fhgufntxvuxtwfbmkckrmnagytst/Build/Products/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = Storage/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/modules";
+			};
+			name = FennecNightly;
+		};
+		E4D438F71A8D3197003FCF55 /* FennecNightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StorageTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = FennecNightly;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		282DA48F1A699E0300A406E2 /* Build configuration list for PBXProject "Storage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				282DA4A91A699E0300A406E2 /* Debug */,
+				282DA4AA1A699E0300A406E2 /* FennecAurora */,
+				E4D438F51A8D3197003FCF55 /* FennecNightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = FennecAurora;
+		};
+		282DA4AB1A699E0300A406E2 /* Build configuration list for PBXNativeTarget "Storage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				282DA4AC1A699E0300A406E2 /* Debug */,
+				282DA4AD1A699E0300A406E2 /* FennecAurora */,
+				E4D438F61A8D3197003FCF55 /* FennecNightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = FennecAurora;
+		};
+		282DA4AE1A699E0300A406E2 /* Build configuration list for PBXNativeTarget "StorageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				282DA4AF1A699E0300A406E2 /* Debug */,
+				282DA4B01A699E0300A406E2 /* FennecAurora */,
+				E4D438F71A8D3197003FCF55 /* FennecNightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = FennecAurora;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 282DA48C1A699E0300A406E2 /* Project object */;
+}

--- a/StorageTests/TestFaviconsTable.swift
+++ b/StorageTests/TestFaviconsTable.swift
@@ -58,7 +58,7 @@ class TestFavcionsTable : XCTestCase {
     func testFaviconsTable() {
         let files = MockFiles()
         self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
-        let f = FaviconsTable<Favicon>(files: files)
+        let f = FaviconsTable<Favicon>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
             f.create(db, version: 1)

--- a/StorageTests/TestJoinedFaviconTable.swift
+++ b/StorageTests/TestJoinedFaviconTable.swift
@@ -58,7 +58,7 @@ class TestJoinedFaviconsTable : XCTestCase {
     func testJoinedFaviconsTable() {
         let files = MockFiles()
         self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
-        let f = JoinedFaviconsHistoryTable<(Site, Favicon)>(files: files)
+        let f = JoinedFaviconsHistoryTable<(Site, Favicon)>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
             f.create(db, version: 1)

--- a/StorageTests/TestJoinedHistoryVisits.swift
+++ b/StorageTests/TestJoinedHistoryVisits.swift
@@ -95,7 +95,7 @@ class TestJoinedHistoryVisits : XCTestCase {
     func testJoinedHistoryVisitsTable() {
         let files = MockFiles()
         self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
-        let h = JoinedHistoryVisitsTable(files: files)
+        let h = JoinedHistoryVisitsTable()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
             h.create(db, version: 2)

--- a/Utils/ExtensionUtils.swift
+++ b/Utils/ExtensionUtils.swift
@@ -26,7 +26,7 @@ struct ExtensionUtils {
                                     } else {
                                         let title = inputItem.attributedContentText?.string as String?
                                         let url = obj as NSURL
-                                        completionHandler(ShareItem(url: url.absoluteString!, title: title), nil)
+                                        completionHandler(ShareItem(url: url.absoluteString!, title: title, favicon: nil), nil)
                                     }
                                 })
                                 return


### PR DESCRIPTION
This adds a join-table for bookmarks <-> favicons. The table is smart enough to query history for a favicon if you don't provide one. It adds the entry to the bookmarks and favicons table, and then updates it own bookmarkId <-> faviconId mapping. I also added a test (basically a copy of the History test we have for the same thing).

I also (after a long rabbit hole) removed the files: argument from the Favicon constructor which isn't used anymore here. I left that in since its nice cleanup.