### PR TITLE
Bug 1138711 - Remove query from search engine accessibility labels

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -108,7 +108,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate {
             engineButton.setImage(engine.image, forState: UIControlState.Normal)
             engineButton.layer.backgroundColor = UIColor.whiteColor().CGColor
             engineButton.addTarget(self, action: "SELdidSelectEngine:", forControlEvents: UIControlEvents.TouchUpInside)
-            engineButton.accessibilityLabel = NSString(format: NSLocalizedString("%@ search for %@", comment: "E.g. \"Google search for Mars\". Please keep the first \"%@\" (which contains the search engine name) as close to the beginning of the translated phrase as possible (it is best to have it as the very first word). This is because the phrase is an accessibility label and VoiceOver users need to hear the search engine name first as that is the key information in the whole phrase (they know the search term because they typed it and from previous rows of the table)."), engine.shortName, searchQuery)
+            engineButton.accessibilityLabel = NSString(format: NSLocalizedString("%@ search", comment: "Label for search engine buttons. The argument corresponds to the name of the search engine."), engine.shortName)
 
             searchEngineScrollViewContent.addSubview(engineButton)
             engineButton.snp_makeConstraints { make in


### PR DESCRIPTION
Currently, the search accessibility label for engines is broken. The label is `%@ search for %@`, where the first argument should correspond to the search engine name, and the second argument should correspond to the search query. Problem is, we don't update these labels every time the search query changes, so the query in the label is always blank (`<engine> search for `).

We could update the label every time the query changes, but an easier fix would be to just omit the query from the label altogether. Presumably, the user already knows what they're searching for by the time they go to these buttons.