### PR TITLE
Bug 1147158 - Site rows should use URL as the default text if there's no title

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -364,8 +364,7 @@ extension SearchViewController: UITableViewDataSource {
         case .BookmarksAndHistory:
             let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
             if let site = data[indexPath.row] as? Site {
-                cell.textLabel?.text = site.title
-                cell.detailTextLabel?.text = site.url
+                (cell as TwoLineTableViewCell).setLines(site.title, detailText: site.url)
                 if let img = site.icon? {
                     let imgUrl = NSURL(string: img.url)
                     cell.imageView?.sd_setImageWithURL(imgUrl, placeholderImage: self.profile.favicons.defaultIcon)

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -37,8 +37,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
         let offset = sectionOffsets[indexPath.section]!
         if let site = data[indexPath.row + offset] as? Site {
-            cell.textLabel?.text = site.title
-            cell.detailTextLabel?.text = site.url
+            (cell as TwoLineTableViewCell).setLines(site.title, detailText: site.url)
             if let img = site.icon? {
                 let imgURL = NSURL(string: img.url)
                 cell.imageView?.sd_setImageWithURL(imgURL, placeholderImage: self.profile.favicons.defaultIcon)

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -107,16 +107,9 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier(RemoteTabIdentifier, forIndexPath: indexPath) as TwoLineTableViewCell
-        if let tab = tabAtIndexPath(indexPath) {
-            // TODO: Populate image with cached favicons.
-            if let title = tab.title {
-                cell.textLabel?.text = title
-                cell.detailTextLabel?.text = tab.URL.absoluteString
-            } else {
-                cell.textLabel?.text = tab.URL.absoluteString
-                cell.detailTextLabel?.text = nil
-            }
-        }
+        let tab = tabAtIndexPath(indexPath)
+        cell.setLines(tab?.title, detailText: tab?.URL.absoluteString)
+        // TODO: Populate image with cached favicons.
         return cell
     }
 

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -30,6 +30,10 @@ class TwoLineTableViewCell: UITableViewCell {
         super.layoutSubviews()
         twoLineHelper.layoutSubviews()
     }
+
+    func setLines(text: String?, detailText: String?) {
+        twoLineHelper.setLines(text, detailText: detailText)
+    }
 }
 
 class TwoLineCollectionViewCell: UICollectionViewCell {
@@ -61,6 +65,10 @@ class TwoLineCollectionViewCell: UICollectionViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         twoLineHelper.layoutSubviews()
+    }
+
+    func setLines(text: String?, detailText: String?) {
+        twoLineHelper.setLines(text, detailText: detailText)
     }
 }
 
@@ -148,5 +156,15 @@ private class TwoLineCellHelper {
             container.frame.width - textLeft - ImageMargin, textLabelHeight)
         detailTextLabel.frame = CGRectMake(textLeft, textLabel.frame.maxY + 5,
             container.frame.width - textLeft - ImageMargin, detailTextLabelHeight)
+    }
+
+    func setLines(text: String?, detailText: String?) {
+        if text?.isEmpty ?? true {
+            textLabel.text = detailText
+            detailTextLabel.text = nil
+        } else {
+            textLabel.text = text
+            detailTextLabel.text = detailText
+        }
     }
 }


### PR DESCRIPTION
Currently, if there's no title in the table rows, the URL gets used as a fallback. That's what we want, except we should have it styled as the primary item (black, larger font).