### PR TITLE
Bug 1134802 - Reader pages should have titles

### DIFF
--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -11,6 +11,7 @@
     %READER-CSS%
   </style>
   <script type="text/javascript">var _firefox_ReaderPage = { style: %READER-STYLE%, webServerBase: "%WEBSERVER-BASE%" };</script>
+  <title>%READER-TITLE%</title>
 </head>
 
 <body>


### PR DESCRIPTION
This small patch simply adds a `<title>` to the reader view content. Now the title shows up correctly in History and on Tabs.