### PR TITLE
Bug 1134799 - Blank top site entries for pages with no titles

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -197,7 +197,7 @@ class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         // Cells for the top site thumbnails.
         if indexPath.item < 6 {
             let cell = collectionView.dequeueReusableCellWithReuseIdentifier(ThumbnailIdentifier, forIndexPath: indexPath) as ThumbnailCell
-            cell.textLabel.text = site.title
+            cell.textLabel.text = site.title.isEmpty ? site.url : site.title
             cell.imageView.image = UIImage(named: DefaultImage)
             cell.imageView.contentMode = UIViewContentMode.Center
             return cell
@@ -205,7 +205,7 @@ class TopSitesDataSource: NSObject, UICollectionViewDataSource {
 
         // Cells for the remainder of the top sites list.
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(RowIdentifier, forIndexPath: indexPath) as TopSitesRow
-        cell.textLabel.text = site.title
+        cell.textLabel.text = site.title.isEmpty ? site.url : site.title
         cell.descriptionLabel.text = site.url
         if let icon = site.icon? {
             cell.imageView.sd_setImageWithURL(NSURL(string: icon.url)!)

--- a/Storage/Storage/Bookmarks.swift
+++ b/Storage/Storage/Bookmarks.swift
@@ -172,12 +172,6 @@ public class MemoryBookmarkFolder: BookmarkFolder, SequenceType {
         return UIImage(named: "bookmark_folder_closed")!
     }
 
-    init(guid: String, name: String, children: [BookmarkNode]) {
-        self.guid = guid
-        self.title = name
-        self.children = children
-    }
-
     public var count: Int {
         return children.count
     }
@@ -200,7 +194,7 @@ public class MemoryBookmarkFolder: BookmarkFolder, SequenceType {
         if (items.isEmpty) {
             return self
         }
-        return MemoryBookmarkFolder(guid: self.guid, name: self.title, children: self.children + items)
+        return MemoryBookmarkFolder(guid: self.guid, title: self.title, children: self.children + items)
     }
 }
 
@@ -240,12 +234,12 @@ public class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination
             res.append(BookmarkItem(guid: Bytes.generateGUID(), title: "Title \(i)", url: "http://www.example.com/\(i)"))
         }
 
-        mobile = MemoryBookmarkFolder(guid: BookmarkRoots.MOBILE_FOLDER_GUID, name: "Mobile Bookmarks", children: res)
+        mobile = MemoryBookmarkFolder(guid: BookmarkRoots.MOBILE_FOLDER_GUID, title: "Mobile Bookmarks", children: res)
 
-        unsorted = MemoryBookmarkFolder(guid: BookmarkRoots.UNFILED_FOLDER_GUID, name: "Unsorted Bookmarks", children: [])
+        unsorted = MemoryBookmarkFolder(guid: BookmarkRoots.UNFILED_FOLDER_GUID, title: "Unsorted Bookmarks", children: [])
         sink = MemoryBookmarksSink()
 
-        root = MemoryBookmarkFolder(guid: BookmarkRoots.PLACES_FOLDER_GUID, name: "Root", children: [mobile, unsorted])
+        root = MemoryBookmarkFolder(guid: BookmarkRoots.PLACES_FOLDER_GUID, title: "Root", children: [mobile, unsorted])
     }
 
     public func modelForFolder(folder: BookmarkFolder, success: (BookmarksModel) -> (), failure: (Any) -> ()) {
@@ -281,7 +275,7 @@ public class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination
     * This class could return the full data immediately. We don't, because real DB-backed code won't.
     */
     public var nullModel: BookmarksModel {
-        let f = MemoryBookmarkFolder(guid: BookmarkRoots.PLACES_FOLDER_GUID, name: "Root", children: [])
+        let f = MemoryBookmarkFolder(guid: BookmarkRoots.PLACES_FOLDER_GUID, title: "Root", children: [])
         return BookmarksModel(modelFactory: self, root: f)
     }
 

--- a/Storage/Storage/BookmarksSqlite.swift
+++ b/Storage/Storage/BookmarksSqlite.swift
@@ -165,11 +165,7 @@ public class BookmarksSqliteFactory : BookmarksModelFactory, ShareToDestination 
         var err: NSError? = nil
         let inserted = db.insert(&err, callback: { (connection, err) -> Int in
             var bookmark: BookmarkItem!
-            if let title = item.title {
-                bookmark = BookmarkItem(guid: Bytes.generateGUID(), title: title, url: item.url)
-            } else {
-                bookmark = BookmarkItem(guid: Bytes.generateGUID(), title: item.url, url: item.url)
-            }
+            bookmark = BookmarkItem(guid: Bytes.generateGUID(), title: item.title ?? "", url: item.url)
 
             return self.table.insert(connection, item: bookmark, err: &err)
         })


### PR DESCRIPTION
First commit is cleanup.

Second commit changes BookmarkItem to use an empty string for sites with no title instead of the URL. I think this is what we agreed on, right? That way, the UI can fall back to the URL (or something else) when needed. Otherwise, there's no way to distinguish between bookmarks that have no title and bookmarks whose title is their URL.

Last commit adds one such UI fallback to the top sites panel.