### PR TITLE
Bug 1146511 - Search results mangled on device rotation

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -537,7 +537,9 @@ private class SuggestionCell: UITableViewCell {
                 if currentLeft > textLeft {
                     currentRow++
                     if currentRow >= SuggestionCellMaxRows {
-                        break
+                        // Don't draw this button if it doesn't fit on the row.
+                        button.frame = CGRectZero
+                        continue
                     }
 
                     currentLeft = textLeft


### PR DESCRIPTION
The view frames get set in landscape, so we need to zero them out again when we go back into portrait.