### PR TITLE
Bug 1109656 - Implement domain autocompletion

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -250,7 +250,6 @@
 		59A680D1116F5BF6CCC9ED6F /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanel.swift */; };
 		59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
 		59A687335CF58A8004B23508 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
-		59A687B4A05CC772FE7E5A09 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68CCB63E2A565CB03F832 /* SearchViewController.swift */; };
 		59A6897152D30C846676DA34 /* TwoLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68B1F857A8638598A63A0 /* TwoLineCell.swift */; };
 		59A68ACAB9DB4B3E04E5D1B7 /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6825233896FC846499289 /* HistoryPanel.swift */; };
@@ -269,8 +268,10 @@
 		D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
 		D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */; };
 		D31FC24C1A8D923000BAF7EC /* Alamofire.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D339C2831AD354B400C087BD /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339C2821AD354B400C087BD /* Loader.swift */; };
 		D33D6BC81ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
 		D33D6BC91ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
+		D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34510871ACF415700EC27F0 /* SearchLoader.swift */; };
 		D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		D3589EF71A8D930000F28118 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E4CD9F191A6D9B7B00318571 /* libz.dylib */; };
 		D36998891AD70A0A00650C6C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36998881AD70A0A00650C6C /* IOKit.framework */; };
@@ -1086,7 +1087,9 @@
 		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotHelper.swift; sourceTree = "<group>"; };
 		D31FC2291A8D908800BAF7EC /* Alamofire.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Alamofire.xcodeproj; path = Carthage/Checkouts/Alamofire/Alamofire.xcodeproj; sourceTree = "<group>"; };
+		D339C2821AD354B400C087BD /* Loader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Thumbnails.swift; path = Storage/Thumbnails.swift; sourceTree = "<group>"; };
+		D34510871ACF415700EC27F0 /* SearchLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchLoader.swift; sourceTree = "<group>"; };
 		D34DC84D1A16C40C00D49B7B /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		D35275151AA8D13B00E9C906 /* ColorUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorUtils.swift; sourceTree = "<group>"; };
 		D36998881AD70A0A00650C6C /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -1858,6 +1861,7 @@
 				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
 				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
+				D34510871ACF415700EC27F0 /* SearchLoader.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -1890,6 +1894,7 @@
 				2F44FA171A9D425700FD20CC /* HashExtensions.swift */,
 				2F44FA1C1A9D460500FD20CC /* HexExtensions.swift */,
 				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
+				D339C2821AD354B400C087BD /* Loader.swift */,
 				282731A11ABC9D2600AA1954 /* Prefs.swift */,
 				288501FA1AC0F63800E7F670 /* ScannerExtensions.swift */,
 				2F13E77E1AC0BFF200D75081 /* StringExtensions.swift */,
@@ -2960,6 +2965,7 @@
 				288A2DB21AB8B37E0023ABC3 /* ReadWriteLock.swift in Sources */,
 				2FDE87541ABA3EBB005317B1 /* KeyboardHelper.swift in Sources */,
 				282730F11ABC99C100AA1954 /* Functions.swift in Sources */,
+				D339C2831AD354B400C087BD /* Loader.swift in Sources */,
 				288501FB1AC0F63800E7F670 /* ScannerExtensions.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
 				2FDE87521ABA3EA0005317B1 /* TimeConstants.swift in Sources */,
@@ -3166,6 +3172,7 @@
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
 				D38B2D341A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
+				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -346,6 +346,7 @@
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FA77971A43B5390010CD32 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D3FA77C41A44F9A80010CD32 /* Locales in Resources */ = {isa = PBXBuildFile; fileRef = D3FA77C31A44F9A80010CD32 /* Locales */; };
+		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
 		E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40FAB0B1A7ABB77009CB80D /* WebServer.swift */; };
 		E414F0791A8445A500283322 /* FennecAurora.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = E414F0781A8445A500283322 /* FennecAurora.entitlements */; };
 		E418D0D91A251B3200CAE47A /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
