### PR TITLE
Fixes 1147381 - Share Button crashes on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -7,13 +7,13 @@ import UIKit
 import Snap
 
 protocol BrowserToolbarDelegate: class {
-    func browserToolbarDidPressBack(browserToolbar: BrowserToolbar)
-    func browserToolbarDidPressForward(browserToolbar: BrowserToolbar)
-    func browserToolbarDidLongPressBack(browserToolbar: BrowserToolbar)
-    func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbar)
-    func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbar)
-    func browserToolbarDidLongPressBookmark(browserToolbar: BrowserToolbar)
-    func browserToolbarDidPressShare(browserToolbar: BrowserToolbar)
+    func browserToolbarDidPressBack(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidPressForward(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidLongPressBack(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidLongPressBookmark(browserToolbar: BrowserToolbar, button: UIButton)
+    func browserToolbarDidPressShare(browserToolbar: BrowserToolbar, button: UIButton)
 }
 
 private let ButtonInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
@@ -103,36 +103,36 @@ class BrowserToolbar: Toolbar {
     }
 
     func SELdidClickBack() {
-        browserToolbarDelegate?.browserToolbarDidPressBack(self)
+        browserToolbarDelegate?.browserToolbarDidPressBack(self, button: backButton)
     }
 
     func SELdidLongPressBack(recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == UIGestureRecognizerState.Began {
-            browserToolbarDelegate?.browserToolbarDidLongPressBack(self)
+            browserToolbarDelegate?.browserToolbarDidLongPressBack(self, button: backButton)
         }
     }
 
     func SELdidClickShare() {
-        browserToolbarDelegate?.browserToolbarDidPressShare(self)
+        browserToolbarDelegate?.browserToolbarDidPressShare(self, button: shareButton)
     }
 
     func SELdidClickForward() {
-        browserToolbarDelegate?.browserToolbarDidPressForward(self)
+        browserToolbarDelegate?.browserToolbarDidPressForward(self, button: forwardButton)
     }
 
     func SELdidLongPressForward(recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == UIGestureRecognizerState.Began {
-            browserToolbarDelegate?.browserToolbarDidLongPressForward(self)
+            browserToolbarDelegate?.browserToolbarDidLongPressForward(self, button: forwardButton)
         }
     }
 
     func SELdidClickBookmark() {
-        browserToolbarDelegate?.browserToolbarDidPressBookmark(self)
+        browserToolbarDelegate?.browserToolbarDidPressBookmark(self, button: bookmarkButton)
     }
 
     func SELdidLongPressBookmark(recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == UIGestureRecognizerState.Began {
-            browserToolbarDelegate?.browserToolbarDidLongPressBookmark(self)
+            browserToolbarDelegate?.browserToolbarDidLongPressBookmark(self, button: bookmarkButton)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -313,29 +313,29 @@ extension BrowserViewController: URLBarDelegate {
 }
 
 extension BrowserViewController: BrowserToolbarDelegate {
-    func browserToolbarDidPressBack(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidPressBack(browserToolbar: BrowserToolbar, button: UIButton) {
         tabManager.selectedTab?.goBack()
     }
 
-    func browserToolbarDidLongPressBack(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidLongPressBack(browserToolbar: BrowserToolbar, button: UIButton) {
         let controller = BackForwardListViewController()
         controller.listData = tabManager.selectedTab?.backList
         controller.tabManager = tabManager
         presentViewController(controller, animated: true, completion: nil)
     }
 
-    func browserToolbarDidPressForward(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidPressForward(browserToolbar: BrowserToolbar, button: UIButton) {
         tabManager.selectedTab?.goForward()
     }
 
-    func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbar, button: UIButton) {
         let controller = BackForwardListViewController()
         controller.listData = tabManager.selectedTab?.forwardList
         controller.tabManager = tabManager
         presentViewController(controller, animated: true, completion: nil)
     }
 
-    func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbar, button: UIButton) {
         if let tab = tabManager.selectedTab? {
             if let url = tab.displayURL?.absoluteString {
                 profile.bookmarks.isBookmarked(url,
@@ -358,15 +358,19 @@ extension BrowserViewController: BrowserToolbarDelegate {
         }
     }
 
-    func browserToolbarDidLongPressBookmark(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidLongPressBookmark(browserToolbar: BrowserToolbar, button: UIButton) {
     }
 
-    func browserToolbarDidPressShare(browserToolbar: BrowserToolbar) {
+    func browserToolbarDidPressShare(browserToolbar: BrowserToolbar, button: UIButton) {
         if let selected = tabManager.selectedTab {
             if let url = selected.displayURL {
-                var shareController = UIActivityViewController(activityItems: [selected.title ?? url.absoluteString!, url], applicationActivities: nil)
-                shareController.modalTransitionStyle = .CoverVertical
-                presentViewController(shareController, animated: true, completion: nil)
+                var activityViewController = UIActivityViewController(activityItems: [selected.title ?? url.absoluteString!, url], applicationActivities: nil)
+                if let popoverPresentationController = activityViewController.popoverPresentationController {
+                    popoverPresentationController.sourceView = browserToolbar
+                    popoverPresentationController.sourceRect = button.frame
+                    popoverPresentationController.permittedArrowDirections = .Any
+                }
+                presentViewController(activityViewController, animated: true, completion: nil)
             }
         }
     }


### PR DESCRIPTION
This fixes a crash on the iPad that happens when we try to present the `UIActivityController`.

Because we need to know the source view/frame of the button pressed, i have also added a reference to the button in the `BrowserToolbarDelegate` functions.