### PR TITLE
Bug 1151353 - Highlight selected search engine

### DIFF
--- a/Client/Frontend/Settings/SearchEnginePicker.swift
+++ b/Client/Frontend/Settings/SearchEnginePicker.swift
@@ -11,6 +11,7 @@ protocol SearchEnginePickerDelegate {
 class SearchEnginePicker: UITableViewController {
     var delegate: SearchEnginePickerDelegate?
     var engines: [OpenSearchEngine]!
+    var selectedSearchEngine: String?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,12 +29,20 @@ class SearchEnginePicker: UITableViewController {
         let cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: nil)
         cell.textLabel?.text = engine.shortName
         cell.imageView?.image = engine.image
+        if engine.shortName == selectedSearchEngine {
+            cell.accessoryType = UITableViewCellAccessoryType.Checkmark
+        }
         return cell
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let engine = engines[indexPath.item]
         delegate?.searchEnginePicker(self, didSelectSearchEngine: engine)
+        tableView.cellForRowAtIndexPath(indexPath)?.accessoryType = UITableViewCellAccessoryType.Checkmark
+    }
+    
+    override func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
+        tableView.cellForRowAtIndexPath(indexPath)?.accessoryType = UITableViewCellAccessoryType.None
     }
 
     func SELcancel() {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -106,6 +106,7 @@ class SearchSettingsTableViewController: UITableViewController {
             // Every engine is a valid choice for the default engine, even the current default engine.
             searchEnginePicker.engines = model.orderedEngines.sorted { e, f in e.shortName < f.shortName }
             searchEnginePicker.delegate = self
+            searchEnginePicker.selectedSearchEngine = model.defaultEngine.shortName
             navigationController?.pushViewController(searchEnginePicker, animated: true)
         }
         return nil


### PR DESCRIPTION
Currently Search Picker does't show which search engine has been selected. With this code an image "X"(can be changed later if required) will be shown in the selected search engine picker cell.