### PR TITLE
Bug 1134796 - Create horizontally scrolling search engine row

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		D38B2D8C1A8D98D90040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; };
+		D39999A91AA01D65005AED21 /* KeyboardWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39999A81AA01D65005AED21 /* KeyboardWatcher.swift */; };
+		D39999AA1AA01D65005AED21 /* KeyboardWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39999A81AA01D65005AED21 /* KeyboardWatcher.swift */; };
 		D39FA16C1A83E17800EE869C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39FA16B1A83E17800EE869C /* CoreGraphics.framework */; };
 		D39FA1811A83E84900EE869C /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1801A83E84900EE869C /* Global.swift */; };
 		D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1821A83E87900EE869C /* NavigationTests.swift */; };
@@ -600,6 +602,7 @@
 		D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KIF.xcodeproj; path = Carthage/Checkouts/KIF/KIF.xcodeproj; sourceTree = "<group>"; };
 		D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SWXMLHash.xcodeproj; path = Carthage/Checkouts/SWXMLHash/SWXMLHash.xcodeproj; sourceTree = "<group>"; };
 		D3968F241A38FE8500CEFD3B /* TabManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
+		D39999A81AA01D65005AED21 /* KeyboardWatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardWatcher.swift; sourceTree = "<group>"; };
 		D39FA15F1A83E0EC00EE869C /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D39FA1621A83E0EC00EE869C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D39FA16B1A83E17800EE869C /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -1043,6 +1046,7 @@
 				E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */,
 				2F44FA171A9D425700FD20CC /* HashExtensions.swift */,
 				2F44FA1C1A9D460500FD20CC /* HexExtensions.swift */,
+				D39999A81AA01D65005AED21 /* KeyboardWatcher.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1769,6 +1773,7 @@
 				E4CD9F2D1A6DC91200318571 /* BrowserLocationView.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				0AE491A61A41C88C0046C724 /* BackForwardListViewController.swift in Sources */,
+				D39999A91AA01D65005AED21 /* KeyboardWatcher.swift in Sources */,
 				0BF48B5E1A96A77400A730CF /* TwoLineCell.swift in Sources */,
 				28CE83C41A1D1D3200576538 /* ClientPayload.swift in Sources */,
 				28CE83C21A1D1D3200576538 /* FxAClient.swift in Sources */,
@@ -1870,6 +1875,7 @@
 				28C077981A3B064000834FE5 /* CryptoTests.swift in Sources */,
 				59A687B4A05CC772FE7E5A09 /* SearchViewController.swift in Sources */,
 				59A680D1116F5BF6CCC9ED6F /* HistoryPanel.swift in Sources */,