@@ -1145,6 +1146,7 @@
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FA77C31A44F9A80010CD32 /* Locales */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Locales; sourceTree = "<group>"; };
+		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
 		E40FAB0B1A7ABB77009CB80D /* WebServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServer.swift; sourceTree = "<group>"; };
 		E414F0781A8445A500283322 /* FennecAurora.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = FennecAurora.entitlements; sourceTree = "<group>"; };
 		E41A7D4A1A1BE04500245963 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
@@ -1721,6 +1723,7 @@
 		D38A1BEB1A9FA2CA00F6A386 /* Widgets */ = {
 			isa = PBXGroup;
 			children = (
+				D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */,
 				0BB5B2861AC0A2B90052877D /* SnackBar.swift */,
 				0BB5B2871AC0A2B90052877D /* Toolbar.swift */,
 				D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */,
@@ -3193,6 +3196,7 @@
 				2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
 				D38B2D3A1A8D96D00040E6B5 /* GCDWebServerResponse.m in Sources */,
+				D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */,
 				0BD19A671A25309B0084FBA7 /* ProfilePrefs.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				0BB5B2BC1AC0AB9F0052877D /* UIImage+Utils.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1821A83E87900EE869C /* NavigationTests.swift */; };
 		D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A994951A3686BD008AD1AC /* BrowserViewController.swift */; };
 		D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A994961A3686BD008AD1AC /* Browser.swift */; };
+		D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ACB4381AD33EBA00748D50 /* WeakList.swift */; };
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CE1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
@@ -1133,6 +1134,7 @@
 		D39FA1821A83E87900EE869C /* NavigationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationTests.swift; sourceTree = "<group>"; };
 		D3A994951A3686BD008AD1AC /* BrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserViewController.swift; sourceTree = "<group>"; };
 		D3A994961A3686BD008AD1AC /* Browser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
+		D3ACB4381AD33EBA00748D50 /* WeakList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakList.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D247311ABCEA1700771C7E /* ThumbnailTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailTests.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
@@ -1880,20 +1882,21 @@
 		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
 				D35275151AA8D13B00E9C906 /* ColorUtils.swift */,
 				E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */,
 				283306E81AB3BB87008999AC /* Functions.swift */,
 				2F44FA171A9D425700FD20CC /* HashExtensions.swift */,
 				2F44FA1C1A9D460500FD20CC /* HexExtensions.swift */,
-				288501FA1AC0F63800E7F670 /* ScannerExtensions.swift */,
 				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
 				282731A11ABC9D2600AA1954 /* Prefs.swift */,
+				288501FA1AC0F63800E7F670 /* ScannerExtensions.swift */,
 				2F13E77E1AC0BFF200D75081 /* StringExtensions.swift */,
 				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
 				0BB5B2BB1AC0AB9F0052877D /* UIImage+Utils.swift */,
 				D39A224A1AC2158800CC40D9 /* ViewExtensions.swift */,
