### PR TITLE
Fixes 1145108 - Aurora build shows a No Mail Accounts message on startup

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -7,16 +7,6 @@ import Alamofire
 import MessageUI
 import Shared
 
-#if MOZ_CHANNEL_AURORA
-/*
- A workaround for an issue with MFMailComposerViewController:
-http://stackoverflow.com/questions/25604552/i-have-real-misunderstanding-with-mfmailcomposeviewcontroller-in-swift-ios8-in
-
- Also, MFMailComposeViewController doesn't work in the iOS 8 simulator.
-*/
-private var mailComposer: MFMailComposeViewController!
-#endif
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow!
@@ -40,7 +30,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window.makeKeyAndVisible()
 
 #if MOZ_CHANNEL_AURORA
-        mailComposer = MFMailComposeViewController()
         checkForAuroraUpdate()
         registerFeedbackNotification()
 #endif
@@ -149,29 +138,23 @@ extension AppDelegate: UIAlertViewDelegate {
     
 extension AppDelegate: MFMailComposeViewControllerDelegate {
     func sendFeedbackMailWithImage(image: UIImage) {
-        let appVersion = NSBundle.mainBundle()
-            .objectForInfoDictionaryKey("CFBundleShortVersionString") as String
-        let buildNumber = NSBundle.mainBundle()
-            .objectForInfoDictionaryKey(kCFBundleVersionKey) as String
-        
         if (MFMailComposeViewController.canSendMail()) {
-            mailComposer.mailComposeDelegate = self
-            mailComposer.setSubject("Feedback on iOS client version v\(appVersion) (\(buildNumber))")
-            mailComposer.setToRecipients(["ios-feedback@mozilla.com"])
+            let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as String
+            let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey(kCFBundleVersionKey) as String
+
+            let mailComposeViewController = MFMailComposeViewController()
+            mailComposeViewController.mailComposeDelegate = self
+            mailComposeViewController.setSubject("Feedback on iOS client version v\(appVersion) (\(buildNumber))")
+            mailComposeViewController.setToRecipients(["ios-feedback@mozilla.com"])
             
             let imageData = UIImagePNGRepresentation(image)
-            mailComposer.addAttachmentData(imageData, mimeType: "image/png", fileName: "feedback.png")
-            self.window.rootViewController?.presentViewController(mailComposer,
-                animated: true, completion: nil)
+            mailComposeViewController.addAttachmentData(imageData, mimeType: "image/png", fileName: "feedback.png")
+            self.window.rootViewController?.presentViewController(mailComposeViewController, animated: true, completion: nil)
         }
     }
     
-    func mailComposeController(controller: MFMailComposeViewController!,
-        didFinishWithResult result: MFMailComposeResult, error: NSError!) {
-            controller.dismissViewControllerAnimated(true, completion: { () -> Void in
-                mailComposer = nil
-                mailComposer = MFMailComposeViewController()
-            })
+    func mailComposeController(mailComposeViewController: MFMailComposeViewController!, didFinishWithResult result: MFMailComposeResult, error: NSError!) {
+        mailComposeViewController.dismissViewControllerAnimated(true, completion: nil)
     }
 }
 #endif


### PR DESCRIPTION
I have removed the workaround where the `MFMailComposeViewController` is created at startup because without it things also seem to work fine. This gets rid of the 'No Mail Accounts' alert when the application starts.