### PR TITLE
Bug 1136951 - Clean up SiteTableViewController

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -12,8 +12,6 @@
 		0B305FB91A7F4F040085B8BC /* Passwords.js in Resources */ = {isa = PBXBuildFile; fileRef = 0B305FB81A7F4F040085B8BC /* Passwords.js */; };
 		0B305FC01A7FDD830085B8BC /* PasswordManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B305FBF1A7FDD830085B8BC /* PasswordManager.swift */; };
 		0B6544D31A96C5F0000DD202 /* libSDWebImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B6544C21A96C59E000DD202 /* libSDWebImage.a */; };
-		0B6545761A97E07C000DD202 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6545751A97E07C000DD202 /* SiteTableViewController.swift */; };
-		0B6545781A97E102000DD202 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6545751A97E07C000DD202 /* SiteTableViewController.swift */; };
 		0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0B9E3DE71A23FBD1008A7877 /* TestPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */; };
 		0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
@@ -95,7 +93,6 @@
 		4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */; };
 		59A680D1116F5BF6CCC9ED6F /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanel.swift */; };
 		59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
-		59A684F3A0E745546D07BDA9 /* TabsViewControllerHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 59A68EC516B0FE3C9B913AB9 /* TabsViewControllerHeader.xib */; };
 		59A687335CF58A8004B23508 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
 		59A687B4A05CC772FE7E5A09 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
 		59A688AEC01E5F62C5C52966 /* TabsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A683E3C04DD83502EF1EC7 /* TabsPanel.swift */; };
@@ -118,6 +115,10 @@
 		D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		D34DC8581A16C40C00D49B7B /* RestAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC8521A16C40C00D49B7B /* RestAPI.swift */; };
 		D3589EF71A8D930000F28118 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E4CD9F191A6D9B7B00318571 /* libz.dylib */; };
+		D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */; };
+		D38A1BEF1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */; };
+		D38A1BF01A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = D38A1BED1A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib */; };
+		D38A1BF11A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = D38A1BED1A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib */; };
 		D38B2CED1A8D94D20040E6B5 /* Snap.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2CE81A8D94CA0040E6B5 /* Snap.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D38B2CEE1A8D95020040E6B5 /* Snap.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2CE81A8D94CA0040E6B5 /* Snap.framework */; };
 		D38B2D2E1A8D96D00040E6B5 /* GCDWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = D38B2D111A8D96D00040E6B5 /* GCDWebServer.m */; };
