### PR TITLE
Bug 1145971 - URL bar long press context menu

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -7,6 +7,7 @@ import UIKit
 
 protocol BrowserLocationViewDelegate {
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView)
+    func browserLocationViewDidLongPressLocation(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView)
     func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView)
 }
@@ -41,6 +42,10 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: "SELtapLocationLabel:")
         locationLabel.addGestureRecognizer(tapGestureRecognizer)
+
+        // Long press gesture recognizer (for URL bar copying/pasting without entering editing mode)
+        let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: "SELlongPressLocationLabel:")
+        locationLabel.addGestureRecognizer(longPressGestureRecognizer)
 
         readerModeButton = ReaderModeButton(frame: CGRectZero)
         readerModeButton.hidden = true
@@ -99,6 +104,12 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
 
     func SELtapLocationLabel(recognizer: UITapGestureRecognizer) {
         delegate?.browserLocationViewDidTapLocation(self)
+    }
+
+    func SELlongPressLocationLabel(recognizer: UILongPressGestureRecognizer) {
+        if (recognizer.state == UIGestureRecognizerState.Began) {
+            delegate?.browserLocationViewDidLongPressLocation(self)
+        }
     }
 
     func SELtapReaderModeButton() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -353,6 +353,40 @@ extension BrowserViewController: URLBarDelegate {
         }
     }
 
+    func urlBarDidLongPressLocation(urlBar: URLBarView) {
+        let longPressAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
+
+        let pasteboardContents = UIPasteboard.generalPasteboard().string
+
+        // Check if anything is on the pasteboard
+        if pasteboardContents != nil {
+            let pasteAndGoAction = UIAlertAction(title: NSLocalizedString("Paste & Go", comment: "Paste the URL into the location bar and visit"), style: .Default, handler: { (alert: UIAlertAction!) -> Void in
+                self.urlBar(urlBar, didSubmitText: pasteboardContents!)
+            })
+            longPressAlertController.addAction(pasteAndGoAction)
+
+            let pasteAction = UIAlertAction(title: NSLocalizedString("Paste", comment: "Paste the URL into the location bar"), style: .Default, handler: { (alert: UIAlertAction!) -> Void in
+                urlBar.updateURLBarText(pasteboardContents!)
+            })
+            longPressAlertController.addAction(pasteAction)
+        }
+
+        let copyAddressAction = UIAlertAction(title: NSLocalizedString("Copy Address", comment: "Copy the URL from the location bar"), style: .Default, handler: { (alert: UIAlertAction!) -> Void in
+            UIPasteboard.generalPasteboard().string = urlBar.currentURL().absoluteString
+        })
+        longPressAlertController.addAction(copyAddressAction)
+
+        let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert view"), style: .Cancel, handler: nil)
+        longPressAlertController.addAction(cancelAction)
+
+        if let popoverPresentationController = longPressAlertController.popoverPresentationController {
+            popoverPresentationController.sourceView = urlBar
+            popoverPresentationController.sourceRect = urlBar.frame
+            popoverPresentationController.permittedArrowDirections = .Any
+        }
+        self.presentViewController(longPressAlertController, animated: true, completion: nil)
+    }
+
     func urlBar(urlBar: URLBarView, didEnterText text: String) {
         if text.isEmpty {
             hideSearchController()

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -30,6 +30,7 @@ protocol URLBarDelegate: class {
     func urlBarDidPressReload(urlBar: URLBarView)
     func urlBarDidBeginEditing(urlBar: URLBarView)
     func urlBarDidEndEditing(urlBar: URLBarView)
+    func urlBarDidLongPressLocation(urlBar: URLBarView)
     func urlBar(urlBar: URLBarView, didEnterText text: String)
     func urlBar(urlBar: URLBarView, didSubmitText text: String)
 }
@@ -252,6 +253,21 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         setNeedsUpdateConstraints()
     }
 
+    func currentURL() -> NSURL {
+        return locationView.url!
+    }
+
+    func updateURLBarText(text: String) {
+        delegate?.urlBarDidBeginEditing(self)
+
+        editTextField.text = text
+        editTextField.becomeFirstResponder()
+
+        updateLayoutForEditing(editing: true)
+
+        delegate?.urlBar(self, didEnterText: text)
+    }
+
     func updateTabCount(count: Int) {
         tabsButton.setTitle(count.description, forState: UIControlState.Normal)
         tabsButton.accessibilityValue = count.description
@@ -295,6 +311,10 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         editTextField.becomeFirstResponder()
 
         updateLayoutForEditing(editing: true)
+    }
+
+    func browserLocationViewDidLongPressLocation(browserLocationView: BrowserLocationView) {
+        delegate?.urlBarDidLongPressLocation(self)
     }
 
     func browserLocationViewDidTapReload(browserLocationView: BrowserLocationView) {


### PR DESCRIPTION
Addressed the feature request in Bug 1145971. Long pressing on the URL bar will now show an action sheet which allows the user to Copy Address, Paste & Go, or Paste (the paste options are only available if there is data on the pasteboard). This follows the same behaviour as found in Firefox for Android.

A `UILongPressGestureRecognizer` was added to the `locationLabel` within `BrowserLocationView`. The default values for press recognition have been kept (0.5 seconds, 1 touch) as those seem to be the same as found in the Android app. When the gesture recognizer fires it calls a new delegate method `browserLocationViewDidLongPressLocation` implemented in `URLBarView` which then calls another new delegate method `urlBarDidLongPressLocation` implemented in `BrowserViewController` which takes care of presenting the action sheet and handling the button which is selected.

As far as possible, existing methods were utilised. However, two new methods needed to be implemented in `URLBarView`. `currentURL` returns the current address in the URL bar (needed when copying the address) and `updateURLBarText` allows us to programatically change the text in the URL bar and put the UI into editing mode.