### PR TITLE
Bug 1135194 - URL text selection is broken

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -188,7 +188,11 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate {
     }
 
     func textFieldDidBeginEditing(textField: UITextField) {
-        textField.selectAll(nil)
+        // Without the async dispatch below, text selection doesn't work
+        // intermittently and crashes on the iPhone 6 Plus (bug 1124310).
+        dispatch_async(dispatch_get_main_queue(), {
+            textField.selectedTextRange = textField.textRangeFromPosition(textField.beginningOfDocument, toPosition: textField.endOfDocument)
+        })
     }
 
     func textFieldShouldClear(textField: UITextField) -> Bool {


### PR DESCRIPTION
As mentioned in [bug 1135194](https://bugzilla.mozilla.org/show_bug.cgi?id=1135194), even a minimal project shows weird text selection behavior, so this is likely an iOS bug. The async dispatch fixes the issue, along with the iPhone 6 Plus crash as expected ([bug 1124310](https://bugzilla.mozilla.org/show_bug.cgi?id=1124310)).