### PR TITLE
1140556 - Adding an item crashes on 32 bit devices

### DIFF
--- a/Storage/Storage/ReadingList.swift
+++ b/Storage/Storage/ReadingList.swift
@@ -8,11 +8,11 @@ public class ReadingListItem {
     public var id: Int? = nil
     public var guid: String?
     public var contentStatus: Int = 0
-    public var clientLastModified: Int
-    public var lastModified: Int?
-    public var storedOn: Int?
-    public var addedOn: Int?
-    public var markedRead_on: Int?
+    public var clientLastModified: Int64
+    public var lastModified: Int64?
+    public var storedOn: Int64?
+    public var addedOn: Int64?
+    public var markedRead_on: Int64?
     public var isDeleted: Bool = false
     public var isArchived: Bool = false
     public var isUnread: Bool = true
@@ -33,7 +33,7 @@ public class ReadingListItem {
         self.title = title
         self.resolvedUrl = resolvedUrl
         self.resolvedTitle = resolvedTitle
-        self.clientLastModified = Int(NSDate().timeIntervalSince1970 * 1000.0)
+        self.clientLastModified = Int64(NSDate().timeIntervalSince1970 * 1000.0)
     }
 }
 

--- a/Storage/Storage/ReadingListTable.swift
+++ b/Storage/Storage/ReadingListTable.swift
@@ -34,7 +34,7 @@ class ReadingListTable<T>: GenericTable<ReadingListItem> {
 
     override func getInsertAndArgs(inout item: ReadingListItem) -> (String, [AnyObject?])? {
         var args = [AnyObject?]()
-        args.append(item.clientLastModified)
+        args.append(NSNumber(longLong: item.clientLastModified))
         args.append(item.url)
         args.append(item.title)
         args.append(item.resolvedUrl)
@@ -45,7 +45,7 @@ class ReadingListTable<T>: GenericTable<ReadingListItem> {
 
     override func getUpdateAndArgs(inout item: ReadingListItem) -> (String, [AnyObject?])? {
         var args = [AnyObject?]()
-        args.append(Int(NSDate().timeIntervalSince1970 * 1000.0))
+        args.append(NSNumber(longLong: Int64(NSDate().timeIntervalSince1970 * 1000.0)))
         args.append(item.url)
         args.append(item.title)
         args.append(item.resolvedUrl)
@@ -68,7 +68,9 @@ class ReadingListTable<T>: GenericTable<ReadingListItem> {
         return { row -> ReadingListItem in
             let item = ReadingListItem(url: row["url"] as String, title: row["title"] as? String)
             item.id = row["id"] as? Int
-            item.clientLastModified = row["client_last_modified"] as Int
+            if let n = row["client_last_modified"] as? NSNumber {
+                item.clientLastModified = n.longLongValue
+            }
             item.guid = row["guid"] as? String
             item.isDeleted = (row["is_deleted"] as Int) != 0
             item.isArchived = (row["is_archived"] as Int) != 0

--- a/Storage/StorageTests/TestReadingListTable.swift
+++ b/Storage/StorageTests/TestReadingListTable.swift
@@ -49,6 +49,7 @@ class TestReadingListTable: XCTestCase {
             for index in 0..<cursor.count {
                 if let item = cursor[index] as? ReadingListItem {
                     XCTAssertEqual(item.id!, insertedItems[countElements(insertedItems)-index-1].id!)
+                    XCTAssertEqual(item.clientLastModified, insertedItems[countElements(insertedItems)-index-1].clientLastModified)
                 } else {
                     XCTFail("Did not get a ReadingListItem back (nil or wrong type)")
                 }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -312,7 +312,7 @@ public class SDRow : SequenceType {
 
         switch type {
         case SQLITE_NULL, SQLITE_INTEGER:
-            ret = Int(sqlite3_column_int(stmt, i))
+            ret = NSNumber(longLong: sqlite3_column_int64(stmt, i))
         case SQLITE_TEXT:
             let text = UnsafePointer<Int8>(sqlite3_column_text(stmt, i))
             ret = String.fromCString(text)


### PR DESCRIPTION
This fixes a bug where adding items to your reading list crashes on 32 bit devices.

We were using the `Int` type to store the timestamp. The `Int` type is architecture dependend, so on our fancy 64 bit test phones this is all good, but on Mark's wimpy 32-bit iPod Touch, it wont fit because the timestamp is a 12 digit number that obviously does not fit in an `Int32`.

The primary reason for the crash is that the Swift runtime throws an assertion when we stuff `NSTimeInterval * 1000.0` into an `Int`:

> floating point value can not be converted to Int because it is greater than Int.max

The obvious solution here is to use Int64 of course. But there is a problem. The SQLite wrapper does not actually support 64 bit values. So that was first fixed with bug [https://bugzilla.mozilla.org/show_bug.cgi?id=1132500](1132500).

In the end all this patch does it change timestamp types to `Int64` and then in the database code wrap those in `NSNumber` instances.

And it adds a test to find out if timestamp values are properly stored and retrieved. Our CI builds now also run on both a 32 and 64 bit simulator.