### PR TITLE
Bug 1147132 - Keyboard covers top sites content

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -18,7 +18,7 @@ private let DefaultImage = "defaultFavicon"
 class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
     weak var homePanelDelegate: HomePanelDelegate?
 
-    private var collection: UICollectionView!
+    private var collection: TopSitesCollectionView!
     private var dataSource: TopSitesDataSource!
     private let layout = TopSitesLayout()
 
@@ -43,7 +43,7 @@ class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
 
         layout.registerClass(TopSitesSeparator.self, forDecorationViewOfKind: SeparatorKind)
 
-        collection = UICollectionView(frame: self.view.frame, collectionViewLayout: layout)
+        collection = TopSitesCollectionView(frame: self.view.frame, collectionViewLayout: layout)
         collection.backgroundColor = UIColor.whiteColor()
         collection.delegate = self
         collection.dataSource = dataSource
@@ -61,6 +61,14 @@ class TopSitesPanel: UIViewController, UICollectionViewDelegate, HomePanel {
         if let site = dataSource?.data[indexPath.item] as? Site {
             homePanelDelegate?.homePanel(self, didSelectURL: NSURL(string: site.url)!)
         }
+    }
+}
+
+private class TopSitesCollectionView: UICollectionView {
+    private override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+        // Hide the keyboard if this view is touched.
+        window?.rootViewController?.view.endEditing(true)
+        super.touchesBegan(touches, withEvent: event)
     }
 }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -85,7 +85,8 @@ private class TopSitesLayout: UICollectionViewLayout {
     }
 
     private var topSectionHeight: CGFloat {
-        let rows = min(count / thumbnailCols, thumbnailRows)
+        let maxRows = ceil(Float(count) / Float(thumbnailCols))
+        let rows = min(Int(maxRows), thumbnailRows)
         return thumbnailHeight * CGFloat(rows) + ThumbnailSectionPadding * 2
     }
 


### PR DESCRIPTION
Hit this issue on a fresh profile with <6 total entries, with the phone in landscape mode. The keyboard covers the tiles, and trying to touch/scroll doesn't make it go away. Looks like there are a couple of problems:
 1. Our collection view height calculation is wrong if there are <6 entries, which breaks scrolling.
 2. Setting `keyboardDismissMode = .OnDrag` makes the keyboard go away if we scroll the view, but the view isn't scrollable if the content doesn't stretch beyond what's visible.