+				D39999AA1AA01D65005AED21 /* KeyboardWatcher.swift in Sources */,
 				59A68BE25C476E8AD5B63E78 /* Panels.swift in Sources */,
 				59A687335CF58A8004B23508 /* BookmarksPanel.swift in Sources */,
 				59A68ACAB9DB4B3E04E5D1B7 /* ReaderPanel.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup a web server that serves us static content. Do this early so that it is ready when the UI is presented.
         setupWebServer()
 
+        // Start the keyboard watcher to monitor and cache keyboard state.
+        KeyboardWatcher.defaultWatcher.startObserving()
+
         profile = BrowserProfile(localName: "profile")
 
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -173,13 +173,13 @@ extension SearchViewController: UITableViewDataSource {
         return 0
     }
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 3
     }
 }
 
 extension SearchViewController: UITableViewDelegate {
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         var url: NSURL?
         if let currentSection = SearchListSection(rawValue: indexPath.section) {
             switch currentSection {

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -18,13 +18,12 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     private func onNewModel(model: BookmarksModel) {
         self.source = model
         dispatch_async(dispatch_get_main_queue()) {
-            self.refreshControl?.endRefreshing()
             self.tableView.reloadData()
         }
     }
 
     private func onModelFailure(e: Any) {
-        self.refreshControl?.endRefreshing()
+        println("Error: failed to get data: \(e)")
     }
 
     override func reloadData() {
@@ -49,11 +48,11 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         return cell
     }
 
-    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return NSLocalizedString("Recent Bookmarks", comment: "Header for bookmarks list")
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
         if let source = source {
             let bookmark = source.current[indexPath.row]

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -27,7 +27,6 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         let opts = QueryOptions()
         opts.sort = .LastVisit
         profile.history.get(opts, complete: { (data: Cursor) -> Void in
-            self.refreshControl?.endRefreshing()
             self.sectionOffsets = [Int: Int]()
             self.data = data
             self.tableView.reloadData()
@@ -51,7 +50,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         return cell
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let offset = sectionOffsets[indexPath.section]!
         if let site = data[indexPath.row + offset] as? Site {
             if let url = NSURL(string: site.url) {
@@ -63,11 +62,11 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     }
 
     // Functions that deal with showing header rows
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return NumSections
     }
 
-    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         switch section {
         case 0: return NSLocalizedString("Today", comment: "")
         case 1: return NSLocalizedString("Yesterday", comment: "")

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -10,7 +10,6 @@ class ReaderPanel: SiteTableViewController, HomePanel {
 
     override func reloadData() {
         profile.readingList.get { (cursor) -> Void in
-            self.refreshControl?.endRefreshing()
             self.data = cursor
             self.tableView.reloadData()
         }
@@ -25,7 +24,7 @@ class ReaderPanel: SiteTableViewController, HomePanel {
         return cell
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         if let readingListItem = data[indexPath.row] as? ReadingListItem {
             if let encodedURL = readingListItem.url.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet()) {
                 if let aboutReaderURL = NSURL(string: "about:reader?url=\(encodedURL)") {

--- a/Client/Frontend/Home/TabsPanel.swift
+++ b/Client/Frontend/Home/TabsPanel.swift
@@ -16,13 +16,12 @@ class TabsPanel: SiteTableViewController, HomePanel {
             .responseJSON { (request, response, data, error) in
                 self.tabsResponse = parseTabsResponse(data)
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.refreshControl?.endRefreshing()
                     self.tableView.reloadData()
                 }
         }
     }
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         if let r = tabsResponse {
             return r.clients.count
         } else {
@@ -67,7 +66,7 @@ class TabsPanel: SiteTableViewController, HomePanel {
         return view
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
         if let tab = tabsResponse?.clients[indexPath.section].tabs[indexPath.row] {
             UIApplication.sharedApplication().openURL(NSURL(string: tab.url)!)

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -51,7 +51,7 @@ private class SiteTableViewHeader : UITableViewHeaderFooterView {
 /**
  * Provides base shared functionality for site rows and headers.
  */
-class SiteTableViewController: UITableViewController {
+class SiteTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     private let CellIdentifier = "CellIdentifier"
     private let HeaderIdentifier = "HeaderIdentifier"
     var profile: Profile! {
@@ -60,17 +60,23 @@ class SiteTableViewController: UITableViewController {
         }
     }
     var data: Cursor = Cursor(status: .Success, msg: "No data set")
+    var tableView = UITableView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.addSubview(tableView)
+        tableView.snp_makeConstraints { make in
+            make.edges.equalTo(self.view)
+            return
+        }
+
+        tableView.delegate = self
+        tableView.dataSource = self
         tableView.registerClass(TwoLineCell.self, forCellReuseIdentifier: CellIdentifier)
         tableView.registerClass(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
 
         tableView.keyboardDismissMode = UIScrollViewKeyboardDismissMode.OnDrag
-
-        refreshControl = UIRefreshControl()
-        refreshControl?.addTarget(self, action: "reloadData", forControlEvents: UIControlEvents.ValueChanged)
     }
 
     func reloadData() {
@@ -79,24 +85,23 @@ class SiteTableViewController: UITableViewController {
         } else {
             self.tableView.reloadData()
         }
-        refreshControl?.endRefreshing()
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return data.count
     }
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         return tableView.dequeueReusableCellWithIdentifier(CellIdentifier) as UITableViewCell
         // Callers should override this to fill in the cell returned here
     }
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return tableView.dequeueReusableHeaderFooterViewWithIdentifier(HeaderIdentifier) as? UIView
         // Callers should override this to fill in the cell returned here
     }
 
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 25
     }
 }

