### PR TITLE
Bug 1135981 - Search View Results Crash

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -196,7 +196,7 @@ extension SearchViewController: UITableViewDelegate {
                     url = NSURL(string: site.url)
                 }
             case .Search:
-                let engine = sortedEngines[indexPath.row - searchSuggestions.count]
+                let engine = sortedEngines[indexPath.row]
                 url = engine.searchURLForQuery(searchQuery)
             }
         }


### PR DESCRIPTION
Fixes crash for when a user taps on a recommended search engine in the search results. Removed offset adjustment for selecting which engine since UITableView's section's indexPaths start from 0 for every section.