### PR TITLE
Bug 1141598 - Reader mode should open full screen

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -662,11 +662,15 @@ extension BrowserViewController: ReaderModeDelegate, UIPopoverPresentationContro
         if tabManager.selectedTab == browser {
             println("DEBUG: New readerModeState: \(state.rawValue)")
             urlBar.updateReaderModeState(state)
+            if state == .Active {
+                hideToolbars(animated: true)
+            }
         }
     }
 
     func readerMode(readerMode: ReaderMode, didDisplayReaderizedContentForBrowser browser: Browser) {
         browser.showContent(animated: true)
+        hideToolbars(animated: true)
     }
 
     func SELshowReaderModeStyle(recognizer: UITapGestureRecognizer) {


### PR DESCRIPTION
This patch hides the browser chrome when you enter reader view via either the reader view button or by opening a link from the reading list panel.