--- a/Utils/KeyboardWatcher.swift
+++ b/Utils/KeyboardWatcher.swift
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Foundation
+
+/**
+ * The keyboard state at the time of notification.
+ */
+class KeyboardState {
+    let height: CGFloat
+    let animationDuration: Double
+    let animationCurve: UIViewAnimationCurve
+
+    private init(_ userInfo: [NSObject: AnyObject]) {
+        height = (userInfo[UIKeyboardFrameBeginUserInfoKey] as NSValue).CGRectValue().height
+        animationDuration = userInfo[UIKeyboardAnimationDurationUserInfoKey] as Double
+
+        // HACK: UIViewAnimationCurve doesn't expose the keyboard animation used (curveValue = 7),
+        // so UIViewAnimationCurve(rawValue: curveValue) returns nil. As a workaround, get a
+        // reference to an EaseIn curve, then change the underlying pointer data with that ref.
+        let curveValue = userInfo[UIKeyboardAnimationCurveUserInfoKey] as Int
+        animationCurve = UIViewAnimationCurve.EaseIn
+        NSNumber(integer: curveValue).getValue(&animationCurve)
+    }
+}
+
+protocol KeyboardWatcherDelegate: class {
+    func keyboardWatcher(keyboardWatcher: KeyboardWatcher, keyboardWillShowWithState state: KeyboardState)
+    func keyboardWatcher(keyboardWatcher: KeyboardWatcher, keyboardWillHideWithState state: KeyboardState)
+}
+
+/**
+ * Convenience class for observing keyboard state.
+ */
+class KeyboardWatcher: NSObject {
+    var keyboardHeight: CGFloat = 0
+
+    private var delegates = [WeakKeyboardDelegate]()
+
+    class var defaultWatcher: KeyboardWatcher {
+        struct Singleton {
+            static let instance = KeyboardWatcher()
+        }
+        return Singleton.instance
+    }
+
+    /**
+     * Starts monitoring the keyboard state.
+     */
+    func startObserving() {
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELkeyboardWillShow:", name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELkeyboardWillHide:", name: UIKeyboardWillHideNotification, object: nil)
+    }
+
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+
+    /**
+     * Adds a delegate to the watcher.
+     * Delegates are weakly held.
+     */
+    func addDelegate(delegate: KeyboardWatcherDelegate) {
+        for weakDelegate in delegates {
+            // Reuse any existing slots that have been deallocated.
+            if weakDelegate.delegate == nil {
+                weakDelegate.delegate = delegate
+                return
+            }
+        }
+
+        delegates.append(WeakKeyboardDelegate(delegate))
+    }
+
+    func SELkeyboardWillShow(notification: NSNotification) {
+        let keyboardState = KeyboardState(notification.userInfo!)
+        keyboardHeight = keyboardState.height
+
+        for weakDelegate in delegates {
+            weakDelegate.delegate?.keyboardWatcher(self, keyboardWillShowWithState: keyboardState)
+        }
+    }
+
+    func SELkeyboardWillHide(notification: NSNotification) {
+        let keyboardState = KeyboardState(notification.userInfo!)
+        keyboardHeight = 0
+
+        for weakDelegate in delegates {
+            weakDelegate.delegate?.keyboardWatcher(self, keyboardWillHideWithState: keyboardState)
+        }
+    }
+}
+
+private class WeakKeyboardDelegate {
+    weak var delegate: KeyboardWatcherDelegate?
+
+    init(_ delegate: KeyboardWatcherDelegate) {
+        self.delegate = delegate
+    }
+}


### PR DESCRIPTION
This one ended up being more of a timesink than expected. Lots of lessons learned here:

* `UITableViewController` is pretty limited, as we've been discussing over the past few days. The first commit here drops the `UITableViewController` subclassing in favor of a standard `UIViewController` with a `UITableView` subview.

* When the screen is larger than the full set of engines, I figured we'd want to center the set of buttons instead of having the list anchored to the bottom left. That turned out to be a bit tricky with autolayout, but I managed to get it working with some of the lesser used constraints (`greaterThanOrEqualTo` and `lessThanOrEqualTo` mixed with priorities).

* The only way to get the keyboard height is to add an observer to `NSNotificationCenter`, listening for `keyboardWillShow`/`keyboardWillHide`. But the keyboard is already showing when we add the `SearchViewController` since typing is what makes it appear, so that means the keyboard height must be known beforehand (since we won't get another notification). To manage this, I created a `KeyboardWatcher` utility class that anyone can hook into. A couple advantages:
  1. `KeyboardWatcher` always keeps track of the keyboard state, so we can just read the keyboard height when its needed without worrying about missed notifications.
  1. It contains a lot of the boilerplate for notification registration, reading the notification info, etc., so implementing a `KeyboardWatcherDelegate` should be more straightforward than dealing with `NSNotificationCenter` directly.

* Finally, getting the animation constants from the notification info was a bear. Seems like it should be straightforward since we can get the constant via `userInfo[UIKeyboardAnimationCurveUserInfoKey]`, except this animation isn't exposed, so calling `UIViewAnimationCurve(rawValue: value)` returns `nil`! To get the proper `UIViewAnimationCurve`, we therefore need to create a dummy curve, then operate on an unsafe pointer to that dummy’s reference to change its value.