### PR TITLE
Fixes 1149683 - Allow long press on reader view icon to add to reading list

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -8,6 +8,7 @@ import UIKit
 protocol BrowserLocationViewDelegate {
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView)
+    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapStop(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapReload(browserLocationView: BrowserLocationView)
 }
@@ -55,6 +56,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
         readerModeButton = ReaderModeButton(frame: CGRectZero)
         readerModeButton.hidden = true
         readerModeButton.addTarget(self, action: "SELtapReaderModeButton", forControlEvents: .TouchUpInside)
+        readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: "SELlongPressReaderModeButton:"))
         addSubview(readerModeButton)
     }
 
@@ -116,6 +118,12 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate {
 
     func SELtapReaderModeButton() {
         delegate?.browserLocationViewDidTapReaderMode(self)
+    }
+
+    func SELlongPressReaderModeButton(recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.Began {
+            delegate?.browserLocationViewDidLongPressReaderMode(self)
+        }
     }
 
     func SELtapStopReload() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -295,6 +295,20 @@ extension BrowserViewController: URLBarDelegate {
         }
     }
 
+    func urlBarDidLongPressReaderMode(urlBar: URLBarView) {
+        if let tab = tabManager.selectedTab {
+            if var url = tab.displayURL? {
+                if let absoluteString = url.absoluteString {
+                    profile.readingList.add(item: ReadingListItem(url: absoluteString, title: tab.title)) { (success) -> Void in
+                        if success {
+                            // TODO Update reading view bar when that has been hooked up
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     func urlBar(urlBar: URLBarView, didEnterText text: String) {
         if text.isEmpty {
             hideSearchController()

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -24,6 +24,7 @@ private struct URLBarViewUX {
 protocol URLBarDelegate: class {
     func urlBarDidPressTabs(urlBar: URLBarView)
     func urlBarDidPressReaderMode(urlBar: URLBarView)
+    func urlBarDidLongPressReaderMode(urlBar: URLBarView)
     func urlBarDidPressStop(urlBar: URLBarView)
     func urlBarDidPressReload(urlBar: URLBarView)
     func urlBarDidBeginEditing(urlBar: URLBarView)
@@ -201,6 +202,10 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate {
 
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView) {
         delegate?.urlBarDidPressReaderMode(self)
+    }
+
+    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView) {
+        delegate?.urlBarDidLongPressReaderMode(self)
     }
 
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView) {


### PR DESCRIPTION
This patch adds a long press gesture handler to the reading view button in the location bar. If pressed long, the page is added to the reading list.

There is currently no feedback. Asking @darrinhenein and @tecgirl to give this a try and see if we need some kind of visual feedback. (How about a *sound clip* - of pages turning. Only half joking.)
