### PR TITLE
Bug 1145231 Hide internal (reader view) urls (OBSOLETE)

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -47,6 +47,13 @@ class Browser: NSObject, WKScriptMessageHandler {
         return webView.URL?
     }
 
+    var displayURL: NSURL? {
+        if let url = webView.URL {
+            return ReaderModeUtils.isReaderModeURL(url) ? ReaderModeUtils.decodeURL(url) : url
+        }
+        return nil
+    }
+
     var canGoBack: Bool {
         return webView.canGoBack
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -125,7 +125,7 @@ class BrowserViewController: UIViewController {
             homePanelController = HomePanelViewController()
             homePanelController!.profile = profile
             homePanelController!.delegate = self
-            homePanelController!.url = tabManager.selectedTab?.url
+            homePanelController!.url = tabManager.selectedTab?.displayURL
 
             view.addSubview(homePanelController!.view)
             addChildViewController(homePanelController!)
@@ -356,7 +356,7 @@ extension BrowserViewController: BrowserToolbarDelegate {
 
     func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbar) {
         if let tab = tabManager.selectedTab? {
-            if let url = tab.url?.absoluteString {
+            if let url = tab.displayURL?.absoluteString {
                 profile.bookmarks.isBookmarked(url,
                     success: { isBookmarked in
                         if isBookmarked {
@@ -382,7 +382,7 @@ extension BrowserViewController: BrowserToolbarDelegate {
 
     func browserToolbarDidPressShare(browserToolbar: BrowserToolbar) {
         if let selected = tabManager.selectedTab {
-            if let url = selected.url {
+            if let url = selected.displayURL {
                 var shareController = UIActivityViewController(activityItems: [selected.title ?? url.absoluteString!, url], applicationActivities: nil)
                 shareController.modalTransitionStyle = .CoverVertical
                 presentViewController(shareController, animated: true, completion: nil)
@@ -516,7 +516,7 @@ extension BrowserViewController: TabManagerDelegate {
         //previous?.webView.scrollView.delegate = nil
         selected?.webView.navigationDelegate = self
         //selected?.webView.scrollView.delegate = self
-        urlBar.updateURL(selected?.url)
+        urlBar.updateURL(selected?.displayURL)
         showToolbars(animated: false)
 
         toolbar.updateBackStatus(selected?.canGoBack ?? false)
@@ -530,7 +530,7 @@ extension BrowserViewController: TabManagerDelegate {
             urlBar.updateReaderModeState(ReaderModeState.Unavailable)
         }
 
-        updateInContentHomePanel(selected?.url)
+        updateInContentHomePanel(selected?.displayURL)
     }
 
     func tabManager(tabManager: TabManager, didCreateTab tab: Browser) {
@@ -639,35 +639,43 @@ extension BrowserViewController: WKNavigationDelegate {
     }
     
     func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
-        urlBar.updateURL(webView.URL);
-        toolbar.updateBackStatus(webView.canGoBack)
-        toolbar.updateFowardStatus(webView.canGoForward)
-        showToolbars(animated: false)
+        if let tab = tabManager.selectedTab {
+            if tab.webView == webView {
+                urlBar.updateURL(tab.displayURL);
+                toolbar.updateBackStatus(webView.canGoBack)
+                toolbar.updateFowardStatus(webView.canGoForward)
+                showToolbars(animated: false)
 
-        if let url = webView.URL?.absoluteString {
-            profile.bookmarks.isBookmarked(url, success: { bookmarked in
-                self.toolbar.updateBookmarkStatus(bookmarked)
-            }, failure: { err in
-                println("Error getting bookmark status: \(err)")
-            })
+                if let url = tab.displayURL?.absoluteString {
+                    profile.bookmarks.isBookmarked(url, success: { bookmarked in
+                        self.toolbar.updateBookmarkStatus(bookmarked)
+                    }, failure: { err in
+                        println("Error getting bookmark status: \(err)")
+                    })
+                }
+
+                updateInContentHomePanel(tab.displayURL)
+            }
         }
-
-        updateInContentHomePanel(webView.URL)
     }
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
-        let notificationCenter = NSNotificationCenter.defaultCenter()
-        var info = [NSObject: AnyObject]()
-        info["url"] = webView.URL
-        info["title"] = webView.title
-        notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
+        if let tab = tabManager.selectedTab {
+            if tab.webView == webView {
+                let notificationCenter = NSNotificationCenter.defaultCenter()
+                var info = [NSObject: AnyObject]()
+                info["url"] = tab.displayURL
+                info["title"] = tab.title
+                notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
 
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
-        // must be followed by LayoutChanged, as ScreenChanged will make VoiceOver
-        // cursor land on the correct initial element, but if not followed by LayoutChanged,
-        // VoiceOver will sometimes be stuck on the element, not allowing user to move
-        // forward/backward. Strange, but LayoutChanged fixes that.
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
+                // must be followed by LayoutChanged, as ScreenChanged will make VoiceOver
+                // cursor land on the correct initial element, but if not followed by LayoutChanged,
+                // VoiceOver will sometimes be stuck on the element, not allowing user to move
+                // forward/backward. Strange, but LayoutChanged fixes that.
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This patch introduces a `displayURL` in `Browser`. The `displayURL` is the 'real' URL that should be used for display purposes and for cases where the URL needs to be used in for example bookmarks, sharing, history.

Currently the `displayURL` only knows about our internal reader view style urls, which are of the form `http://localhost:12345/reader-mode/page?url=$REAL_URL_ENCODED`.