### PR TITLE
Bug 1149106 - Hide "Add to Reading List" (Safari) in the browser toolbar share popup

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -441,6 +441,8 @@ extension BrowserViewController: BrowserToolbarDelegate {
         if let selected = tabManager.selectedTab {
             if let url = selected.displayURL {
                 var activityViewController = UIActivityViewController(activityItems: [selected.title ?? url.absoluteString!, url], applicationActivities: nil)
+                // Hide 'Add to Reading List' which currently uses Safari
+                activityViewController.excludedActivityTypes = [UIActivityTypeAddToReadingList]
                 if let popoverPresentationController = activityViewController.popoverPresentationController {
                     // Using the button for the sourceView here results in this not showing on iPads.
                     popoverPresentationController.sourceView = toolbar ?? urlBar


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1149106, let's just hide the activity type for now