### PR TITLE
Fixes 1132500 - Database abstraction layer should support Int64

### DIFF
--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -312,7 +312,7 @@ public class SDRow : SequenceType {
 
         switch type {
         case SQLITE_NULL, SQLITE_INTEGER:
-            ret = Int(sqlite3_column_int(stmt, i))
+            ret = NSNumber(longLong: sqlite3_column_int64(stmt, i))
         case SQLITE_TEXT:
             let text = UnsafePointer<Int8>(sqlite3_column_text(stmt, i))
             ret = String.fromCString(text)


### PR DESCRIPTION
This fix returns integers coming from SQLite as `Int64` values wrapped in an `NSNumber`. You can now retrieve integer values as follows:

```
// The current way we use now in the code
if let id = row["id"] as? Int {
    self.id = id
}

// If you need an Int64 value
if let lastModified = row["last_modified"] as? NSNumber {
    self.lastModified = lastModified.longLongValue
}
```