-				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
+				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2953,6 +2956,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FDE87531ABA3EB4005317B1 /* ColorUtils.swift in Sources */,
+				D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */,
 				288A2DB21AB8B37E0023ABC3 /* ReadWriteLock.swift in Sources */,
 				2FDE87541ABA3EBB005317B1 /* KeyboardHelper.swift in Sources */,
 				282730F11ABC99C100AA1954 /* Functions.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -109,7 +109,7 @@ class BrowserViewController: UIViewController {
         header = wrapInEffect(urlBar, parent: view)
         urlBar.browserToolbarDelegate = self
 
-        searchLoader = SearchLoader(history: profile.history)
+        searchLoader = SearchLoader(history: profile.history, urlBar: urlBar)
 
         // Setup the reader mode control bar. This bar starts not visible with a zero height.
         readerModeBar = ReaderModeBarView(frame: CGRectZero)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -25,7 +25,8 @@ class BrowserViewController: UIViewController {
     private var webViewContainer: UIView!
     private let uriFixup = URIFixup()
     private var screenshotHelper: ScreenshotHelper!
-    private var homePanelIsInline: Bool = false
+    private var homePanelIsInline = false
+    private var searchLoader: SearchLoader!
 
     var profile: Profile!
 
@@ -107,6 +108,8 @@ class BrowserViewController: UIViewController {
         urlBar.delegate = self
         header = wrapInEffect(urlBar, parent: view)
         urlBar.browserToolbarDelegate = self
+
+        searchLoader = SearchLoader(history: profile.history)
 
         // Setup the reader mode control bar. This bar starts not visible with a zero height.
         readerModeBar = ReaderModeBarView(frame: CGRectZero)
@@ -228,6 +231,8 @@ class BrowserViewController: UIViewController {
         searchController!.searchEngines = profile.searchEngines
         searchController!.searchDelegate = self
         searchController!.profile = self.profile
+
+        searchLoader.addListener(searchController!)
 
         view.addSubview(searchController!.view)
         searchController!.view.snp_makeConstraints { make in
@@ -388,6 +393,8 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBar(urlBar: URLBarView, didEnterText text: String) {
+        searchLoader.query = text
+
         if text.isEmpty {
             hideSearchController()
         } else {

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Storage
+
+// TODO: Swift current requires that classes extending generic classes must also be generic.
+// This is a workaround until that requirement is fixed.
+typealias SearchLoader = _SearchLoader<AnyObject, AnyObject>
+
+class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor, SearchViewController> {
+    private let history: History
+
+    init(history: History) {
+        self.history = history
+        super.init()
+    }
+
+    var query: String = "" {
+        didSet {
+            if query.isEmpty {
+                self.load(Cursor(status: .Success, msg: "Empty query"))
+                return
+            }
+
+            let options = QueryOptions(filter: query, filterType: FilterType.Url, sort: QuerySort.Frecency)
+            self.history.get(options, complete: { (cursor: Cursor) in
+                if cursor.status != .Success {
+                    println("Err: \(cursor.statusMessage)")
+                } else {
+                    self.load(cursor)
+                }
+            })
+        }
+    }
+}

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -6,15 +6,23 @@ import Foundation
 import Shared
 import Storage
 
+private let URLBeforePathRegex = NSRegularExpression(pattern: "^https?://([^/]+/)", options: nil, error: nil)!
+
 // TODO: Swift current requires that classes extending generic classes must also be generic.
 // This is a workaround until that requirement is fixed.
 typealias SearchLoader = _SearchLoader<AnyObject, AnyObject>
 
+/**
+ * Shared data source for the SearchViewController and the URLBar domain completion.
+ * Since both of these use the same SQL query, we can perform the query once and dispatch the results.
+ */
 class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor, SearchViewController> {
     private let history: History
+    private let urlBar: URLBarView
 
-    init(history: History) {
+    init(history: History, urlBar: URLBarView) {
         self.history = history
+        self.urlBar = urlBar
         super.init()
     }
 
@@ -31,8 +39,43 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor, SearchViewController> {
                     println("Err: \(cursor.statusMessage)")
                 } else {
                     self.load(cursor)
+                    self.urlBar.setAutocompleteSuggestion(self.getAutocompleteSuggestion(cursor))
                 }
             })
         }
