### PR TITLE
Bug 1147000 - No panel selected at startup

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -73,22 +73,23 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         selectedButtonIndex = 0
     }
 
-    var selectedButtonIndex: Int = 0 {
+    var selectedButtonIndex: Int? = nil {
         didSet {
-            if oldValue == selectedButtonIndex {
-                // Prevent flicker, allocations, and disk access: avoid duplicate view controllers.
-                return
+            if let index = oldValue {
+                let currentButton = buttons[index]
+                currentButton.selected = false
             }
 
-            let currentButton = buttons[oldValue]
-            currentButton.selected = false
+            hideCurrentPanel()
 
-            let newButton = buttons[selectedButtonIndex]
-            newButton.selected = true
+            if let index = selectedButtonIndex {
+                let newButton = buttons[index]
+                newButton.selected = true
 
-            let panel = self.panels[selectedButtonIndex].makeViewController(profile: profile)
-            (panel as HomePanel).homePanelDelegate = self
-            self.showPanel(panel)
+                let panel = self.panels[index].makeViewController(profile: profile)
+                (panel as HomePanel).homePanelDelegate = self
+                self.showPanel(panel)
+            }
         }
     }
 
@@ -104,8 +105,6 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     }
 
     private func showPanel(panel: UIViewController) {
-        hideCurrentPanel()
-
         controllerContainerView.addSubview(panel.view)
         panel.view.snp_makeConstraints { make in
             make.top.equalTo(self.buttonContainerView.snp_bottom)


### PR DESCRIPTION
Looks like a regression from the index optimization in [bug 1146708](https://bugzilla.mozilla.org/show_bug.cgi?id=1146708), where we don't select a panel if the selected index hasn't changed. Problem is, the selected index is initially 0, so the initial load bails and nothing is selected.