### PR TITLE
Bug 1142222 - boolForKey returns false for undefined keys

### DIFF
--- a/ClientTests/ProfilePrefsTests.swift
+++ b/ClientTests/ProfilePrefsTests.swift
@@ -6,14 +6,32 @@ import Foundation
 import XCTest
 
 class TestProfilePrefs: ProfileTest {
+    override func setUp() {
+        withTestPrefs { prefs in
+            // TODO: Running these tests clears all of your browser prefs since
+            // we reuse the profile. We need a separate profile for testing.
+            prefs.clearAll()
+        }
+    }
+
     func withTestPrefs(callback: (prefs: ProfilePrefs) -> Void) {
         withTestProfile { profile in
             callback(prefs: NSUserDefaultsProfilePrefs(profile: profile))
         }
     }
 
+    func testClearPrefs() {
+            withTestPrefs { prefs in
+            prefs.setObject("foo", forKey: "bar")
+            XCTAssertEqual(prefs.stringForKey("bar")!, "foo")
+            prefs.clearAll()
+            XCTAssertNil(prefs.stringForKey("bar"))
+        }
+    }
+
     func testStringForKey() {
         withTestPrefs { prefs in
+            XCTAssertNil(prefs.stringForKey("key"))
             prefs.setObject("value", forKey: "key")
             XCTAssertEqual(prefs.stringForKey("key")!, "value")
             // Non-String values return nil.
@@ -24,6 +42,7 @@ class TestProfilePrefs: ProfileTest {
 
     func testBoolForKey() {
         withTestPrefs { prefs in
+            XCTAssertNil(prefs.boolForKey("key"))
             prefs.setObject(true, forKey: "key")
             XCTAssertEqual(prefs.boolForKey("key")!, true)
             prefs.setObject(false, forKey: "key")
@@ -33,14 +52,15 @@ class TestProfilePrefs: ProfileTest {
             prefs.setObject(1, forKey: "key")
             XCTAssertEqual(prefs.boolForKey("key")!, true)
             prefs.setObject("1", forKey: "key")
-            XCTAssertEqual(prefs.boolForKey("key")!, true)
+            XCTAssertNil(prefs.boolForKey("key"))
             prefs.setObject("x", forKey: "key")
-            XCTAssertEqual(prefs.boolForKey("key")!, false)
+            XCTAssertNil(prefs.boolForKey("key"))
         }
     }
 
     func testStringArrayForKey() {
         withTestPrefs { prefs in
+            XCTAssertNil(prefs.stringArrayForKey("key"))
             prefs.setObject(["value1", "value2"], forKey: "key")
             XCTAssertEqual(prefs.stringArrayForKey("key")!, ["value1", "value2"])
             // Non-[String] values return nil.

--- a/Providers/ProfilePrefs.swift
+++ b/Providers/ProfilePrefs.swift
@@ -80,7 +80,10 @@ public class NSUserDefaultsProfilePrefs : ProfilePrefs {
     }
 
     public func boolForKey(defaultName: String) -> Bool? {
-        return userDefaults.boolForKey(qualifyKey(defaultName))
+        // boolForKey just returns false if the key doesn't exist. We need to
+        // distinguish between false and non-existent keys, so use objectForKey
+        // and cast the result instead.
+        return userDefaults.objectForKey(qualifyKey(defaultName)) as? Bool
     }
 
     public func stringArrayForKey(defaultName: String) -> [String]? {

--- a/Providers/ProfilePrefs.swift
+++ b/Providers/ProfilePrefs.swift
@@ -12,6 +12,7 @@ public protocol ProfilePrefs {
     func arrayForKey(defaultName: String) -> [AnyObject]?
     func dictionaryForKey(defaultName: String) -> [String : AnyObject]?
     func removeObjectForKey(defaultName: String)
+    func clearAll()
 }
 
 public class MockProfilePrefs : ProfilePrefs {
@@ -50,6 +51,10 @@ public class MockProfilePrefs : ProfilePrefs {
 
     public func removeObjectForKey(defaultName: String) {
         self.things[defaultName] = nil
+    }
+
+    public func clearAll() {
+        self.things.removeAllObjects()
     }
 }
 
@@ -99,6 +104,14 @@ public class NSUserDefaultsProfilePrefs : ProfilePrefs {
     }
 
     public func removeObjectForKey(defaultName: String) {
-        userDefaults.removeObjectForKey(qualifyKey(defaultName));
+        userDefaults.removeObjectForKey(qualifyKey(defaultName))
+    }
+
+    public func clearAll() {
+        // TODO: userDefaults.removePersistentDomainForName() has no effect for app group suites.
+        // iOS Bug? Iterate and remove each manually for now.
+        for key in userDefaults.dictionaryRepresentation().keys {
+            userDefaults.removeObjectForKey(key as NSString)
+        }
     }
 }


### PR DESCRIPTION
Working on the search suggestions opt in, I found the following line was always false:
```
self.shouldShowSearchSuggestionsOptIn = prefs.boolForKey(ShowSearchSuggestionsOptIn) ?? true
```
Turns out `userDefaults.boolForKey()` never returns nil when the pref isn't defined, returning false instead.

I then tried to add a simple nil assertion for undefined prefs, clearing prefs before each run in ProfilePrefsTests. That's where things got interesting since, for some reason, `userDefaults.removePersistentDomainForName()` simply has no effect for our app group. The workaround of manually removing each key works, but it's still unclear whether this is an iOS bug or our own.