### PR TITLE
Bug 1151387: Properly hide/unhide views for accessibility in home panel and search view

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -198,6 +198,8 @@ class BrowserViewController: UIViewController {
             view.addSubview(homePanelController!.view)
             addChildViewController(homePanelController!)
         }
+        webViewContainer.hidden = true
+        toolbar?.hidden = !inline
         view.setNeedsUpdateConstraints()
     }
 
@@ -206,6 +208,8 @@ class BrowserViewController: UIViewController {
             controller.view.removeFromSuperview()
             controller.removeFromParentViewController()
             homePanelController = nil
+            webViewContainer.hidden = false
+            toolbar?.hidden = false
         }
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -240,6 +240,8 @@ class BrowserViewController: UIViewController {
             return
         }
 
+        homePanelController?.view?.hidden = true
+
         addChildViewController(searchController!)
     }
 
@@ -248,6 +250,7 @@ class BrowserViewController: UIViewController {
             searchController.view.removeFromSuperview()
             searchController.removeFromParentViewController()
             self.searchController = nil
+            homePanelController?.view?.hidden = false
         }
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -363,6 +363,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
     func prepareEditingAnimation(editing: Bool) {
         // Make sure everything is showing during the transition (we'll hide it afterwards).
         self.progressBar.hidden = editing
+        self.locationView.hidden = editing
         self.editTextField.hidden = !editing
         self.tabsButton.hidden = false
         self.cancelButton.hidden = false


### PR DESCRIPTION
Without this, both VoiceOver and Switch Control go over elements that are not
visually visible, and are thus not meant to be interacted with nor perceivable.

Patches donated by [A11Y LTD.](http://a11y.ltd.uk)