### PR TITLE
Bug 1143957 - Top sites polish and fixes

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -408,7 +408,7 @@ extension SearchViewController: UITableViewDataSource {
         }
     }
 
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
         if let currentSection = SearchListSection(rawValue: indexPath.section) {
             switch currentSection {
             case .SearchSuggestions:
@@ -417,7 +417,7 @@ extension SearchViewController: UITableViewDataSource {
                 suggestionCell.layoutIfNeeded()
                 return suggestionCell.frame.height
             default:
-                return tableView.rowHeight
+                return super.tableView(tableView, heightForRowAtIndexPath: indexPath)
             }
         }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -455,7 +455,7 @@ private protocol SuggestionCellDelegate: class {
 /**
  * Cell that wraps a list of search suggestion buttons.
  */
-private class SuggestionCell: TwoLineCell {
+private class SuggestionCell: UITableViewCell {
     weak var delegate: SuggestionCellDelegate?
     let container = UIView()
 
@@ -509,7 +509,7 @@ private class SuggestionCell: TwoLineCell {
         super.layoutSubviews()
 
         // The left bounds of the suggestions align with where text would be displayed.
-        let textLeft = textLabel!.frame.origin.x
+        let textLeft: CGFloat = 44
 
         // The maximum width of the container, after which suggestions will wrap to the next line.
         let maxWidth = contentView.frame.width
@@ -558,6 +558,9 @@ private class SuggestionCell: TwoLineCell {
         frame.size.height = height + 2 * SuggestionCellVerticalPadding
         contentView.frame = frame
         container.frame = frame
+
+        let imageY = (frame.size.height - 24) / 2
+        imageView!.frame = CGRectMake(10, imageY, 24, 24)
     }
 }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -14,9 +14,10 @@ private let DefaultImage = "defaultFavicon"
 
 class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate?
-    var collection: UICollectionView!
-    var dataSource: TopSitesDataSource!
-    let layout = TopSitesLayout()
+
+    private var collection: UICollectionView!
+    private var dataSource: TopSitesDataSource!
+    private let layout = TopSitesLayout()
 
     var profile: Profile! {
         didSet {
@@ -59,19 +60,19 @@ class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
     }
 }
 
-class TopSitesLayout: UICollectionViewLayout {
-    let ToolbarHeight: CGFloat = 44
-    let StatusBarHeight: CGFloat = 20
-    let RowHeight: CGFloat = 58
-    let AspectRatio: CGFloat = 0.7
+private class TopSitesLayout: UICollectionViewLayout {
+    private let ToolbarHeight: CGFloat = 44
+    private let StatusBarHeight: CGFloat = 20
+    private let RowHeight: CGFloat = 58
+    private let AspectRatio: CGFloat = 0.7
 
-    var numRows: CGFloat = 3
-    var numCols: CGFloat = 2
-    var width: CGFloat { return self.collectionView?.frame.width ?? 0 }
-    var thumbnailWidth: CGFloat { return CGFloat(width / numCols) }
-    var thumbnailHeight: CGFloat { return thumbnailWidth * AspectRatio }
+    private var numRows: CGFloat = 3
+    private var numCols: CGFloat = 2
+    private var width: CGFloat { return self.collectionView?.frame.width ?? 0 }
+    private var thumbnailWidth: CGFloat { return CGFloat(width / numCols) }
+    private var thumbnailHeight: CGFloat { return thumbnailWidth * AspectRatio }
 
-    var count: Int {
+    private var count: Int {
         if let dataSource = self.collectionView?.dataSource as? TopSitesDataSource {
             return dataSource.data.count
         }
@@ -87,7 +88,7 @@ class TopSitesLayout: UICollectionViewLayout {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setupForOrientation(orientation: UIInterfaceOrientation) {
+    private func setupForOrientation(orientation: UIInterfaceOrientation) {
         if orientation.isLandscape {
             numRows = 2
             numCols = 3
@@ -180,7 +181,7 @@ class TopSitesLayout: UICollectionViewLayout {
     }
 }
 
-class TopSitesDataSource: NSObject, UICollectionViewDataSource {
+private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
     var data: Cursor
 
     init(data: Cursor) {

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -43,7 +43,7 @@ class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
         collection.delegate = self
         collection.dataSource = dataSource
         collection.registerClass(ThumbnailCell.self, forCellWithReuseIdentifier: ThumbnailIdentifier)
-        collection.registerClass(TopSitesRow.self, forCellWithReuseIdentifier: RowIdentifier)
+        collection.registerClass(TwoLineCollectionViewCell.self, forCellWithReuseIdentifier: RowIdentifier)
         collection.keyboardDismissMode = .OnDrag
         view.addSubview(collection)
         collection.snp_makeConstraints { make in
@@ -62,7 +62,7 @@ class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
 class TopSitesLayout: UICollectionViewLayout {
     let ToolbarHeight: CGFloat = 44
     let StatusBarHeight: CGFloat = 20
-    let RowHeight: CGFloat = 70
+    let RowHeight: CGFloat = 58
     let AspectRatio: CGFloat = 0.7
 
     var numRows: CGFloat = 3
@@ -204,9 +204,9 @@ class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         }
 
         // Cells for the remainder of the top sites list.
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(RowIdentifier, forIndexPath: indexPath) as TopSitesRow
+        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(RowIdentifier, forIndexPath: indexPath) as TwoLineCollectionViewCell
         cell.textLabel.text = site.title.isEmpty ? site.url : site.title
-        cell.descriptionLabel.text = site.url
+        cell.detailTextLabel.text = site.url
         if let icon = site.icon? {
             cell.imageView.sd_setImageWithURL(NSURL(string: icon.url)!)
         } else {
@@ -227,60 +227,10 @@ private class TopSitesSeparator: UICollectionReusableView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = UIColor.lightGrayColor()
+        self.backgroundColor = SeparatorColor
     }
 
     required init(coder aDecoder: NSCoder) {
         assertionFailure("Not implemented")
-    }
-}
-
-// TODO: This should reuse TwoLineCell somehow. Maybe change TwoLineCell to a generic
-// UIView, then set it as the contentView so it can be used with any cell type.
-private class TopSitesRow: UICollectionViewCell {
-    let textLabel = UILabel()
-    let descriptionLabel = UILabel()
-    let imageView = UIImageView()
-    let margin = 10
-
-    override init() {
-        super.init()
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-
-        contentView.addSubview(textLabel)
-        contentView.addSubview(descriptionLabel)
-        contentView.addSubview(imageView)
-
-        imageView.contentMode = .ScaleAspectFill
-        imageView.image = UIImage(named: "defaultFavicon")
-        imageView.snp_makeConstraints({ make in
-            make.top.left.equalTo(self.contentView).offset(self.margin)
-            make.bottom.equalTo(self.contentView).offset(-self.margin)
-            make.width.equalTo(self.contentView.snp_height).offset(-2*self.margin)
-        })
-
-        textLabel.font = UIFont(name: "FiraSans-SemiBold", size: 13)
-        textLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkGrayColor()
-        textLabel.snp_makeConstraints({ make in
-            make.top.equalTo(self.imageView.snp_top)
-            make.right.equalTo(self.contentView).offset(-self.margin)
-            make.left.equalTo(self.imageView.snp_right).offset(self.margin)
-        })
-
-        descriptionLabel.font = UIFont(name: "FiraSans-SemiBold", size: 13)
-        descriptionLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.lightTextColor() : UIColor.lightGrayColor()
-        descriptionLabel.snp_makeConstraints({ make in
-            make.top.equalTo(self.textLabel.snp_bottom)
-            make.right.equalTo(self.contentView).offset(-self.margin)
-            make.left.equalTo(self.imageView.snp_right).offset(self.margin)
-        })
-
-    }
-
-    required init(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -73,7 +73,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
 
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.registerClass(TwoLineCell.self, forCellReuseIdentifier: CellIdentifier)
+        tableView.registerClass(TwoLineTableViewCell.self, forCellReuseIdentifier: CellIdentifier)
         tableView.registerClass(SiteTableViewHeader.self, forHeaderFooterViewReuseIdentifier: HeaderIdentifier)
         tableView.layoutMargins = UIEdgeInsetsZero
         tableView.keyboardDismissMode = UIScrollViewKeyboardDismissMode.OnDrag
@@ -103,5 +103,9 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
 
     func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 25
+    }
+
+    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        return 58
     }
 }

--- a/Client/Frontend/Widgets/ThumbnailCell.swift
+++ b/Client/Frontend/Widgets/ThumbnailCell.swift
@@ -4,10 +4,15 @@
 
 import UIKit
 
+private let BorderColor = UIColor(rgb: 0xeeeeee)
+private let LabelFont = UIFont(name: "FiraSans-Regular", size: 11)
+private let LabelColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkGrayColor()
+private let CellInsets = UIEdgeInsetsMake(8, 8, 8, 8)
+private let TextMargin = 5
+
 class ThumbnailCell: UICollectionViewCell {
     let textLabel = UILabel()
     let imageView = UIImageView()
-    let margin = 10
 
     override init() {
         super.init()
@@ -19,20 +24,20 @@ class ThumbnailCell: UICollectionViewCell {
         contentView.addSubview(textLabel)
         contentView.addSubview(imageView)
 
-        textLabel.font = UIFont(name: "FiraSans-SemiBold", size: 13)
-        textLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkGrayColor()
-        textLabel.snp_makeConstraints({ make in
-            make.bottom.right.equalTo(self.contentView).offset(-self.margin)
-            make.left.equalTo(self.contentView).offset(self.margin)
-            make.height.equalTo(26)
+        imageView.layer.borderColor = BorderColor.CGColor
+        imageView.layer.borderWidth = 2
+        imageView.layer.cornerRadius = 3
+        imageView.snp_makeConstraints({ make in
+            make.top.left.right.equalTo(self.contentView).insets(CellInsets)
+            return
         })
 
-        imageView.layer.borderColor = UIColor.lightGrayColor().CGColor
-        imageView.layer.borderWidth = 1
-        imageView.snp_makeConstraints({ make in
-            make.top.equalTo(self.contentView).offset(self.margin)
-            make.left.right.equalTo(self.textLabel)
-            make.bottom.equalTo(self.textLabel.snp_top)
+        textLabel.setContentHuggingPriority(1000, forAxis: UILayoutConstraintAxis.Vertical)
+        textLabel.font = LabelFont
+        textLabel.textColor = LabelColor
+        textLabel.snp_makeConstraints({ make in
+            make.top.equalTo(self.imageView.snp_bottom).offset(TextMargin)
+            make.left.right.bottom.equalTo(self.contentView).insets(CellInsets)
         })
     }
 

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -4,41 +4,97 @@
 
 import UIKit
 
-private let IconSize: CGFloat = 28
-private let Margin: CGFloat = 8
+private let ImageSize: CGFloat = 24
+private let ImageMargin: CGFloat = 10
+private let TextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor(rgb: 0x333333)
+private let DetailTextColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGrayColor() : UIColor.grayColor()
 
-// UITableViewController doesn't let us specify a style for recycling views. We override the default style here.
-class TwoLineCell : UITableViewCell {
+class TwoLineTableViewCell: UITableViewCell {
+    private let twoLineHelper: TwoLineCellHelper!
+
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-        // ignore the style argument, use our own to override
         super.init(style: UITableViewCellStyle.Subtitle, reuseIdentifier: reuseIdentifier)
 
-        textLabel?.font = UIFont(name: "FiraSans-SemiBold", size: 13)
-        textLabel?.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : UIColor.darkGrayColor()
+        twoLineHelper = TwoLineCellHelper(container: self, textLabel: textLabel!, detailTextLabel: detailTextLabel!, imageView: imageView!)
+
         indentationWidth = 0
-
-        detailTextLabel?.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.darkGrayColor() : UIColor.lightGrayColor()
-
-        imageView?.contentMode = .ScaleAspectFill
-
         layoutMargins = UIEdgeInsetsZero
-        separatorInset = UIEdgeInsetsMake(0, IconSize + 2 * Margin, 0, 0)
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        let height: CGFloat = self.frame.height
-        let textLeft = IconSize + 2 * Margin
-
-        imageView?.frame = CGRectMake(Margin, Margin, IconSize, IconSize)
-        textLabel?.frame = CGRectMake(textLeft, textLabel!.frame.origin.y,
-            self.frame.width - textLeft - Margin, textLabel!.frame.height)
-        detailTextLabel?.frame = CGRectMake(textLeft, detailTextLabel!.frame.origin.y,
-            self.frame.width - textLeft - Margin, detailTextLabel!.frame.height)
+        separatorInset = UIEdgeInsetsMake(0, ImageSize + 2 * ImageMargin, 0, 0)
     }
 
     required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        twoLineHelper.layoutSubviews()
+    }
+}
+
+class TwoLineCollectionViewCell: UICollectionViewCell {
+    private let twoLineHelper: TwoLineCellHelper!
+    let textLabel = UILabel()
+    let detailTextLabel = UILabel()
+    let imageView = UIImageView()
+
+    override init() {
+        super.init()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        contentView.addSubview(textLabel)
+        contentView.addSubview(detailTextLabel)
+        contentView.addSubview(imageView)
+
+        twoLineHelper = TwoLineCellHelper(container: self, textLabel: textLabel, detailTextLabel: detailTextLabel, imageView: imageView)
+
+        layoutMargins = UIEdgeInsetsZero
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        twoLineHelper.layoutSubviews()
+    }
+}
+
+private class TwoLineCellHelper {
+    private let container: UIView
+    let textLabel: UILabel
+    let detailTextLabel: UILabel
+    let imageView: UIImageView
+
+    init(container: UIView, textLabel: UILabel, detailTextLabel: UILabel, imageView: UIImageView) {
+        self.container = container
+        self.textLabel = textLabel
+        self.detailTextLabel = detailTextLabel
+        self.imageView = imageView
+
+        textLabel.font = UIFont(name: "FiraSans-Regular", size: 13)
+        textLabel.textColor = TextColor
+
+        detailTextLabel.font = UIFont(name: "FiraSans-Regular", size: 10)
+        detailTextLabel.textColor = DetailTextColor
+
+        imageView.contentMode = .ScaleAspectFill
+    }
+
+    func layoutSubviews() {
+        let height = container.frame.height
+        let textLeft = ImageSize + 2 * ImageMargin
+        let textLabelHeight = textLabel.intrinsicContentSize().height
+        let detailTextLabelHeight = detailTextLabel.intrinsicContentSize().height
+        let contentHeight = textLabelHeight + detailTextLabelHeight + 1
+        imageView.frame = CGRectMake(ImageMargin, (height - ImageSize) / 2, ImageSize, ImageSize)
+        textLabel.frame = CGRectMake(textLeft, (height - contentHeight) / 2,
+            container.frame.width - textLeft - ImageMargin, textLabelHeight)
+        detailTextLabel.frame = CGRectMake(textLeft, textLabel.frame.maxY + 1,
+            container.frame.width - textLeft - ImageMargin, detailTextLabelHeight)
     }
 }


### PR DESCRIPTION
First commit makes SuggestionCell extend UITableViewCell directly instead of TwoLineCell. The SuggestionCell doesn't even show the two lines of the TwoLineCell, so it doesn't make sense to use it as the parent class.

Second commit creates `TwoLineTableViewCell` and `TwoLineCollectionViewCell` classes, using them in top sites and site tables. The existing `TwoLineCell` code was moved into `TwoLineCellHelper` so that we can share the implementation between cell types.

Third commit is minor cleanup.

Fourth patch fixes all the rest of the top sites bugs. Lots of layout fun! Also includes code cleanup/comments since that code was a bit difficult to read.