### PR TITLE
Fixes 1146564 - Implement a Readability Service

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -322,6 +322,10 @@
 		E4A888171A95679500CDC337 /* FxA.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */; };
 		E4A960241ABB9D500069AD6F /* ReaderModeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */; };
+		E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A961171AC041C40069AD6F /* ReadabilityService.swift */; };
+		E4A961341AC051360069AD6F /* ReadabilityBrowserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */; };
+		E4A961361AC052DE0069AD6F /* ReadabilityBrowserHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */; };
+		E4A961381AC06FA50069AD6F /* ReaderViewLoading.html in Resources */ = {isa = PBXBuildFile; fileRef = E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */; };
 		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */; };
 		E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */; };
@@ -1053,6 +1057,10 @@
 		E4988B6E1A9B964B008B8B92 /* FennecNightly.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = FennecNightly.entitlements; sourceTree = "<group>"; };
 		E4988B6F1A9B965A008B8B92 /* FennecNightly.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = FennecNightly.entitlements; sourceTree = "<group>"; };
 		E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeUtils.swift; sourceTree = "<group>"; };
+		E4A961171AC041C40069AD6F /* ReadabilityService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityService.swift; sourceTree = "<group>"; };
+		E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityBrowserHelper.swift; sourceTree = "<group>"; };
+		E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ReadabilityBrowserHelper.js; sourceTree = "<group>"; };
+		E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ReaderViewLoading.html; sourceTree = "<group>"; };
 		E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeCache.swift; sourceTree = "<group>"; };
 		E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeHandlers.swift; sourceTree = "<group>"; };
 		E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILB.ttf; sourceTree = "<group>"; };
@@ -1869,6 +1877,10 @@
 				E4CD9F5A1A71506C00318571 /* Reader.css */,
 				E4CD9F6C1A77DD2800318571 /* ReaderModeStyleViewController.swift */,
 				E4ECCD8C1AB091470005E717 /* Reader.xcassets */,
+				E4A961171AC041C40069AD6F /* ReadabilityService.swift */,
+				E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */,
+				E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */,
+				E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */,
 			);
 			path = Reader;
 			sourceTree = "<group>";
@@ -2640,6 +2652,7 @@
 				E4CD9F5B1A71506C00318571 /* Reader.css in Resources */,
 				E4B7B7611A793CF20022C5E0 /* CharisSILB.ttf in Resources */,
 				E4B7B7621A793CF20022C5E0 /* CharisSILBI.ttf in Resources */,
+				E4A961361AC052DE0069AD6F /* ReadabilityBrowserHelper.js in Resources */,
 				E4B7B7861A793CF20022C5E0 /* FiraSans-UltraLight.ttf in Resources */,
 				2F44FB2C1A9D5D8500FD20CC /* Home.xcassets in Resources */,
 				0B305FB91A7F4F040085B8BC /* Passwords.js in Resources */,
@@ -2653,6 +2666,7 @@
 				2F834D161A80629A006A0B7B /* FxASignIn.js in Resources */,
 				E4B7B7681A793CF20022C5E0 /* FiraSans-Bold.ttf in Resources */,
 				E4B7B7781A793CF20022C5E0 /* FiraSans-Italic.ttf in Resources */,
+				E4A961381AC06FA50069AD6F /* ReaderViewLoading.html in Resources */,
 				E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */,
 				0BF42D391A7C0E8900889E28 /* Favicons.js in Resources */,
 				E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */,
@@ -2915,6 +2929,7 @@
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */,
+				E4A961341AC051360069AD6F /* ReadabilityBrowserHelper.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				D38B2D311A8D96D00040E6B5 /* GCDWebServerConnection.m in Sources */,
 				D38B2D401A8D96D00040E6B5 /* GCDWebServerFileRequest.m in Sources */,
@@ -2936,6 +2951,7 @@
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
+				E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
 				59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */,
 				D30B0F301AA7D66300C01CA3 /* ThumbnailCell.swift in Sources */,

