### PR TITLE
Bug 1146095 - StorageTests are disabled and broken

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -129,6 +129,16 @@
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2FCAE2231ABB51F800877008"
+               BuildableName = "StorageTests.xctest"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/StorageTests/MockFiles.swift
+++ b/StorageTests/MockFiles.swift
@@ -1,46 +1,9 @@
 import Foundation
 import XCTest
 
-class MockFiles : FileAccessor {
-    func getDir(name: String?, basePath: String? = nil) -> String? {
-        var path = basePath
-        if path == nil {
-            path = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
-            path?.stringByAppendingPathExtension("testing")
-        }
-
-        if let name = name {
-            path = path?.stringByAppendingPathExtension(name)
-        }
-
-        return path
-    }
-
-    func move(src: String, srcBasePath: String? = nil, dest: String, destBasePath: String? = nil) -> Bool {
-        if let f = get(src, basePath: srcBasePath) {
-            if let f2 = get(dest, basePath: destBasePath) {
-                return NSFileManager.defaultManager().moveItemAtPath(f, toPath: f2, error: nil)
-            }
-        }
-
-        return false
-    }
-
-    func get(path: String, basePath: String? = nil) -> String? {
-        return getDir(nil, basePath: basePath)?.stringByAppendingPathComponent(path)
-    }
-
-    func remove(filename: String, basePath: String? = nil) {
-        let fileManager = NSFileManager.defaultManager()
-        if var file = get(filename, basePath: nil) {
-            fileManager.removeItemAtPath(file, error: nil)
-        }
-    }
-
-    func exists(filename: String, basePath: String? = nil) -> Bool {
-        if var file = get(filename, basePath: nil) {
-            return NSFileManager.defaultManager().fileExistsAtPath(file)
-        }
-        return false
+class MockFiles: FileAccessor {
+    init() {
+        let docPath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as String
+        super.init(rootPath: docPath.stringByAppendingPathComponent("testing"))
     }
 }

--- a/StorageTests/TestBookmarks.swift
+++ b/StorageTests/TestBookmarks.swift
@@ -89,7 +89,7 @@ class TestBookmarks : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testBookmarksTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db")!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let bookmarks = BookmarkTable<BookmarkNode>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in

--- a/StorageTests/TestFaviconsTable.swift
+++ b/StorageTests/TestFaviconsTable.swift
@@ -57,7 +57,7 @@ class TestFavcionsTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testFaviconsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let f = FaviconsTable<Favicon>(files: files)
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -82,6 +82,6 @@ class TestFavcionsTable : XCTestCase {
         self.clear(f)
         self.checkIcons(f, options: nil, urls: [String]())
         
-        files.remove("test.db", basePath: nil)
+        files.remove("test.db")
     }
 }

--- a/StorageTests/TestHistoryTable.swift
+++ b/StorageTests/TestHistoryTable.swift
@@ -73,7 +73,7 @@ class TestHistoryTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testHistoryTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let h = HistoryTable<Site>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -99,6 +99,6 @@ class TestHistoryTable : XCTestCase {
         self.clear(h)
         self.checkSites(h, options: nil, urls: [String: String]())
 
-        files.remove("test.db", basePath: nil)
+        files.remove("test.db")
     }
 }

--- a/StorageTests/TestJoinedFaviconTable.swift
+++ b/StorageTests/TestJoinedFaviconTable.swift
@@ -57,7 +57,7 @@ class TestJoinedFaviconsTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testJoinedFaviconsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let f = JoinedFaviconsHistoryTable<(Site, Favicon)>(files: files)
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -85,6 +85,6 @@ class TestJoinedFaviconsTable : XCTestCase {
         self.clear(f)
         self.checkIcons(f, options: nil, urls: [String]())
         
-        files.remove("test.db", basePath: nil)
+        files.remove("test.db")
     }
 }

--- a/StorageTests/TestJoinedHistoryVisits.swift
+++ b/StorageTests/TestJoinedHistoryVisits.swift
@@ -94,7 +94,7 @@ class TestJoinedHistoryVisits : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testJoinedHistoryVisitsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let h = JoinedHistoryVisitsTable(files: files)
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -142,6 +142,6 @@ class TestJoinedHistoryVisits : XCTestCase {
         self.clear(h)
         self.checkSites(h, options: nil, urls: [String: String]())
         
-        files.remove("test.db", basePath: nil)
+        files.remove("test.db")
     }
 }

--- a/StorageTests/TestReadingListTable.swift
+++ b/StorageTests/TestReadingListTable.swift
@@ -12,7 +12,7 @@ class TestReadingListTable: XCTestCase {
     override func setUp() {
         let files = MockFiles()
         files.remove("TestReadingListTable.db")
-        db = SwiftData(filename: files.get("TestReadingListTable.db")!)
+        db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("TestReadingListTable.db"))
 
         readingListTable = ReadingListTable<ReadingListItem>()
         db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in

--- a/StorageTests/TestVisitsTable.swift
+++ b/StorageTests/TestVisitsTable.swift
@@ -58,7 +58,7 @@ class TestVisitsTable : XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testVisitsTable() {
         let files = MockFiles()
-        self.db = SwiftData(filename: files.get("test.db", basePath: nil)!)
+        self.db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent("test.db"))
         let h = VisitsTable<Visit>()
 
         self.db.withConnection(SwiftData.Flags.ReadWriteCreate, cb: { (db) -> NSError? in
@@ -89,6 +89,6 @@ class TestVisitsTable : XCTestCase {
         self.clear(h, s: true)
         self.checkVisits(h, options: nil, vs: [])
 
-        files.remove("test.db", basePath: nil)
+        files.remove("test.db")
     }
 }


### PR DESCRIPTION
StorageTests aren't running at all. We deleted the Storage scheme in #240, but it looks like we forgot to move the StorageTests into the Client scheme.

Re-enabling them, we find that they're all broken due to API changes in #234 that didn't get updated here.