### PR TITLE
Bug 1137279 - iOS Status Bar Quick Scroll

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -457,6 +457,10 @@ extension BrowserViewController: UIScrollViewDelegate {
         }
     }
 
+    func scrollViewDidScrollToTop(scrollView: UIScrollView) {
+        showToolbars(animated: true)
+    }
+
     private func hideToolbars(#animated: Bool) {
         UIView.animateWithDuration(animated ? 0.5 : 0.0, animations: { () -> Void in
             self.scrollUrlBar(CGFloat(-1*MAXFLOAT))


### PR DESCRIPTION
This fixes an issue where tapping the iOS status bar to quick scroll the web view to the top does not show the address bar or the bottom tool bar. An additional pull down gesture is needed to reveal these, and it is fairly glitchy when it does appear and requires a pretty forceful pull down gesture.

This patch uses scrollViewDidScrollToTop rather than scrollViewShouldScrollToTop so that the bars only appear once the scroll has completed. Animation is enabled to make it a nicer experience for the user.

(this is my first pull request on this project - please be gentle :)