--- a/Client/Frontend/Reader/ReadabilityBrowserHelper.js
+++ b/Client/Frontend/Reader/ReadabilityBrowserHelper.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    // To keep this file readable and Readability.js separate, since we import it from an external
+    // repository, we merge it in this file programatically. We do not include it as a user script
+    // because that means pages can mess with it; by including it below, it is part of an anonymous
+    // function that only exists once.
+
+    %READABILITYJS%
+
+    var uri = {
+        spec: document.location.href,
+        host: document.location.host,
+        prePath: document.location.protocol + "//" + document.location.host, // TODO This is incomplete, needs username/password and port
+        scheme: document.location.protocol.substr(0, document.location.protocol.indexOf(":")),
+        pathBase: document.location.protocol + "//" + document.location.host + location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1)
+    }
+
+    // document.cloneNode() can cause the webview to break (bug 1128774).
+    // Serialize and then parse the document instead.
+    var docStr = new XMLSerializer().serializeToString(document);
+    var doc = new DOMParser().parseFromString(docStr, "text/html");
+
+    var readability = new Readability(uri, doc);
+    var readabilityResult = readability.parse();
+
+    webkit.messageHandlers.readabilityMessageHandler.postMessage(readabilityResult);
+})();

--- a/Client/Frontend/Reader/ReadabilityBrowserHelper.swift
+++ b/Client/Frontend/Reader/ReadabilityBrowserHelper.swift
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+protocol ReadabilityBrowserHelperDelegate {
+    func readabilityBrowserHelper(readabilityBrowserHelper: ReadabilityBrowserHelper, didFinishWithReadabilityResult result: ReadabilityResult)
+}
+
+class ReadabilityBrowserHelper: BrowserHelper {
+    var delegate: ReadabilityBrowserHelperDelegate?
+
+    class func name() -> String {
+        return "ReadabilityBrowserHelper"
+    }
+
+    init?(browser: Browser) {
+        if let readabilityPath = NSBundle.mainBundle().pathForResource("Readability", ofType: "js") {
+            if let readabilitySource = NSMutableString(contentsOfFile: readabilityPath, encoding: NSUTF8StringEncoding, error: nil) {
+                if let readabilityBrowserHelperPath = NSBundle.mainBundle().pathForResource("ReadabilityBrowserHelper", ofType: "js") {
+                    if let readabilityBrowserHelperSource = NSMutableString(contentsOfFile: readabilityBrowserHelperPath, encoding: NSUTF8StringEncoding, error: nil) {
+                        readabilityBrowserHelperSource.replaceOccurrencesOfString("%READABILITYJS%", withString: readabilitySource, options: NSStringCompareOptions.LiteralSearch, range: NSMakeRange(0, readabilityBrowserHelperSource.length))
+                        var userScript = WKUserScript(source: readabilityBrowserHelperSource, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
+                        browser.webView.configuration.userContentController.addUserScript(userScript)
+                    }
+                }
+            }
+        }
+    }
+
+    func scriptMessageHandlerName() -> String? {
+        return "readabilityMessageHandler"
+    }
+
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if let readabilityResult = ReadabilityResult(object: message.body) {
+            delegate?.readabilityBrowserHelper(self, didFinishWithReadabilityResult: readabilityResult)
+        }
+   }
+}

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+private let ReadabilityServiceSharedInstance = ReadabilityService()
+
+private let ReadabilityTaskDefaultTimeout = 15
+private let ReadabilityServiceDefaultConcurrency = 1
+
+enum ReadabilityOperationResult {
+    case Success(ReadabilityResult)
+    case Error(NSError)
+    case Timeout
+}
+
+class ReadabilityOperation: NSOperation, WKNavigationDelegate, ReadabilityBrowserHelperDelegate {
+    var url: NSURL
+    var semaphore: dispatch_semaphore_t
+    var result: ReadabilityOperationResult?
+    var browser: Browser!
+
+    init(url: NSURL) {
+        self.url = url
+        self.semaphore = dispatch_semaphore_create(0)
+    }
+
+    override func main() {
+        if self.cancelled {
+            return
+        }
+
+        // Setup a browser, attach a Readability helper. Kick all this off on the main thread since UIKit
+        // and WebKit are not safe from other threads.
+
+        dispatch_async(dispatch_get_main_queue(), { () -> Void in
+            let configuration = WKWebViewConfiguration()
+            self.browser = Browser(configuration: configuration)
+            self.browser.webView.navigationDelegate = self
+
+            if let readabilityBrowserHelper = ReadabilityBrowserHelper(browser: self.browser) {
+                readabilityBrowserHelper.delegate = self
+                self.browser.addHelper(readabilityBrowserHelper, name: ReadabilityBrowserHelper.name())
+            }
+
+            // Load the page in the webview. This either fails with a navigation error, or we get a readability
+            // callback. Or it takes too long, in which case the semaphore times out.
+            
+            self.browser.loadRequest(NSURLRequest(URL: self.url))
+        })
+
+        if dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, Int64(Double(ReadabilityTaskDefaultTimeout) * Double(NSEC_PER_SEC)))) != 0 {
+            result = ReadabilityOperationResult.Timeout
+        }
+
+        // Maybe this is where we should store stuff in the cache / run a callback?
+
+        if let result = self.result {
+            switch result {
+            case .Timeout:
+                // Don't do anything on timeout
+                break
+            case .Success(let readabilityResult):
+                var error: NSError? = nil
+                if !ReaderModeCache.sharedInstance.put(url, readabilityResult, error: &error) {
+                    if error != nil {
+                        println("Failed to store readability results in the cache: \(error?.localizedDescription)")
+                        // TODO Fail
+                    }
+                }
+            case .Error(let error):
+                // TODO Not entitely sure what to do on error. Needs UX discussion and followup bug.
+                break
+            }
+        }
+    }
+
+    func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
+        result = ReadabilityOperationResult.Error(error)
+        dispatch_semaphore_signal(semaphore)
+    }
+
+    func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
+        result = ReadabilityOperationResult.Error(error)
+        dispatch_semaphore_signal(semaphore)
+    }
+
+    func readabilityBrowserHelper(readabilityBrowserHelper: ReadabilityBrowserHelper, didFinishWithReadabilityResult readabilityResult: ReadabilityResult) {
+        result = ReadabilityOperationResult.Success(readabilityResult)
+        dispatch_semaphore_signal(semaphore)
+    }
+}
+
+class ReadabilityService {
+    class var sharedInstance: ReadabilityService {
+        return ReadabilityServiceSharedInstance
+    }
+
+    var queue: NSOperationQueue
+
+    init() {
+        queue = NSOperationQueue()
+        queue.maxConcurrentOperationCount = ReadabilityServiceDefaultConcurrency
+    }
+
+    func process(url: NSURL) {
+        queue.addOperation(ReadabilityOperation(url: url))
+    }
+}

