### PR TITLE
Fixes 1144511 - Serve reader view content via the built-in web server

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -252,7 +252,12 @@
 		E483C0541AB7716C004A79A7 /* KeysPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28CE83BD1A1D1D3200576538 /* KeysPayload.swift */; };
 		E4A888161A95679500CDC337 /* FxA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; };
 		E4A888171A95679500CDC337 /* FxA.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */; };
+		E4A960241ABB9D500069AD6F /* ReaderModeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */; };
 		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
+		E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */; };
+		E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */; };
+		E4B423DE1ABA0436007E66C8 /* ReaderModeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */; };
 		E4B7B7611A793CF20022C5E0 /* CharisSILB.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */; };
 		E4B7B7621A793CF20022C5E0 /* CharisSILBI.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B73B1A793CF20022C5E0 /* CharisSILBI.ttf */; };
 		E4B7B7631A793CF20022C5E0 /* CharisSILI.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B73C1A793CF20022C5E0 /* CharisSILI.ttf */; };
@@ -762,6 +767,9 @@
 		E4988B571A9B95FF008B8B92 /* FennecNightly.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = FennecNightly.entitlements; sourceTree = "<group>"; };
 		E4988B6E1A9B964B008B8B92 /* FennecNightly.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = FennecNightly.entitlements; sourceTree = "<group>"; };
 		E4988B6F1A9B965A008B8B92 /* FennecNightly.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = FennecNightly.entitlements; sourceTree = "<group>"; };
+		E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeUtils.swift; sourceTree = "<group>"; };
+		E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeCache.swift; sourceTree = "<group>"; };
+		E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeHandlers.swift; sourceTree = "<group>"; };
 		E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILB.ttf; sourceTree = "<group>"; };
 		E4B7B73B1A793CF20022C5E0 /* CharisSILBI.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILBI.ttf; sourceTree = "<group>"; };
 		E4B7B73C1A793CF20022C5E0 /* CharisSILI.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILI.ttf; sourceTree = "<group>"; };
@@ -1382,6 +1390,9 @@
 			children = (
 				F84B21F61A0910F600AAB793 /* Readability.js */,
 				E4CD9E901A6897FB00318571 /* ReaderMode.swift */,
+				E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */,
+				E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */,
+				E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */,
 				E4CD9E991A68980A00318571 /* ReaderMode.js */,
 				E4CD9F531A71506400318571 /* Reader.html */,
 				E4CD9F5A1A71506C00318571 /* Reader.css */,
@@ -2054,6 +2065,8 @@
 				2F9990461AA51F5A0063E75D /* HexExtensions.swift in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				2F1BDFA11A85240400213B54 /* FirefoxAccountState.swift in Sources */,
+				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
+				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				28CE83C51A1D1D3200576538 /* EncryptedRecord.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
@@ -2079,6 +2092,7 @@
 				0B1C05D71A798B1F004C78B0 /* UIImageViewAligned.m in Sources */,
 				D34DC8581A16C40C00D49B7B /* RestAPI.swift in Sources */,
 				0BD19A651A2530840084FBA7 /* Locking.swift in Sources */,
+				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
@@ -2140,9 +2154,11 @@
 				E42475E31AB73B9B00B23D33 /* SWTableViewCell.m in Sources */,
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				E483C0541AB7716C004A79A7 /* KeysPayload.swift in Sources */,
+				E4A960241ABB9D500069AD6F /* ReaderModeUtils.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
 				2F34452E1AB247A100FD9731 /* TokenServerClient.swift in Sources */,
