### PR TITLE
Bug 1145231 - Internal Reader View URLs should be hidden

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -47,6 +47,13 @@ class Browser: NSObject, WKScriptMessageHandler {
         return webView.URL?
     }
 
+    var displayURL: NSURL? {
+        if let url = webView.URL {
+            return ReaderModeUtils.isReaderModeURL(url) ? ReaderModeUtils.decodeURL(url) : url
+        }
+        return nil
+    }
+
     var canGoBack: Bool {
         return webView.canGoBack
     }


### PR DESCRIPTION
This patch introduces a `displayURL` in `Browser`. The `displayURL` is the 'real' URL that should be used for display purposes and for cases where the URL needs to be used in for example bookmarks, sharing, history.

Currently the `displayURL` only knows about our internal reader view style urls, which are of the form `http://localhost:12345/reader-mode/page?url=$REAL_URL_ENCODED`.