### PR TITLE
Bug 1148835 - Follow up to fix ui bustage

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -96,6 +96,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         editTextField.font = AppConstants.DefaultMediumFont
         editTextField.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         editTextField.layer.borderColor = URLBarViewUX.TextFieldActiveBorderColor.CGColor
+        editTextField.hidden = true
         editTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
         locationContainer.addSubview(editTextField)
 
@@ -416,8 +417,6 @@ class URLBarView: UIView, BrowserLocationViewDelegate, UITextFieldDelegate, Brow
         } else {
             finishEditingAnimation(editing)
         }
-
-        curveShape.setNeedsLayout()
     }
 
     func SELdidClickCancel() {


### PR DESCRIPTION
Silly mistake at the last second before landing. editTextField.hidden = true isn't set in finishAnimation() so we need to set it here at startup. I also removed an un-necessary call to setNeedsLayout on the curveShape.

I'm going to land this quickly to fix bustage, but if someone wants to review it later, I'll try to fix it tomorrow.