+				E4B423DE1ABA0436007E66C8 /* ReaderModeCache.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1D1A9D460500FD20CC /* HexExtensions.swift in Sources */,
 				28FEEE1E1AAFF116007FA476 /* EncryptedRecord.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -85,10 +85,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func setupWebServer() {
         let server = WebServer.sharedInstance
-        // Register our fonts, which we want to expose to web content that we present in the WebView
-        server.registerMainBundleResourcesOfType("ttf", module: "fonts")
-        // TODO: In the future let other modules register specific resources here. Unfortunately you cannot add
-        // more handlers after start() has been called, so we need to organize it all here at app startup time.
+        ReaderModeHandlers.register(server)
         server.start()
     }
 }

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -21,6 +21,11 @@ class WebServer {
         return server.running || server.startWithPort(0, bonjourName: nil)
     }
 
+    /// Convenience method to register a dynamic handler. Will be mounted at $base/$module/$resource
+    func registerHandlerForMethod(method: String, module: String, resource: String, handler: (request: GCDWebServerRequest!) -> GCDWebServerResponse!) {
+        server.addHandlerForMethod(method, path: "/\(module)/\(resource)", requestClass: GCDWebServerRequest.self, processBlock: handler)
+    }
+
     /// Convenience method to register a resource in the main bundle. Will be mounted at $base/$module/$resource
     func registerMainBundleResource(resource: String, module: String) {
         if let path = NSBundle.mainBundle().pathForResource(resource, ofType: nil) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -191,18 +191,6 @@ class BrowserViewController: UIViewController {
         urlBar.finishEditing()
 
         if let tab = tabManager.selectedTab {
-            if ReaderMode.isReaderModeURL(url) {
-                if let readerMode = tab.getHelper(name: "ReaderMode") as? ReaderMode {
-                    // Switch to reader mode immediately when we detect it can be activated. The reader mode will still
-                    // call its delegate to let us know its state changed so that we can update the UI.
-                    readerMode.activateImmediately = true
-                    // We don't show the initial page when opening a reader: url. This will probably change to some overlay on top of the webview.
-                    tab.hideContent(animated: false)
-                    if let originalURL = ReaderMode.decodeURL(url) {
-                        url = originalURL
-                    }
-                }
-            }
             tab.loadRequest(NSURLRequest(URL: url))
         }
     }
@@ -274,22 +262,13 @@ extension BrowserViewController: URLBarDelegate {
     func urlBarDidPressReaderMode(urlBar: URLBarView) {
         if let tab = tabManager.selectedTab {
             if let readerMode = tab.getHelper(name: "ReaderMode") as? ReaderMode {
-                if readerMode.state == .Available {
-                    // Update the style of the reader mode to what was last configured
-                    if let dict = self.profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
-                        if let style = ReaderModeStyle(dict: dict) {
-                            readerMode.style = style
-                        }
-                    }
-                    readerMode.enableReaderMode()
-
-//                    hideToolbars(animated: true, completion: { finished in
-//                        //self.showReaderModeBar(animated: false)
-//                    })
-                    self.showReaderModeBar(animated: true)
-                } else {
-                    readerMode.disableReaderMode()
-                    self.hideReaderModeBar(animated: true)
+                switch readerMode.state {
+                case .Available:
+                    enableReaderMode()
+                case .Active:
+                    disableReaderMode()
+                case .Unavailable:
+                    break
                 }
             }
         }
@@ -882,6 +861,60 @@ extension BrowserViewController {
     func hideReaderModeBar(#animated: Bool) {
         readerModeBar.hidden = true
     }
+
+    /// There are two ways we can enable reader mode. In the simplest case we open a URL to our internal reader mode
+    /// and be done with it. In the more complicated case, reader mode was already open for this page and we simply
+    /// navigated away from it. So we look to the left and right in the BackForwardList to see if a readerized version
+    /// of the current page is there. And if so, we go there.
+
+    func enableReaderMode() {
+        if let webView = tabManager.selectedTab?.webView {
+            let backList = webView.backForwardList.backList as [WKBackForwardListItem]
+            let forwardList = webView.backForwardList.forwardList as [WKBackForwardListItem]
+
+            if let currentURL = webView.backForwardList.currentItem?.URL {
+                if let readerModeURL = ReaderModeUtils.encodeURL(currentURL) {
+                    if backList.count > 1 && backList.last?.URL == readerModeURL {
+                        webView.goToBackForwardListItem(backList.last!)
+                    } else if forwardList.count > 0 && forwardList.first?.URL == readerModeURL {
+                        webView.goToBackForwardListItem(forwardList.first!)
+                    } else {
+                        // Store the readability result in the cache and load it. This will later move to the ReadabilityHelper.
+                        webView.evaluateJavaScript("\(ReaderModeNamespace).readerize()", completionHandler: { (object, error) -> Void in
+                            if let readabilityResult = ReadabilityResult(object: object) {
+                                ReaderModeCache.sharedInstance.put(currentURL, readabilityResult, error: nil)
+                                webView.loadRequest(NSURLRequest(URL: readerModeURL))
+                            }
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    /// Disabling reader mode can mean two things. In the simplest case we were opened from the reading list, which
+    /// means that there is nothing in the BackForwardList except the internal url for the reader mode page. In that
+    /// case we simply open a new page with the original url. In the more complicated page, the non-readerized version
+    /// of the page is either to the left or right in the BackForwardList. If that is the case, we navigate there.
+
+    func disableReaderMode() {
+        if let webView = tabManager.selectedTab?.webView {
+            let backList = webView.backForwardList.backList as [WKBackForwardListItem]
+            let forwardList = webView.backForwardList.forwardList as [WKBackForwardListItem]
+
+            if let currentURL = webView.backForwardList.currentItem?.URL {
+                if let originalURL = ReaderModeUtils.decodeURL(currentURL) {
+                    if backList.count > 1 && backList.last?.URL == originalURL {
+                        webView.goToBackForwardListItem(backList.last!)
+                    } else if forwardList.count > 0 && forwardList.first?.URL == originalURL {
+                        webView.goToBackForwardListItem(forwardList.first!)
+                    } else {
+                        webView.loadRequest(NSURLRequest(URL: originalURL))
+                    }
+                }
+            }
+        }
+    }
 }
 
 extension BrowserViewController: ReaderModeBarViewDelegate {
@@ -917,8 +950,8 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
             // TODO Persist to database - The code below needs an update to talk to improved storage layer
             if let tab = tabManager.selectedTab? {
                 if var url = tab.url? {
-                    if ReaderMode.isReaderModeURL(url) {
-                        if let url = ReaderMode.decodeURL(url) {
+                    if ReaderModeUtils.isReaderModeURL(url) {
+                        if let url = ReaderModeUtils.decodeURL(url) {
                             if let absoluteString = url.absoluteString {
                                 profile.readingList.add(item: ReadingListItem(url: absoluteString, title: tab.title)) { (success) -> Void in
                                     //readerModeBar.added = true

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -210,7 +210,7 @@ class ReadingListPanel: UITableViewController, HomePanel, SWTableViewCellDelegat
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
         // TODO Hook up data store
         if let item = data?[indexPath.row] as? ReadingListItem {
-            if let encodedURL = ReaderMode.encodeURL(NSURL(string: item.url)!) {
+            if let encodedURL = ReaderModeUtils.encodeURL(NSURL(string: item.url)!) {
                 homePanelDelegate?.homePanel(self, didSelectURL: encodedURL)
             }
         }

--- a/Client/Frontend/Reader/Reader.css
+++ b/Client/Frontend/Reader/Reader.css
@@ -4,48 +4,48 @@
 
 @font-face {
     font-family: sans-serif;
-    src: url('FiraSans-Regular.ttf');
+    src: url('/reader-mode/fonts/FiraSans-Regular.ttf');
 }
 
 @font-face {
     font-family: sans-serif;
-    src: url('FiraSans-Bold.ttf');
+    src: url('/reader-mode/fonts/FiraSans-Bold.ttf');
     font-weight: bold;
 }
 
 @font-face {
     font-family: sans-serif;
-    src: url('FiraSans-Italic.ttf');
+    src: url('/reader-mode/fonts/FiraSans-Italic.ttf');
     font-style: italic;
 }
 
 @font-face {
     font-family: sans-serif;
-    src: url('FiraSans-BoldItalic.ttf');
+    src: url('/reader-mode/fonts/FiraSans-BoldItalic.ttf');
     font-weight: bold;
     font-style: italic;
 }
 
 @font-face {
     font-family: serif;
-    src: url('CharisSILR.ttf');
+    src: url('/reader-mode/fonts/CharisSILR.ttf');
 }
 
 @font-face {
     font-family: serif;
-    src: url('CharisSILB.ttf');
+    src: url('/reader-mode/fonts/CharisSILB.ttf');
     font-weight: bold;
 }
 
 @font-face {
     font-family: serif;
-    src: url('CharisSILI.ttf');
+    src: url('/reader-mode/fonts/CharisSILI.ttf');
     font-style: italic;
 }
 
 @font-face {
     font-family: serif;
-    src: url('CharisSILBI.ttf');
+    src: url('/reader-mode/fonts/CharisSILBI.ttf');
     font-weight: bold;
     font-style: italic;
 }

--- a/Client/Frontend/Reader/ReaderModeCache.swift
+++ b/Client/Frontend/Reader/ReaderModeCache.swift
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let ReaderModeCacheSharedInstance = ReaderModeCache()
+
+/// Really basic persistent cache to store readerized content. Has a simple hashed structure
+/// to avoid storing many items in the same directory.
+///
+/// This currently lives in ~/Library/Caches so that the data can be pruned in case the OS needs
+/// more space. Whether that is a good idea or not is not sure. We have a bug on file to investigate
+/// and improve at a later time.
+
+class ReaderModeCache {
+    class var sharedInstance: ReaderModeCache {
+        return ReaderModeCacheSharedInstance
+    }
+
+    func put(url: NSURL, _ readabilityResult: ReadabilityResult, error: NSErrorPointer) -> Bool {
+        if let cacheDirectoryPath = cacheDirectoryForURL(url) {
+            if NSFileManager.defaultManager().createDirectoryAtPath(cacheDirectoryPath, withIntermediateDirectories: true, attributes: nil, error: error) {
+                let contentFilePath = cacheDirectoryPath.stringByAppendingPathComponent("content.json")
+                let string: NSString = readabilityResult.encode()
+                return string.writeToFile(contentFilePath, atomically: true, encoding: NSUTF8StringEncoding, error: error)
+            }
+        }
+        return false
+    }
+
+    func get(url: NSURL, error: NSErrorPointer) -> ReadabilityResult? {
+        if let cacheDirectoryPath = cacheDirectoryForURL(url) {
+            let contentFilePath = cacheDirectoryPath.stringByAppendingPathComponent("content.json")
+            if NSFileManager.defaultManager().fileExistsAtPath(contentFilePath) {
+                if let string = NSString(contentsOfFile: contentFilePath, encoding: NSUTF8StringEncoding, error: error) {
+                    return ReadabilityResult(string: string)
+                }
+            }
+        }
+        return nil
+    }
+
+    func delete(url: NSURL, error: NSErrorPointer) {
+        if let cacheDirectoryPath = cacheDirectoryForURL(url) {
+            if NSFileManager.defaultManager().fileExistsAtPath(cacheDirectoryPath) {
+                NSFileManager.defaultManager().removeItemAtPath(cacheDirectoryPath, error: error)
+            }
+        }
+    }
+
+    private func cacheDirectoryForURL(url: NSURL) -> NSString? {
+        if let paths = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true) as? [String] {
+            if paths.count > 0 {
+                if let hashedPath = hashedPathForURL(url) {
+                    return NSString.pathWithComponents([paths[0], hashedPath])
+                }
+            }
+        }
+        return nil
+    }
+
+    private func hashedPathForURL(url: NSURL) -> NSString? {
+        if let hash = hashForURL(url) {
+            return NSString.pathWithComponents([hash.substringWithRange(NSMakeRange(0, 2)), hash.substringWithRange(NSMakeRange(2, 2)), hash.substringFromIndex(4)])
+        }
+        return nil
+    }
+
+    private func hashForURL(url: NSURL) -> NSString? {
+        if let absoluteString = url.absoluteString {
+            if let data = absoluteString.dataUsingEncoding(NSUTF8StringEncoding) {
+                return data.sha1.hexEncodedString
+            }
+        }
+        return nil
+    }
+}

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+struct ReaderModeHandlers {
+    static func register(webServer: WebServer) {
+        // Register our fonts, which we want to expose to web content that we present in the WebView
+        webServer.registerMainBundleResourcesOfType("ttf", module: "reader-mode/fonts")
+
+        // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests
+        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page") { (request: GCDWebServerRequest!) -> GCDWebServerResponse! in
+            if let url = request.query["url"] as? String {
+                if let url = NSURL(string: url) {
+                    if let readabilityResult = ReaderModeCache.sharedInstance.get(url, error: nil) {
+                        var readerModeStyle = DefaultReaderModeStyle
+                        if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
+                            if let dict = appDelegate.profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
+                                if let style = ReaderModeStyle(dict: dict) {
+                                    readerModeStyle = style
+                                }
+                            }
+                        }
+                        if let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle) {
+                            return GCDWebServerDataResponse(HTML: html)
+                        }
+                    }
+                }
+            }
+            return GCDWebServerDataResponse(HTML: "There was an error converting the page")
+        }
+    }
+}

--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+struct ReaderModeUtils {
+
+    static let DomainPrefixesToSimplify = ["www.", "mobile.", "m.", "blog."]
+
+    static func simplifyDomain(domain: String) -> String {
+        for prefix in DomainPrefixesToSimplify {
+            if domain.hasPrefix(prefix) {
+                return domain.substringFromIndex(advance(domain.startIndex, countElements(prefix)))
+            }
+        }
+        return domain
+    }
+
+    static func generateReaderContent(readabilityResult: ReadabilityResult, initialStyle: ReaderModeStyle) -> String? {
+        if let stylePath = NSBundle.mainBundle().pathForResource("Reader", ofType: "css") {
+            if let css = NSString(contentsOfFile: stylePath, encoding: NSUTF8StringEncoding, error: nil) {
+                if let tmplPath = NSBundle.mainBundle().pathForResource("Reader", ofType: "html") {
+                    if let tmpl = NSMutableString(contentsOfFile: tmplPath, encoding: NSUTF8StringEncoding, error: nil) {
+                        tmpl.replaceOccurrencesOfString("%READER-CSS%", withString: css,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-STYLE%", withString: initialStyle.encode(),
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-DOMAIN%", withString: simplifyDomain(readabilityResult.domain),
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-URL%", withString: readabilityResult.url,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-TITLE%", withString: readabilityResult.title,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-CREDITS%", withString: readabilityResult.credits,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%READER-CONTENT%", withString: readabilityResult.content,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        tmpl.replaceOccurrencesOfString("%WEBSERVER-BASE%", withString: WebServer.sharedInstance.base,
+                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
+
+                        return tmpl
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    static func isReaderModeURL(url: NSURL) -> Bool {
+        let baseReaderModeURL: String = WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
+        if let absoluteString = url.absoluteString {
+            return absoluteString.hasPrefix(baseReaderModeURL)
+        }
+        return false
+    }
+
+    static func decodeURL(url: NSURL) -> NSURL? {
+        let baseReaderModeURL: String = WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
+        if let absoluteString = url.absoluteString {
+            if absoluteString.hasPrefix(baseReaderModeURL) {
+                let encodedURL = absoluteString.substringFromIndex(advance(absoluteString.startIndex, baseReaderModeURL.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) + 5)) // TODO Actually parse the url
+                if let decodedURL = encodedURL.stringByRemovingPercentEncoding {
+                    return NSURL(string: decodedURL)
+                }
+            }
+        }
+        return nil
+    }
+
+    static func encodeURL(url: NSURL?) -> NSURL? {
+        let baseReaderModeURL: String = WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
+        if let absoluteString = url?.absoluteString {
+            if let encodedURL = absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.alphanumericCharacterSet()) {
+                if let aboutReaderURL = NSURL(string: "\(baseReaderModeURL)?url=\(encodedURL)") {
+                    return aboutReaderURL
+                }
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
This patch changes reader view to serve content via the built-in web server. This results in much better interaction with the `WKWebView` because we now display reader view content by calling `webView.loadRequest()` instead of `webView.loadHTML`.

This also solved the following two issues:

* 1144291 - Navigating to a reader mode page from the history stack results in blank page
* 1144510 - Reader view content is cached permenantly

This patch is also the beginning of cached and offline reader view content. Standard practice now is to store the readerized content into `~/Library/Caches/ReaderView/XX/YY/ZZZZZZZZ/content.json` - there is currently no way to expire this content, but that will likely be hooked up when we do reading list syncing.

There are a couple of outstanding bugs that need to followup this one because I did not want to combine too much in a single PR. Including:

* 1144404 - Reader Mode URLS (about:reader) should not be part of history 
* 1145231 - Internal Reader View URLs should be hidden