@@ -505,7 +506,6 @@
 		0B305FB81A7F4F040085B8BC /* Passwords.js */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.javascript; path = Passwords.js; sourceTree = "<group>"; tabWidth = 1; };
 		0B305FBF1A7FDD830085B8BC /* PasswordManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManager.swift; sourceTree = "<group>"; };
 		0B6544B01A96C59E000DD202 /* SDWebImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDWebImage.xcodeproj; path = Carthage/Checkouts/SDWebImage/SDWebImage.xcodeproj; sourceTree = "<group>"; };
-		0B6545751A97E07C000DD202 /* SiteTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteTableViewController.swift; sourceTree = "<group>"; };
 		0B8E0FF31A932BD500161DC3 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		0B9E3DE31A23FBD1008A7877 /* TestPanels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPanels.swift; sourceTree = "<group>"; };
 		0BA896491A250E6500C1010C /* ProfileTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileTest.swift; sourceTree = "<group>"; };
@@ -557,7 +557,6 @@
 		59A68480808F0CFC2E6B79DD /* Panels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Panels.swift; sourceTree = "<group>"; };
 		59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPanel.swift; sourceTree = "<group>"; };
 		59A68CCB63E2A565CB03F832 /* SearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
-		59A68EC516B0FE3C9B913AB9 /* TabsViewControllerHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabsViewControllerHeader.xib; sourceTree = "<group>"; };
 		9B64C2A71A6451A800473AE3 /* LongPress.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = LongPress.js; path = JavaScripts/LongPress.js; sourceTree = "<group>"; };
 		9B9AE2231A48B9A500AF2C23 /* LongPressGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressGestureRecognizer.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
@@ -567,6 +566,8 @@
 		D31FC2291A8D908800BAF7EC /* Alamofire.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Alamofire.xcodeproj; path = Carthage/Checkouts/Alamofire/Alamofire.xcodeproj; sourceTree = "<group>"; };
 		D34DC84D1A16C40C00D49B7B /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		D34DC8521A16C40C00D49B7B /* RestAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestAPI.swift; sourceTree = "<group>"; };
+		D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteTableViewController.swift; sourceTree = "<group>"; };
+		D38A1BED1A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SiteTableViewControllerHeader.xib; sourceTree = "<group>"; };
 		D38B2CD81A8D94CA0040E6B5 /* Snap.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Snap.xcodeproj; path = Carthage/Checkouts/Snap/Snap.xcodeproj; sourceTree = "<group>"; };
 		D38B2D101A8D96D00040E6B5 /* GCDWebServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDWebServer.h; sourceTree = "<group>"; };
 		D38B2D111A8D96D00040E6B5 /* GCDWebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDWebServer.m; sourceTree = "<group>"; };
@@ -900,6 +901,15 @@
 			path = Providers;
 			sourceTree = "<group>";
 		};
+		D38A1BEB1A9FA2CA00F6A386 /* Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */,
+				D38A1BED1A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib */,
+			);
+			path = Widgets;
+			sourceTree = "<group>";
+		};
 		D38B2D0E1A8D96D00040E6B5 /* GCDWebServer */ = {
 			isa = PBXGroup;
 			children = (
@@ -1040,13 +1050,13 @@
 		F84B21B51A090F8100AAB793 = {
 			isa = PBXGroup;
 			children = (
-				2F44F9ED1A9D417500FD20CC /* Base32.xcodeproj */,
-				D39FA16B1A83E17800EE869C /* CoreGraphics.framework */,
 				D3FA77C31A44F9A80010CD32 /* Locales */,
 				E4CD9F191A6D9B7B00318571 /* libz.dylib */,
+				D39FA16B1A83E17800EE869C /* CoreGraphics.framework */,
 				0B8E0FF31A932BD500161DC3 /* ImageIO.framework */,
 				28CE83E81A1D206D00576538 /* Client-Bridging-Header.h */,
 				D31FC2291A8D908800BAF7EC /* Alamofire.xcodeproj */,
+				2F44F9ED1A9D417500FD20CC /* Base32.xcodeproj */,
 				28CE83CA1A1D1D5100576538 /* FxA.xcodeproj */,
 				D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */,
 				0B6544B01A96C59E000DD202 /* SDWebImage.xcodeproj */,
@@ -1149,9 +1159,10 @@
 			isa = PBXGroup;
 			children = (
 				D3A994941A368691008AD1AC /* Browser */,
-				F84B21F51A0910F600AAB793 /* Reader */,
 				F84B22211A09122500AAB793 /* Home */,
+				F84B21F51A0910F600AAB793 /* Reader */,
 				2F44FC551A9E83E200FD20CC /* Settings */,
+				D38A1BEB1A9FA2CA00F6A386 /* Widgets */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -1172,16 +1183,14 @@
 		F84B22211A09122500AAB793 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				F84B22221A09122500AAB793 /* HomePanelViewController.swift */,
-				F84B22261A09127C00AAB793 /* Home.xcassets */,
-				59A6825233896FC846499289 /* HistoryPanel.swift */,
-				59A68480808F0CFC2E6B79DD /* Panels.swift */,
 				59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */,
-				0BF48B5D1A96A77400A730CF /* TwoLineCell.swift */,
-				0B6545751A97E07C000DD202 /* SiteTableViewController.swift */,
+				59A6825233896FC846499289 /* HistoryPanel.swift */,
+				F84B22221A09122500AAB793 /* HomePanelViewController.swift */,
+				59A68480808F0CFC2E6B79DD /* Panels.swift */,
 				59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */,
 				59A683E3C04DD83502EF1EC7 /* TabsPanel.swift */,
-				59A68EC516B0FE3C9B913AB9 /* TabsViewControllerHeader.xib */,
+				0BF48B5D1A96A77400A730CF /* TwoLineCell.swift */,
+				F84B22261A09127C00AAB793 /* Home.xcassets */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1671,6 +1680,7 @@
 				E4B7B77D1A793CF20022C5E0 /* FiraSans-Regular.ttf in Resources */,
 				E4B7B7791A793CF20022C5E0 /* FiraSans-Light.ttf in Resources */,
 				9B64C2A81A6451A800473AE3 /* LongPress.js in Resources */,
+				D38A1BF01A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib in Resources */,
 				E4CD9E9A1A68980A00318571 /* ReaderMode.js in Resources */,
 				E4B7B7641A793CF20022C5E0 /* CharisSILR.ttf in Resources */,
 				2F834D161A80629A006A0B7B /* FxASignIn.js in Resources */,
@@ -1679,7 +1689,6 @@
 				0BF42D391A7C0E8900889E28 /* Favicons.js in Resources */,
 				E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */,
 				2F44FB2D1A9D5D8500FD20CC /* FiraSans-BoldItalic.ttf in Resources */,
-				59A684F3A0E745546D07BDA9 /* TabsViewControllerHeader.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1688,6 +1697,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F1BDF931A8523B000213B54 /* LICENSE in Resources */,
+				D38A1BF11A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib in Resources */,
 				2F834D171A80629A006A0B7B /* FxASignIn.js in Resources */,
 				0BF9F8BC1A3A82CA0049A0FA /* Images.xcassets in Resources */,
 			);
@@ -1744,7 +1754,6 @@
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				28CE83C51A1D1D3200576538 /* EncryptedRecord.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
-				0B6545761A97E07C000DD202 /* SiteTableViewController.swift in Sources */,
 				D38B2D2E1A8D96D00040E6B5 /* GCDWebServer.m in Sources */,
 				2F834D141A80629A006A0B7B /* FxAGetStartedViewController.swift in Sources */,
 				28CE83C81A1D1D3200576538 /* SyncMeta.swift in Sources */,
@@ -1777,6 +1786,7 @@
 				D38B2D4F1A8D96D00040E6B5 /* GCDWebServerFileResponse.m in Sources */,
 				E43A4E551A96B88100E25676 /* GCDWebServerDataRequest.m in Sources */,
 				F84B22241A09122500AAB793 /* HomePanelViewController.swift in Sources */,
+				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				28CE83C91A1D1D3200576538 /* TokenServerClient.swift in Sources */,
 				2F44FA181A9D425700FD20CC /* HashExtensions.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
@@ -1821,7 +1831,6 @@
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				D38B2D2F1A8D96D00040E6B5 /* GCDWebServer.m in Sources */,
 				0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */,
-				0B6545781A97E102000DD202 /* SiteTableViewController.swift in Sources */,
 				D38B2D351A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
 				2F834D211A8062D1006A0B7B /* json.swift in Sources */,
 				E42CCE021A24C4E300B794D3 /* ExtensionUtils.swift in Sources */,
@@ -1850,6 +1859,7 @@
 				D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
 				D38B2D381A8D96D00040E6B5 /* GCDWebServerRequest.m in Sources */,
+				D38A1BEF1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				0BA8964C1A250E6500C1010C /* TestBookmarks.swift in Sources */,
 				D38B2D321A8D96D00040E6B5 /* GCDWebServerConnection.m in Sources */,
 				0BE108361A1B1EC700D4B712 /* TestLocking.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -144,7 +144,7 @@ class BrowserViewController: UIViewController {
 
         searchController = SearchViewController()
         searchController!.searchEngines = profile.searchEngines
-        searchController!.homePanelDelegate = self
+        searchController!.searchDelegate = self
         searchController!.profile = self.profile
 
         view.addSubview(searchController!.view)
@@ -369,13 +369,13 @@ extension BrowserViewController: BrowserToolbarDelegate {
 }
 
 extension BrowserViewController: HomePanelViewControllerDelegate {
-    func homePanelViewController(homePanelViewController: HomePanelViewController, didSubmitURL url: NSURL) {
+    func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL) {
         finishEditingAndSubmit(url)
     }
 }
 
-extension BrowserViewController: HomePanelDelegate {
-    func homePanel(didSubmitURL url: NSURL) {
+extension BrowserViewController: SearchViewControllerDelegate {
+    func searchViewController(searchViewController: SearchViewController, didSelectURL url: NSURL) {
         finishEditingAndSubmit(url)
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -13,10 +13,15 @@ private enum SearchListSection: Int {
     case Search
 }
 
+protocol SearchViewControllerDelegate: class {
+    func searchViewController(searchViewController: SearchViewController, didSelectURL url: NSURL)
+}
+
 class SearchViewController: SiteTableViewController {
     private var sortedEngines = [OpenSearchEngine]()
     private var suggestClient: SearchSuggestClient?
     private var searchSuggestions = [String]()
+    var searchDelegate: SearchViewControllerDelegate?
 
     var searchEngines: SearchEngines? {
         didSet {
@@ -197,7 +202,7 @@ extension SearchViewController: UITableViewDelegate {
         }
 
         if let url = url {
-            homePanelDelegate?.homePanel(didSubmitURL: url)
+            searchDelegate?.searchViewController(self, didSelectURL: url)
         }
     }
 }

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -5,7 +5,8 @@
 import UIKit
 import Storage
 
-class BookmarksPanel: SiteTableViewController {
+class BookmarksPanel: SiteTableViewController, HomePanel {
+    weak var homePanelDelegate: HomePanelDelegate? = nil
     var source: BookmarksModel?
 
     override var profile: Profile! {
@@ -30,10 +31,6 @@ class BookmarksPanel: SiteTableViewController {
         self.source?.reloadData(self.onNewModel, self.onModelFailure)
     }
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return 1
-    }
-
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let source = source {
             return source.current.count
@@ -53,7 +50,7 @@ class BookmarksPanel: SiteTableViewController {
     }
 
     override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "Recent Bookmarks"
+        return NSLocalizedString("Recent Bookmarks", comment: "Header for bookmarks list")
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
@@ -63,7 +60,7 @@ class BookmarksPanel: SiteTableViewController {
 
             switch (bookmark) {
             case let item as BookmarkItem:
-                homePanelDelegate?.homePanel(didSubmitURL: NSURL(string: item.url)!)
+                homePanelDelegate?.homePanel(self, didSelectURL: NSURL(string: item.url)!)
                 break
 
             case let folder as BookmarkFolder:

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -13,11 +13,13 @@ private func getDate(#dayOffset: Int) -> NSDate {
     return calendar.dateByAddingUnit(NSCalendarUnit.CalendarUnitDay, value: dayOffset, toDate: today, options: nil)!
 }
 
-class HistoryPanel: SiteTableViewController {
+class HistoryPanel: SiteTableViewController, HomePanel {
+    weak var homePanelDelegate: HomePanelDelegate? = nil
+
     private let NumSections = 4
-    private var Today = getDate(dayOffset: 0)
-    private var Yesterday = getDate(dayOffset: -1)
-    private var ThisWeek = getDate(dayOffset: -7)
+    private let Today = getDate(dayOffset: 0)
+    private let Yesterday = getDate(dayOffset: -1)
+    private let ThisWeek = getDate(dayOffset: -7)
 
     private var sectionOffsets = [Int: Int]()
 
@@ -53,7 +55,7 @@ class HistoryPanel: SiteTableViewController {
         let offset = sectionOffsets[indexPath.section]!
         if let site = data[indexPath.row + offset] as? Site {
             if let url = NSURL(string: site.url) {
-                homePanelDelegate?.homePanel(didSubmitURL: url)
+                homePanelDelegate?.homePanel(self, didSelectURL: url)
                 return
             }
         }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -12,7 +12,7 @@ private let SelectedIconColor = UIColor(red: 62.0 / 255, green: 136.0 / 255, blu
 private let ContainerHeight = 40
 
 protocol HomePanelViewControllerDelegate: class {
-    func homePanelViewController(homePanelViewController: HomePanelViewController, didSubmitURL url: NSURL)
+    func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL)
 }
 
 @objc
@@ -22,7 +22,7 @@ protocol HomePanel: class {
 
 @objc
 protocol HomePanelDelegate: class {
-    func homePanel(didSubmitURL url: NSURL)
+    func homePanel(homePanel: HomePanel, didSelectURL url: NSURL)
 }
 
 class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelDelegate {
@@ -162,8 +162,8 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         return overlayedImage
     }
 
-    func homePanel(didSubmitURL url: NSURL) {
-        delegate?.homePanelViewController(self, didSubmitURL: url)
+    func homePanel(homePanel: HomePanel, didSelectURL url: NSURL) {
+        delegate?.homePanelViewController(self, didSelectURL: url)
         dismissViewControllerAnimated(true, completion: nil)
     }
 }

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -5,7 +5,9 @@
 import UIKit
 import Storage
 
-class ReaderPanel: SiteTableViewController {
+class ReaderPanel: SiteTableViewController, HomePanel {
+    weak var homePanelDelegate: HomePanelDelegate? = nil
+
     override func reloadData() {
         profile.readingList.get { (cursor) -> Void in
             self.refreshControl?.endRefreshing()
@@ -27,7 +29,7 @@ class ReaderPanel: SiteTableViewController {
         if let readingListItem = data[indexPath.row] as? ReadingListItem {
             if let encodedURL = readingListItem.url.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet()) {
                 if let aboutReaderURL = NSURL(string: "about:reader?url=\(encodedURL)") {
-                    homePanelDelegate?.homePanel(didSubmitURL: aboutReaderURL)
+                    homePanelDelegate?.homePanel(self, didSelectURL: aboutReaderURL)
                 }
             }
         }

--- a/Client/Frontend/Home/TabsPanel.swift
+++ b/Client/Frontend/Home/TabsPanel.swift
@@ -6,7 +6,8 @@ import UIKit
 import Alamofire
 import Storage
 
-class TabsPanel: SiteTableViewController {
+class TabsPanel: SiteTableViewController, HomePanel {
+    weak var homePanelDelegate: HomePanelDelegate? = nil
     private var tabsResponse: TabsResponse?
 
     override func reloadData() {

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -1,14 +1,11 @@
-/** This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
 import Storage
 
-/** Provides some base shared functionality for home view panels for shared
- * row and header types.
- */
-class SiteTableViewHeader : UITableViewHeaderFooterView {
+private class SiteTableViewHeader : UITableViewHeaderFooterView {
     // I can't get drawRect to play nicely with the glass background. As a fallback
     // we just use views for the top and bottom borders.
     let topBorder = UIView()
@@ -51,8 +48,10 @@ class SiteTableViewHeader : UITableViewHeaderFooterView {
     }
 }
 
-class SiteTableViewController: UITableViewController, HomePanel {
-    weak var homePanelDelegate: HomePanelDelegate? = nil
+/**
+ * Provides base shared functionality for site rows and headers.
+ */
+class SiteTableViewController: UITableViewController {
     private let CellIdentifier = "CellIdentifier"
     private let HeaderIdentifier = "HeaderIdentifier"
     var profile: Profile! {

--- a/Client/Frontend/Widgets/SiteTableViewControllerHeader.xib
+++ b/Client/Frontend/Widgets/SiteTableViewControllerHeader.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6724" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6711"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="FiraSans-Light.ttf">


### PR DESCRIPTION
SiteTableViewController is still coupled to HomePanelDelegate, which is a bit strange considering SiteTableViewController doesn't even use the delegate it owns. I think we can clean this up by:
* Moving SiteTableViewController out of Home/ and into Widgets/
* Removing the unused HomePanelDelegate from SiteTableViewController
* Making home panels subclass SiteTableViewController directly, implement HomePanel directly, and own their own delegates