### PR TITLE
Share To Extension Fixes

### DIFF
--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -10,7 +10,10 @@ private let LastUsedShareDestinationsKey = "LastUsedShareDestinations"
 @objc(InitialViewController)
 class InitialViewController: UIViewController, ShareControllerDelegate {
     var shareDialogController: ShareDialogController!
-    var profile: Profile?
+
+    lazy var profile: Profile = {
+        return BrowserProfile(localName: "profile")
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -120,12 +123,10 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
     //
     
     func shareToReadingList(item: ShareItem) {
-        // TODO: Discuss how to share to the (local) reading list
+        profile.readingList.shareItem(item)
     }
     
     func shareToBookmarks(item: ShareItem) {
-        if profile != nil { // TODO: We need to properly deal with this.
-            profile!.bookmarks.shareItem(item)
-        }
+        profile.bookmarks.shareItem(item)
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -10,8 +10,8 @@ import Shared
 class ProfileFileAccessor: FileAccessor {
     init(profile: Profile) {
         let profileDirName = "profile.\(profile.localName())"
-        let basePath = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.DocumentDirectory, NSSearchPathDomainMask.UserDomainMask, true)[0] as? String
-        let profilePath = basePath!.stringByAppendingPathComponent(profileDirName)
+        let url = NSFileManager.defaultManager().containerURLForSecurityApplicationGroupIdentifier(ExtensionUtils.sharedContainerIdentifier())!
+        let profilePath = url.path!.stringByAppendingPathComponent(profileDirName)
         super.init(rootPath: profilePath)
     }
 }

--- a/Storage/ReadingList.swift
+++ b/Storage/ReadingList.swift
@@ -43,4 +43,6 @@ public protocol ReadingList {
     func clear(complete: (success: Bool) -> Void)
     func get(complete: (data: Cursor) -> Void)
     func add(#item: ReadingListItem, complete: (success: Bool) -> Void)
+
+    func shareItem(item: ShareItem)
 }

--- a/Storage/SQL/SQLiteReadingList.swift
+++ b/Storage/SQL/SQLiteReadingList.swift
@@ -57,6 +57,12 @@ public class SQLiteReadingList: ReadingList {
         }
     }
 
+    public func shareItem(item: ShareItem) {
+        add(item: ReadingListItem(url: item.url, title: item.title)) { (success) -> Void in
+            // Nothing we can do here when items are added from an extension.
+        }
+    }
+
     private let debug_enabled = false
     private func debug(msg: String) {
         if debug_enabled {


### PR DESCRIPTION
This patch fixes two bugs:

*  Fixes 1147024 - The Share To extension needs to use the shared application container
*  Fixes 1147084 - Hook up the Share To extension to the Reading List Provider

Tested on both simulator and device.