+    }
+
+    private func getAutocompleteSuggestion(cursor: Cursor) -> String? {
+        for result in cursor {
+            let url = (result as! Site).url
+
+            // Extract the pre-path substring from the URL. This should be more efficient than parsing via
+            // NSURL since we need to only look at the beginning of the string.
+            // Note that we won't match non-HTTP(S) URLs.
+            if let match = URLBeforePathRegex.firstMatchInString(url, options: nil, range: NSRange(location: 0, length: count(url))) {
+                // If the pre-path component starts with the filter, just use it as is.
+                let prePathURL = (url as NSString).substringWithRange(match.rangeAtIndex(0))
+                if prePathURL.startsWith(query) {
+                    return prePathURL
+                }
+
+                // Otherwise, find and use any matching domain.
+                // To simplify the search, prepend a ".", and search the string for ".query".
+                // For example, for http://en.m.wikipedia.org, domainWithDotPrefix will be ".en.m.wikipedia.org".
+                // This allows us to use the "." as a separator, so we can match "en", "m", "wikipedia", and "org",
+                let domain = (url as NSString).substringWithRange(match.rangeAtIndex(1))
+                let domainWithDotPrefix: String = ".\(domain)"
+                if let range = domainWithDotPrefix.rangeOfString(".\(query)", options: NSStringCompareOptions.CaseInsensitiveSearch, range: nil, locale: nil) {
+                    // We don't actually want to match the top-level domain ("com", "org", etc.) by itself, so
+                    // so make sure the result includes at least one ".".
+                    let matchedDomain: String = domainWithDotPrefix.substringFromIndex(advance(range.startIndex, 1))
+                    if matchedDomain.contains(".") {
+                        return matchedDomain
+                    }
+                }
+            }
+        }
+
+        return nil
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -47,7 +47,7 @@ protocol SearchViewControllerDelegate: class {
     func searchViewController(searchViewController: SearchViewController, didSelectURL url: NSURL)
 }
 
-class SearchViewController: SiteTableViewController, KeyboardHelperDelegate {
+class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
     var searchDelegate: SearchViewControllerDelegate?
 
     private var suggestClient: SearchSuggestClient?
@@ -222,7 +222,6 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate {
 
     override func reloadData() {
         querySuggestClient()
-        queryHistoryClient()
     }
 
     private func layoutTable() {
@@ -339,23 +338,9 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate {
         })
     }
 
-    private func queryHistoryClient() {
-        if searchQuery.isEmpty {
-            data = Cursor(status: .Success, msg: "Empty query")
-            return
-        }
-
-        let options = QueryOptions()
-        options.sort = .LastVisit
-        options.filter = searchQuery
-
-        profile.history.get(options, complete: { (data: Cursor) -> Void in
-            self.data = data
-            if data.status != .Success {
-                println("Err: \(data.statusMessage)")
-            }
-            self.tableView.reloadData()
-        })
+    func loader(dataLoaded data: Cursor) {
+        self.data = data
+        tableView.reloadData()
     }
 }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -365,7 +365,7 @@ extension SearchViewController: UITableViewDelegate {
 
         let section = SearchListSection(rawValue: indexPath.section)!
         if section == SearchListSection.BookmarksAndHistory {
-            if let site = data[indexPath.row] as? Site {
+            if let site = data?[indexPath.row] as? Site {
                 url = NSURL(string: site.url)
             }
         }
@@ -405,7 +405,7 @@ extension SearchViewController: UITableViewDataSource {
 
         case .BookmarksAndHistory:
             let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
-            if let site = data[indexPath.row] as? Site {
+            if let site = data?[indexPath.row] as? Site {
                 if let cell = cell as? TwoLineTableViewCell {
                     cell.setLines(site.title, detailText: site.url)
                     if let img = site.icon {
@@ -425,7 +425,7 @@ extension SearchViewController: UITableViewDataSource {
         case .SearchSuggestions:
             return searchEngines.shouldShowSearchSuggestions ? 1 : 0
         case .BookmarksAndHistory:
-            return data.count
+            return data?.count ?? 0
         }
     }
 

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -47,7 +47,7 @@ protocol SearchViewControllerDelegate: class {
     func searchViewController(searchViewController: SearchViewController, didSelectURL url: NSURL)
 }
 
-class SearchViewController: SiteTableViewController, UITableViewDelegate, KeyboardHelperDelegate {
+class SearchViewController: SiteTableViewController, KeyboardHelperDelegate {
     var searchDelegate: SearchViewControllerDelegate?
 
     private var suggestClient: SearchSuggestClient?
@@ -359,6 +359,43 @@ class SearchViewController: SiteTableViewController, UITableViewDelegate, Keyboa
     }
 }
 
+extension SearchViewController: UITableViewDelegate {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        var url: NSURL?
+
+        let section = SearchListSection(rawValue: indexPath.section)!
+        if section == SearchListSection.BookmarksAndHistory {
+            if let site = data[indexPath.row] as? Site {
+                url = NSURL(string: site.url)
+            }
+        }
+
+        if let url = url {
+            searchDelegate?.searchViewController(self, didSelectURL: url)
+        }
+    }
+
+    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        if let currentSection = SearchListSection(rawValue: indexPath.section) {
+            switch currentSection {
+            case .SearchSuggestions:
+                // heightForRowAtIndexPath is called *before* the cell is created, so to get the height,
+                // force a layout pass first.
+                suggestionCell.layoutIfNeeded()
+                return suggestionCell.frame.height
+            default:
+                return super.tableView(tableView, heightForRowAtIndexPath: indexPath)
+            }
+        }
+
+        return 0
+    }
+
+    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 0
+    }
+}
+
 extension SearchViewController: UITableViewDataSource {
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         switch SearchListSection(rawValue: indexPath.section)! {
@@ -392,43 +429,8 @@ extension SearchViewController: UITableViewDataSource {
         }
     }
 
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
-    }
-
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return SearchListSection.Count
-    }
-
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        var url: NSURL?
-
-        let section = SearchListSection(rawValue: indexPath.section)!
-        if section == SearchListSection.BookmarksAndHistory {
-            if let site = data[indexPath.row] as? Site {
-                url = NSURL(string: site.url)
-            }
-        }
-
-        if let url = url {
-            searchDelegate?.searchViewController(self, didSelectURL: url)
-        }
-    }
-
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        if let currentSection = SearchListSection(rawValue: indexPath.section) {
-            switch currentSection {
-            case .SearchSuggestions:
-                // heightForRowAtIndexPath is called *before* the cell is created, so to get the height,
-                // force a layout pass first.
-                suggestionCell.layoutIfNeeded()
-                return suggestionCell.frame.height
-            default:
-                return super.tableView(tableView, heightForRowAtIndexPath: indexPath)
-            }
-        }
-
-        return 0
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -35,7 +35,7 @@ protocol URLBarDelegate: class {
     func urlBar(urlBar: URLBarView, didSubmitText text: String)
 }
 
-class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, BrowserToolbarProtocol {
+class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDelegate, BrowserToolbarProtocol {
     weak var delegate: URLBarDelegate?
 
     private var locationView: BrowserLocationView!
@@ -90,7 +90,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         editTextField.returnKeyType = UIReturnKeyType.Go
         editTextField.clearButtonMode = UITextFieldViewMode.WhileEditing
         editTextField.layer.backgroundColor = UIColor.whiteColor().CGColor
-        editTextField.delegate = self
+        editTextField.autocompleteDelegate = self
         editTextField.font = AppConstants.DefaultMediumFont
         editTextField.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         editTextField.layer.borderColor = URLBarViewUX.TextFieldActiveBorderColor.CGColor
@@ -320,38 +320,38 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         delegate?.urlBarDidPressStop(self)
     }
 
-    func textFieldShouldReturn(textField: UITextField) -> Bool {
+    func autocompleteTextFieldShouldReturn(autocompleteTextField: AutocompleteTextField) -> Bool {
         delegate?.urlBar(self, didSubmitText: editTextField.text)
         return true
     }
 
-    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
-        let text = textField.text as NSString
-        let fullText = text.stringByReplacingCharactersInRange(range, withString: string)
-        delegate?.urlBar(self, didEnterText: fullText)
-
-        return true
+    func autocompleteTextField(autocompleteTextField: AutocompleteTextField, didTextChange text: String) {
+        delegate?.urlBar(self, didEnterText: text)
     }
 
-    func textFieldDidBeginEditing(textField: UITextField) {
+    func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField) {
         // Without the async dispatch below, text selection doesn't work
         // intermittently and crashes on the iPhone 6 Plus (bug 1124310).
         dispatch_async(dispatch_get_main_queue(), {
-            textField.selectedTextRange = textField.textRangeFromPosition(textField.beginningOfDocument, toPosition: textField.endOfDocument)
+            autocompleteTextField.selectedTextRange = autocompleteTextField.textRangeFromPosition(autocompleteTextField.beginningOfDocument, toPosition: autocompleteTextField.endOfDocument)
         })
 
-        textField.layer.borderWidth = 1
+        autocompleteTextField.layer.borderWidth = 1
         locationContainer.layer.shadowOpacity = 0
     }
 
-    func textFieldDidEndEditing(textField: UITextField) {
+    func autocompleteTextFieldDidEndEditing(autocompleteTextField: AutocompleteTextField) {
         locationContainer.layer.shadowOpacity = 0.05
-        textField.layer.borderWidth = 0
+        autocompleteTextField.layer.borderWidth = 0
     }
 
-    func textFieldShouldClear(textField: UITextField) -> Bool {
+    func autocompleteTextFieldShouldClear(autocompleteTextField: AutocompleteTextField) -> Bool {
         delegate?.urlBar(self, didEnterText: "")
         return true
+    }
+
+    func setAutocompleteSuggestion(suggestion: String?) {
+        editTextField.setAutocompleteSuggestion(suggestion)
     }
 
     func finishEditing() {
@@ -550,7 +550,7 @@ private class CurveView: UIView {
     }
 }
 
-private class ToolbarTextField: UITextField {
+private class ToolbarTextField: AutocompleteTextField {
     override func textRectForBounds(bounds: CGRect) -> CGRect {
         let rect = super.textRectForBounds(bounds)
         return rect.rectByInsetting(dx: 5, dy: 5)

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -36,7 +36,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = super.tableView(tableView, cellForRowAtIndexPath: indexPath)
         let offset = sectionOffsets[indexPath.section]!
-        if let site = data[indexPath.row + offset] as? Site {
+        if let site = data?[indexPath.row + offset] as? Site {
             if let cell = cell as? TwoLineTableViewCell {
                 cell.setLines(site.title, detailText: site.url)
                 if let img = site.icon {
@@ -53,7 +53,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
 
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let offset = sectionOffsets[indexPath.section]!
-        if let site = data[indexPath.row + offset] as? Site {
+        if let site = data?[indexPath.row + offset] as? Site {
             if let url = NSURL(string: site.url) {
                 homePanelDelegate?.homePanel(self, didSelectURL: url)
                 return
@@ -124,15 +124,17 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         sectionOffsets[searchingSection] = 0
 
         // Loop over all the data. Record the start of each "section" of our list.
-        for i in 0..<data.count {
-            if let site = data[i] as? Site {
-                if !isInSection(site.latestVisit!.date, section: searchingSection) {
-                    searchingSection++
-                    sectionOffsets[searchingSection] = i
-                }
+        if let data = data {
+            for i in 0..<data.count {
+                if let site = data[i] as? Site {
+                    if !isInSection(site.latestVisit!.date, section: searchingSection) {
+                        searchingSection++
+                        sectionOffsets[searchingSection] = i
+                    }
 
-                if searchingSection == NumSections {
-                    break
+                    if searchingSection == NumSections {
+                        break
+                    }
                 }
             }
         }
@@ -142,7 +144,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         // of a section easier.
         searchingSection++
         for i in searchingSection...NumSections {
-            sectionOffsets[i] = data.count
+            sectionOffsets[i] = data?.count ?? 0
         }
 
         // This function wants the size of a section, so return the distance between two adjacent ones

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// Delegate for the text field events. Since AutocompleteTextField owns the UITextFieldDelegate,
+/// callers must use this instead.
+protocol AutocompleteTextFieldDelegate: class {
+    func autocompleteTextField(autocompleteTextField: AutocompleteTextField, didTextChange text: String)
+    func autocompleteTextFieldShouldReturn(autocompleteTextField: AutocompleteTextField) -> Bool
+    func autocompleteTextFieldShouldClear(autocompleteTextField: AutocompleteTextField) -> Bool
+    func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField)
+    func autocompleteTextFieldDidEndEditing(autocompleteTextField: AutocompleteTextField)
+}
+
+private struct AutocompleteTextFieldUX {
+    static let HighlightColor = UIColor(rgb: 0xccdded)
+}
+
+class AutocompleteTextField: UITextField, UITextFieldDelegate {
+    weak var autocompleteDelegate: AutocompleteTextFieldDelegate?
+
+    private var autocompleting = false
+    private var acceptingSuggestions = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        super.delegate = self
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        super.delegate = self
+    }
+
+    private var enteredText: NSString = "" {
+        didSet {
+            autocompleteDelegate?.autocompleteTextField(self, didTextChange: enteredText as String)
+        }
+    }
+
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        let text = textField.text as NSString
+
+        // If we're autocompleting, stretch the range to the end of the text.
+        let range = autocompleting ? NSMakeRange(range.location, text.length - range.location) : range
+
+        // Update the entered text if we're adding characters or we're not autocompleting.
+        // Otherwise, we're going to clear the autocompletion, which means the entered text shouldn't change.
+        if !string.isEmpty || !autocompleting {
+            enteredText = text.stringByReplacingCharactersInRange(range, withString: string)
+        }
+
+        // TODO: short-circuit if no previous match and text is longer.
+        // TODO: cache last autocomplete result to prevent unnecessary iterations.
+        if !string.isEmpty {
+            acceptingSuggestions = true
+
+            // Do the replacement. We'll asynchronously set the autocompletion suggestion if needed.
+            return true
+        }
+
+        if autocompleting {
+            // Characters are being deleted, so clear the autocompletion, but don't change the text.
+            clearAutocomplete()
+            return false
+        }
+
+        // Characters are being deleted, and there's no autocompletion active, so go on.
+        return true
+    }
+
+    func setAutocompleteSuggestion(suggestion: String?) {
+        // We're not accepting suggestions, so ignore.
+        if !acceptingSuggestions {
+            return
+        }
+
+        // If there's no suggestion, clear the existing autocompletion and bail.
+        if suggestion == nil {
+            clearAutocomplete()
+            return
+        }
+
+        // Create the attributed string with the autocompletion highlight.
+        let attributedString = NSMutableAttributedString(string: suggestion!)
+        attributedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(self.enteredText.length, count(suggestion!) - self.enteredText.length))
+        attributedText = attributedString
+
+        // Set the current position to the beginning of the highlighted text.
+        let position = positionFromPosition(beginningOfDocument, offset: self.enteredText.length)
+        selectedTextRange = textRangeFromPosition(position, toPosition: position)
+
+        // Enable autocompletion mode as long as there are still suggested characters remaining.
+        autocompleting = enteredText != suggestion
+    }
+
+    /// Finalize any highlighted text.
+    private func finishAutocomplete() {
+        if autocompleting {
+            enteredText = attributedText?.string ?? ""
+            clearAutocomplete()
+        }
+    }
+
+    /// Clear any highlighted text and turn off the autocompleting flag.
+    private func clearAutocomplete() {
+        if autocompleting {
+            attributedText = NSMutableAttributedString(string: enteredText as String)
+            acceptingSuggestions = false
+            autocompleting = false
+
+            // Set the current position to the end of the text.
+            selectedTextRange = textRangeFromPosition(endOfDocument, toPosition: endOfDocument)
+        }
+    }
+
+    override func caretRectForPosition(position: UITextPosition!) -> CGRect {
+        return autocompleting ? CGRectZero : super.caretRectForPosition(position)
+    }
+
+    override func touchesEnded(touches: Set<NSObject>, withEvent event: UIEvent) {
+        finishAutocomplete()
+        super.touchesEnded(touches, withEvent: event)
+    }
+
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        finishAutocomplete()
+        return autocompleteDelegate?.autocompleteTextFieldShouldReturn(self) ?? true
+    }
+
+    func textFieldDidBeginEditing(textField: UITextField) {
+        autocompleteDelegate?.autocompleteTextFieldDidBeginEditing(self)
+    }
+
+    func textFieldDidEndEditing(textField: UITextField) {
+        finishAutocomplete()
+        autocompleteDelegate?.autocompleteTextFieldDidEndEditing(self)
+    }
+
+    func textFieldShouldClear(textField: UITextField) -> Bool {
+        clearAutocomplete()
+        return autocompleteDelegate?.autocompleteTextFieldShouldClear(self) ?? true
+    }
+}

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -63,7 +63,7 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
             reloadData()
         }
     }
-    var data: Cursor = Cursor(status: .Success, msg: "No data set")
+    var data: Cursor?
     var tableView = UITableView()
 
     override func viewDidLoad() {
@@ -84,15 +84,15 @@ class SiteTableViewController: UIViewController, UITableViewDelegate, UITableVie
     }
 
     func reloadData() {
-        if data.status != .Success {
-            println("Err: \(data.statusMessage)")
+        if data != nil && data!.status != .Success {
+            println("Err: \(data!.statusMessage)")
         } else {
             self.tableView.reloadData()
         }
     }
 
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return data.count
+        return data?.count ?? 0
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {

--- a/Utils/Loader.swift
+++ b/Utils/Loader.swift
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ * Interface for listening to Loader updates.
+ */
+public protocol LoaderListener: class {
+    typealias T
+    func loader(dataLoaded data: T)
+}
+
+/**
+ * Base implementation for a "push" data model.
+ * Interested clients add themselves as listeners for data changes.
+ */
+public class Loader<T, ListenerType: LoaderListener where T == ListenerType.T> {
+    private let listeners = WeakList<ListenerType>()
+
+    public init() {}
+
+    public func addListener(listener: ListenerType) {
+        listeners.add(listener)
+    }
+
+    public func load(data: T) {
+        for listener in listeners {
+            listener.loader(dataLoaded: data)
+        }
+    }
+}

--- a/Utils/WeakList.swift
+++ b/Utils/WeakList.swift
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ * A list that weakly holds references to its items.
+ * Note that while the references themselves are cleared, their wrapper objects
+ * are not (though they are reused). Also note that since slots are reused,
+ * order is not preserved.
+ *
+ * This class crashes at runtime with EXC_BAD_ACCESS if a protocol is given as
+ * the type T. Make sure to use a class type.
+ */
+public class WeakList<T: AnyObject>: SequenceType {
+    private var items = [WeakRef<T>]()
+
+    public init() {}
+
+    /**
+     * Adds an item to the list.
+     * Note that every insertion iterates through the list to find any "holes" (items that have
+     * been deallocated) to reuse them, so this class may not be appropriate in situations where
+     * appending is frequent.
+     */
+    public func add(item: T) {
+        for wrapper in items {
+            // Reuse any existing slots that have been deallocated.
+            if wrapper.value == nil {
+                wrapper.value = item
+                return
+            }
+        }
+
+        items.append(WeakRef(item))
+    }
+
+    public func generate() -> GeneratorOf<T> {
+        var index = 0
+
+        return GeneratorOf<T> {
+            if index >= self.items.count {
+                return nil
+            }
+
+            for i in index..<self.items.count {
+                if let value = self.items[i].value {
+                    index = i + 1
+                    return value
+                }
+            }
+
+            index = self.items.count
+            return nil
+        }
+    }
+}
+
+private class WeakRef<T: AnyObject> {
+    weak var value: T?
+
+    init(_ value: T) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
I was originally going to port over the autocomplete handling from the older PR, but it needed to be updated to handle requests asynchronously (from the profile), and I found the implementation a bit tricky to understand without any comments, so I decided to just write an `AutocompleteTextField` from scratch. There were a few edge case bugs that needed be ironed out, but it seems to work pretty well now.

Rather than parsing the URL via `NSURL`, I decided to use a regex -- mainly for performance. Unfortunately, SQLite doesn't have regex support built in, so our frecency query will return lots of false positives. Doing a full `NSURL` parse of all of these can get expensive, especially considering we only care about the part leading up to the path. Our Android implementation does this, and I notice it taking several _seconds_ to show autocomplete results sometimes, so I tried to come up with something better.