### PR TITLE
Fix scroll behaviour in tab tray

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -310,7 +310,7 @@ private class SwipeAnimator: NSObject {
 }
 
 extension SwipeAnimator: UIGestureRecognizerDelegate {
-    private func gestureRecognizerShouldBegin(recognizer: UIGestureRecognizer) -> Bool {
+    @objc private func gestureRecognizerShouldBegin(recognizer: UIGestureRecognizer) -> Bool {
         let cellView = recognizer.view as UIView!
         let panGesture = recognizer as! UIPanGestureRecognizer
         let translation = panGesture.translationInView(cellView.superview!)


### PR DESCRIPTION
* this broke (in 1.2?) so we need to expose this delegate to the obj-c runtime