### PR TITLE
Bug 1144871 - Improve FileAccessor API

### DIFF
--- a/ClientTests/TestFavicons.swift
+++ b/ClientTests/TestFavicons.swift
@@ -65,7 +65,7 @@ class TestFavicons : ProfileTest {
 
             // TODO: Use the local file server for URLs here, so that we can test download/save/delete of local storage
             self.clear(h)
-            profile.files.remove("browser.db", basePath: nil)
+            profile.files.remove("browser.db", error: nil)
         }
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -5,70 +5,13 @@
 import Foundation
 import Storage
 
-class ProfileFileAccessor : FileAccessor {
-    let profile: Profile
+class ProfileFileAccessor: FileAccessor {
     init(profile: Profile) {
-        self.profile = profile
-    }
-
-    private func createDir(path: String) -> String? {
-        if !NSFileManager.defaultManager().fileExistsAtPath(path) {
-            var err: NSError? = nil
-            if !NSFileManager.defaultManager().createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil, error: &err) {
-                println("Error creating profile folder at \(path): \(err?.localizedDescription)")
-                return nil
-            }
-        }
-        return path
-    }
-
-    func getDir(name: String?, basePath: String? = nil) -> String? {
-        var path = basePath
-        if path == nil {
-        	path = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
-            path = createDir(path!.stringByAppendingPathComponent(profileDirName))
-
-        }
-
-        if let name = name {
-            path = createDir(path!.stringByAppendingPathComponent(name))
-        }
-        return path!
-    }
-
-    func move(src: String, srcBasePath: String? = nil, dest: String, destBasePath: String? = nil) -> Bool {
-        if let f = self.get(src, basePath: nil) {
-            if let f2 = self.get(dest) {
-                return NSFileManager.defaultManager().moveItemAtPath(f, toPath: f2, error: nil)
-            }
-        }
-
-        return false
-    }
-
-    private var profileDirName: String {
-        return "profile.\(profile.localName())"
-    }
-
-    func get(filename: String, basePath: String? = nil) -> String? {
-        return getDir(nil, basePath: basePath)?.stringByAppendingPathComponent(filename)
-    }
-
-
-    func remove(filename: String, basePath: String? = nil) {
-        let fileManager = NSFileManager.defaultManager()
-        if var file = self.get(filename) {
-            fileManager.removeItemAtPath(file, error: nil)
-        }
-    }
-
-    func exists(filename: String, basePath: String? = nil) -> Bool {
-        if var file = self.get(filename, basePath: basePath) {
-            return NSFileManager.defaultManager().fileExistsAtPath(file)
-        }
-        return false
-    }
-}
+        let profileDirName = "profile.\(profile.localName())"
+        let basePath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
+        let profilePath = basePath!.stringByAppendingPathComponent(profileDirName)
+        super.init(rootPath: profilePath)
+    }}
 
 /**
  * A Profile manages access to the user's data.

--- a/Storage/Storage/SQL/BrowserDB.swift
+++ b/Storage/Storage/SQL/BrowserDB.swift
@@ -52,7 +52,7 @@ class BrowserDB {
 
     init?(files: FileAccessor) {
         self.files = files
-        db = SwiftData(filename: files.get(FileName, basePath: nil)!)
+        db = SwiftData(filename: files.getAndCreateAbsoluteDir(error: nil)!.stringByAppendingPathComponent(FileName))
         self.schemaTable = SchemaTable()
         self.createOrUpdate(self.schemaTable)
     }
@@ -126,7 +126,7 @@ class BrowserDB {
             // attached and expecting a working DB, but at least we should be able to restart
             if !success {
                 println("Couldn't create or update \(table.name)")
-                self.files.move(self.FileName, srcBasePath: nil, dest: "\(self.FileName).bak", destBasePath: nil)
+                self.files.move(self.FileName, toRelativePath: "\(self.FileName).bak", error: nil)
                 success = self.createTable(connection, table: table)
             }
             return success

--- a/Storage/Storage/SQL/SQLFavicons.swift
+++ b/Storage/Storage/SQL/SQLFavicons.swift
@@ -29,7 +29,7 @@ public class SQLiteFavicons : Favicons {
             return self.table.delete(connection, item: nil, err: &err)
         }
 
-        files.remove("favicons", basePath: nil)
+        files.remove("favicons", error: nil)
 
         dispatch_async(dispatch_get_main_queue()) {
             complete?(success: err == nil)


### PR DESCRIPTION
There are several quirks with our `FileAccessor`/`ProfileFileAccessor` implementations:
* `basePath` is an unnecessary (and unused) parameter in several methods, where we fall back to the profile directory. If we pass in another `basePath`, the operations won't even happen inside of the profile, which I'd argue shouldn't happen in `ProfileFileAccessor`.
* Errors are swallowed up. We can forward an `NSErrorPointer` so the caller decides what to do with it.
* A number of methods have some unexpected side effects. For example, `remove()`, `get()`, and `exists()` will all create directories if the directory doesn't exist.

As part of the refactoring, I changed `FileAccessor` to a class instead of a protocol since most of the operations are not profile-specific. `FileAccessor` is now a more well-defined "accessor" that acts on paths relative to its root.