--- a/Client/Frontend/Reader/ReaderModeCache.swift
+++ b/Client/Frontend/Reader/ReaderModeCache.swift
@@ -49,6 +49,14 @@ class ReaderModeCache {
         }
     }
 
+    func contains(url: NSURL, error: NSErrorPointer) -> Bool {
+        if let cacheDirectoryPath = cacheDirectoryForURL(url) {
+            let contentFilePath = cacheDirectoryPath.stringByAppendingPathComponent("content.json")
+            return NSFileManager.defaultManager().fileExistsAtPath(contentFilePath)
+        }
+        return false
+    }
+
     private func cacheDirectoryForURL(url: NSURL) -> NSString? {
         if let paths = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true) as? [String] {
             if paths.count > 0 {

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -9,11 +9,29 @@ struct ReaderModeHandlers {
         // Register our fonts, which we want to expose to web content that we present in the WebView
         webServer.registerMainBundleResourcesOfType("ttf", module: "reader-mode/fonts")
 
-        // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests
+        // Register a handler that simply lets us know if a document is in the cache or not. This is called from the
+        // reader view interstitial page to find out when it can stop showing the 'Loading...' page and instead load
+        // the readerized content.
+        webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page-exists") { (request: GCDWebServerRequest!) -> GCDWebServerResponse! in
+            if let url = request.query["url"] as? String {
+                if let url = NSURL(string: url) {
+                    if ReaderModeCache.sharedInstance.contains(url, error: nil) {
+                        return GCDWebServerResponse(statusCode: 200)
+                    } else {
+                        return GCDWebServerResponse(statusCode: 404)
+                    }
+                }
+            }
+            return GCDWebServerResponse(statusCode: 500)
+        }
+
+        // Register the handler that accepts /reader-mode/page?url=http://www.example.com requests.
         webServer.registerHandlerForMethod("GET", module: "reader-mode", resource: "page") { (request: GCDWebServerRequest!) -> GCDWebServerResponse! in
             if let url = request.query["url"] as? String {
                 if let url = NSURL(string: url) {
                     if let readabilityResult = ReaderModeCache.sharedInstance.get(url, error: nil) {
+                        // We have this page in our cache, so we can display it. Just grab the correct style from the
+                        // profile and then generate HTML from the Readability results.
                         var readerModeStyle = DefaultReaderModeStyle
                         if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
                             if let dict = appDelegate.profile.prefs.dictionaryForKey(ReaderModeProfileKeyStyle) {
@@ -25,10 +43,24 @@ struct ReaderModeHandlers {
                         if let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle) {
                             return GCDWebServerDataResponse(HTML: html)
                         }
+                    } else {
+                        // This page has not been converted to reader mode yet. This happens when you for example add an
+                        // item via the app extension and the application has not yet had a change to readerize that
+                        // page in the background.
+                        //
+                        // What we do is simply queue the page in the ReadabilityService and then show our loading
+                        // screen, which will periodically call page-exists to see if the readerized content has
+                        // become available.
+                        ReadabilityService.sharedInstance.process(url)
+                        if let readerViewLoadingPath = NSBundle.mainBundle().pathForResource("ReaderViewLoading", ofType: "html") {
+                            if let readerViewLoading = NSMutableString(contentsOfFile: readerViewLoadingPath, encoding: NSUTF8StringEncoding, error: nil) {
+                                return GCDWebServerDataResponse(HTML: readerViewLoading)
+                            }
+                        }
                     }
                 }
             }
-            return GCDWebServerDataResponse(HTML: "There was an error converting the page")
+            return GCDWebServerDataResponse(HTML: "There was an error converting the page") // TODO Needs a proper error page
         }
     }
 }

--- a/Client/Frontend/Reader/ReaderViewLoading.html
+++ b/Client/Frontend/Reader/ReaderViewLoading.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+ - License, v. 2.0. If a copy of the MPL was not distributed with this
+ - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<html>
+
+    <body>
+        <h1 id="message">TODO Loading Interstitial</h1>
+    </body>
+
+    <script>
+        var numberOfChecks = 10;
+
+        function triggerCheck() {
+            if (numberOfChecks--) {
+                setTimeout(function() { checkIfContentIsAvailable(); }, 1000);
+            } else {
+                var e = document.getElementById("message")
+                if (e != null) {
+                    e.innerText = "There was a problem loading the content. Click here to load the original page.";
+                }
+            }
+        }
+
+        function checkIfContentIsAvailable() {
+            var request = new XMLHttpRequest();
+            request.open("GET", "/reader-mode/page-exists" + document.location.search, true);
+            request.onload = function() {
+                if (request.status == 200) {
+                    location.reload(true);
+                } else {
+                    triggerCheck();
+                }
+            };
+            request.onerror = function() {
+                triggerCheck();
+            };
+            request.send();
+        }
+
+        triggerCheck();
+    </script>
+
+</html>


### PR DESCRIPTION
This patch introduces a `ReadabilityService`. This is a background services that uses the `WKWebView` and a new `ReadabilityBrowserHelper` to readerize pages on demand in the background.

Couple of notes:

* The interstitial that is displayed when you open a page from the reading list for which we have no content yet is very raw. It just shows a `<h1>` with a message. This needs UX. This is all located in `ReaderViewLoading.html`.
* The `ReaderModeService` may need a better way to handle errors. Right now things simply time out after which we display an error. We can probably speed that up so that the user does not have to wait 10 seconds.
* The current `ReaderMode` (which is also a `BrowserHelper`) can be much simplified by using this new `ReadabilityBrowserHelper`. There will be a nicer separation of concerns when we do that.

This is a good first iteration that I would like to expose to our testers sooner than later. This code needs to mature in the coming weeks though.