### PR TITLE
Bug 1130257 Change Print theme to Sepia

### DIFF
--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -73,6 +73,11 @@ body {
   color: #eeeeee;
 }
 
+.sepia {
+    background-color: #f0ece7;
+    color: #333333;
+}
+
 .sans-serif {
   font-family: sans-serif;
 }
@@ -234,6 +239,13 @@ body {
 .dark > .content a:hover,
 .dark > .content a:active {
   color: #00acff !important;
+}
+
+.sepia > .content a,
+.sepia > .content a:visited,
+.sepia > .content a:hover,
+.sepia > .content a:active {
+    color: #00acff !important;
 }
 
 .content * {

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -11,6 +11,7 @@
     %READER-CSS%
   </style>
   <script type="text/javascript">var _firefox_ReaderPage = { style: %READER-STYLE%, webServerBase: "%WEBSERVER-BASE%" };</script>
+  <title>%READER-TITLE%</title>
 </head>
 
 <body>

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -23,7 +23,7 @@ enum ReaderModeState: String {
 enum ReaderModeTheme: String {
     case Light = "light"
     case Dark = "dark"
-    case Print = "print"
+    case Sepia = "sepia"
 }
 
 enum ReaderModeFontType: String {

--- a/Client/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/Client/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -81,7 +81,7 @@ class ReaderModeStyleViewController: UIViewController {
         themeButtons = [
             ThemeButton(theme: ReaderModeTheme.Light),
             ThemeButton(theme: ReaderModeTheme.Dark),
-            ThemeButton(theme: ReaderModeTheme.Print)
+            ThemeButton(theme: ReaderModeTheme.Sepia)
         ]
 
         setupButtons(themeButtons, inRow: themeRow, action: "SELchangeTheme:")


### PR DESCRIPTION
This patch changes the Print theme to Sepia. This is a basic implementation that changes the option name to Sepia and does minimal CSS changes to include new colors.

We need to do a followup to bring the reader view CSS up to date with mobile or desktop. That work is not part of this bug.