### PR TITLE
Fixes 1147126 - Long-press and hold on a link crashes Firefox on iPad

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -980,6 +980,13 @@ extension BrowserViewController: LongPressGestureDelegate {
         actionSheetController.title = dialogTitleURL!.absoluteString
         var cancelAction = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel, nil)
         actionSheetController.addAction(cancelAction)
+
+        if let popoverPresentationController = actionSheetController.popoverPresentationController {
+            popoverPresentationController.sourceView = self.view
+            popoverPresentationController.sourceRect = CGRectInset(CGRect(origin: longPressRecognizer.locationInView(self.view), size: CGSizeZero), -8, -8)
+            popoverPresentationController.permittedArrowDirections = .Any
+        }
+        
         self.presentViewController(actionSheetController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Present the `UIAlertController` in a `UIPopoverPresentationController` if available.