### PR TITLE
Bug 1153652 - Disable Browser tool bar buttons for url like "about:"

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -203,4 +203,9 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
         helper?.updateReloadStatus(isLoading)
     }
 
+    func updatePageStatus(isWebPage: Bool) {
+        bookmarkButton.enabled = isWebPage
+        stopReloadButton.enabled = isWebPage
+        shareButton.enabled = isWebPage
+    }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -831,6 +831,8 @@ extension BrowserViewController: TabManagerDelegate {
         toolbar?.updateBackStatus(selected?.canGoBack ?? false)
         toolbar?.updateFowardStatus(selected?.canGoForward ?? false)
         toolbar?.updateReloadStatus(selected?.webView.loading ?? false)
+        toolbar?.updatePageStatus(isWebPage(selected!.displayURL!))
+
         self.urlBar.updateBackStatus(selected?.canGoBack ?? false)
         self.urlBar.updateFowardStatus(selected?.canGoForward ?? false)
         self.urlBar.updateProgressBar(Float(selected?.webView.estimatedProgress ?? 0))
@@ -892,6 +894,17 @@ extension BrowserViewController: TabManagerDelegate {
         tab.webView.scrollView.delegate = nil
 
         tab.webView.removeFromSuperview()
+    }
+
+    func isWebPage(url: NSURL) -> Bool {
+        let httpSchemes = ["http", "https"]
+
+        if let scheme = url.scheme,
+            index = find(httpSchemes, scheme) {
+                return true
+        }
+        
+        return false
     }
 }
 
@@ -977,6 +990,8 @@ extension BrowserViewController: WKNavigationDelegate {
                 urlBar.updateURL(tab.displayURL);
                 toolbar?.updateBackStatus(webView.canGoBack)
                 toolbar?.updateFowardStatus(webView.canGoForward)
+                toolbar?.updatePageStatus(isWebPage(webView.URL!))
+
                 urlBar.updateBackStatus(webView.canGoBack)
                 urlBar.updateFowardStatus(webView.canGoForward)
                 showToolbars(animated: false)


### PR DESCRIPTION
Disable Browser toolbar buttons like reload, share and bookmark when the url is like "about:"

Bugzilla URL https://bugzilla.mozilla.org/show_bug.cgi?id=1153652