### PR TITLE
Bug 1155859 - SwiftData fixes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
 		D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */; };
 		D31FC24C1A8D923000BAF7EC /* Alamofire.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D32CACED1AE04DA1000658EB /* TestSwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */; };
 		D339C2831AD354B400C087BD /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339C2821AD354B400C087BD /* Loader.swift */; };
 		D33D6BC81ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
 		D33D6BC91ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
@@ -1207,6 +1208,7 @@
 		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotHelper.swift; sourceTree = "<group>"; };
 		D31FC2291A8D908800BAF7EC /* Alamofire.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Alamofire.xcodeproj; path = Carthage/Checkouts/Alamofire/Alamofire.xcodeproj; sourceTree = "<group>"; };
+		D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSwiftData.swift; sourceTree = "<group>"; };
 		D339C2821AD354B400C087BD /* Loader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Thumbnails.swift; path = Storage/Thumbnails.swift; sourceTree = "<group>"; };
 		D34510871ACF415700EC27F0 /* SearchLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchLoader.swift; sourceTree = "<group>"; };
@@ -1827,7 +1829,6 @@
 			isa = PBXGroup;
 			children = (
 				2FCAE2791ABB533A00877008 /* MockFiles.swift */,
-				2FCAE27A1ABB533A00877008 /* TestSQLiteRemoteClientsAndTabs.swift */,
 				2FCAE27B1ABB533A00877008 /* TestBookmarks.swift */,
 				2FCAE27C1ABB533A00877008 /* TestFaviconsTable.swift */,
 				2FCAE27D1ABB533A00877008 /* TestHistoryTable.swift */,
@@ -1835,6 +1836,8 @@
 				2FCAE27F1ABB533A00877008 /* TestJoinedHistoryVisits.swift */,
 				2FCAE2801ABB533A00877008 /* TestReadingListTable.swift */,
 				2FCAE2811ABB533A00877008 /* TestSQLiteReadingList.swift */,
+				2FCAE27A1ABB533A00877008 /* TestSQLiteRemoteClientsAndTabs.swift */,
+				D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */,
 				2FCAE2821ABB533A00877008 /* TestTableTable.swift */,
 				2FCAE2831ABB533A00877008 /* TestVisitsTable.swift */,
 				2FCAE22B1ABB51F800877008 /* Supporting Files */,
@@ -2091,7 +2094,6 @@
 		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				287DA9D51AE06D220055AC35 /* Extensions */,
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
 				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
@@ -2102,6 +2104,7 @@
 				282731A11ABC9D2600AA1954 /* Prefs.swift */,
 				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
 				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
+				287DA9D51AE06D220055AC35 /* Extensions */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3456,6 +3459,7 @@
 				2FA4351A1ABB6829008031D1 /* Site.swift in Sources */,
 				2FCAE28B1ABB533A00877008 /* TestReadingListTable.swift in Sources */,
 				2FA435211ABB6831008031D1 /* JoinedHistoryVisitsTable.swift in Sources */,
+				D32CACED1AE04DA1000658EB /* TestSwiftData.swift in Sources */,
 				2FCAE28A1ABB533A00877008 /* TestJoinedHistoryVisits.swift in Sources */,
 				2FA4352C1ABB6873008031D1 /* Visit.swift in Sources */,
 				2FA435201ABB6831008031D1 /* JoinedFaviconsHistoryTable.swift in Sources */,

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -17,9 +17,13 @@ public class MockProfile: Profile {
         return name
     }
 
+    lazy var db: BrowserDB = {
+        return BrowserDB(files: self.files)
+    } ()
+
     lazy var bookmarks: protocol<BookmarksModelFactory, ShareToDestination> = {
         // Eventually this will be a SyncingBookmarksModel or an OfflineBookmarksModel, perhaps.
-        return BookmarksSqliteFactory(files: self.files)
+        return BookmarksSqliteFactory(db: self.db)
         } ()
 
     lazy var searchEngines: SearchEngines = {
@@ -35,11 +39,11 @@ public class MockProfile: Profile {
         } ()
 
     lazy var favicons: Favicons = {
-        return SQLiteFavicons(files: self.files)
+        return SQLiteFavicons(db: self.db)
         }()
 
     lazy var history: History = {
-        return SQLiteHistory(files: self.files)
+        return SQLiteHistory(db: self.db)
         }()
 
     lazy var readingList: ReadingListService? = {
@@ -47,7 +51,7 @@ public class MockProfile: Profile {
         }()
 
     private lazy var remoteClientsAndTabs: RemoteClientsAndTabs = {
-        return SQLiteRemoteClientsAndTabs(files: self.files)
+        return SQLiteRemoteClientsAndTabs(db: self.db)
         }()
 
     lazy var passwords: Passwords = {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -94,8 +94,12 @@ public class BrowserProfile: Profile {
         return ProfileFileAccessor(profile: self)
     }
 
+    lazy var db: BrowserDB = {
+        return BrowserDB(files: self.files)
+    } ()
+
     lazy var bookmarks: protocol<BookmarksModelFactory, ShareToDestination> = {
-        return BookmarksSqliteFactory(files: self.files)
+        return BookmarksSqliteFactory(db: self.db)
     }()
 
     lazy var searchEngines: SearchEngines = {
@@ -107,7 +111,7 @@ public class BrowserProfile: Profile {
     }
 
     lazy var favicons: Favicons = {
-        return SQLiteFavicons(files: self.files)
+        return SQLiteFavicons(db: self.db)
     }()
 
     // lazy var ReadingList readingList
@@ -117,7 +121,7 @@ public class BrowserProfile: Profile {
     }()
 
     lazy var history: History = {
-        return SQLiteHistory(files: self.files)
+        return SQLiteHistory(db: self.db)
     }()
 
     lazy var readingList: ReadingListService? = {
@@ -125,7 +129,7 @@ public class BrowserProfile: Profile {
     }()
 
     private lazy var remoteClientsAndTabs: RemoteClientsAndTabs = {
-        return SQLiteRemoteClientsAndTabs(files: self.files)
+        return SQLiteRemoteClientsAndTabs(db: self.db)
     }()
 
     private class func syncClientsToStorage(storage: RemoteClientsAndTabs, prefs: Prefs, ready: Ready) -> Deferred<Result<Ready>> {
@@ -186,7 +190,7 @@ public class BrowserProfile: Profile {
     }
 
     lazy var passwords: Passwords = {
-        return SQLitePasswords(files: self.files)
+        return SQLitePasswords(db: self.db)
     }()
 
     lazy var thumbnails: Thumbnails = {

--- a/Storage/Cursor.swift
+++ b/Storage/Cursor.swift
@@ -73,6 +73,12 @@ public class Cursor: SequenceType {
         status = .Closed
         statusMessage = "Closed"
     }
+
+    deinit {
+        if status != CursorStatus.Closed {
+            close()
+        }
+    }
 }
 
 /*

--- a/Storage/Favicons.swift
+++ b/Storage/Favicons.swift
@@ -6,8 +6,6 @@ import UIKit
 
 /* The base favicons protocol */
 public protocol Favicons {
-    init(files: FileAccessor)
-
     var defaultIcon: UIImage { get }
 
     func clear(options: QueryOptions?, complete: ((success: Bool) -> Void)?)

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -4,8 +4,6 @@
 
 /* The base history protocol */
 public protocol History {
-    init(files: FileAccessor)
-
     func clear(complete: (success: Bool) -> Void)
     func get(options: QueryOptions?, complete: (data: Cursor) -> Void)
     func addVisit(visit: Visit, complete: (success: Bool) -> Void)

--- a/Storage/ReadingList.swift
+++ b/Storage/ReadingList.swift
@@ -38,8 +38,6 @@ public class ReadingListItem {
 }
 
 public protocol ReadingList {
-    init(files: FileAccessor)
-
     func clear(complete: (success: Bool) -> Void)
     func get(complete: (data: Cursor) -> Void)
     func add(#item: ReadingListItem, complete: (success: Bool) -> Void)

--- a/Storage/SQL/BookmarksSqlite.swift
+++ b/Storage/SQL/BookmarksSqlite.swift
@@ -176,8 +176,8 @@ public class BookmarksSqliteFactory : BookmarksModelFactory, ShareToDestination 
     let db: BrowserDB
     let table = BookmarkTable<BookmarkNode>()
 
-    public init(files: FileAccessor) {
-        db = BrowserDB(files: files)!
+    public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(table)
     }
 

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -41,7 +41,7 @@ let DBCouldNotOpenErrorCode = 200
 // Version 3 - Added a favicons table
 // Version 4 - Added a readinglist table
 // Version 5 - Added the clients and the tabs tables.
-class BrowserDB {
+public class BrowserDB {
     private let db: SwiftData
     // XXX: Increasing this should blow away old history, since we currently dont' support any upgrades
     private let Version: Int = 5
@@ -51,7 +51,7 @@ class BrowserDB {
 
     private var initialized = [String]()
 
-    init?(files: FileAccessor) {
+    public init(files: FileAccessor) {
         self.files = files
         db = SwiftData(filename: files.getAndEnsureDirectory()!.stringByAppendingPathComponent(FileName))
         self.schemaTable = SchemaTable()

--- a/Storage/SQL/SQLFavicons.swift
+++ b/Storage/SQL/SQLFavicons.swift
@@ -9,7 +9,6 @@ import UIKit
  * The sqlite-backed implementation of the favicons protocol.
  */
 public class SQLiteFavicons : Favicons {
-    let files: FileAccessor
     let db: BrowserDB
     let table = JoinedFaviconsHistoryTable<(Site, Favicon)>()
 
@@ -17,9 +16,8 @@ public class SQLiteFavicons : Favicons {
         return UIImage(named: "defaultFavicon")!
     }()
 
-    required public init(files: FileAccessor) {
-        self.files = files
-        self.db = BrowserDB(files: files)!
+    required public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(table)
     }
 
@@ -28,8 +26,6 @@ public class SQLiteFavicons : Favicons {
         let res = db.delete(&err) { (conn, inout err: NSError?) -> Int in
             return self.table.delete(conn, item: nil, err: &err)
         }
-
-        files.remove("favicons")
 
         dispatch_async(dispatch_get_main_queue()) {
             complete?(success: err == nil)

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -8,14 +8,12 @@ import Foundation
  * The sqlite-backed implementation of the history protocol.
  */
 public class SQLiteHistory : History {
-    let files: FileAccessor
     let db: BrowserDB
     private let table = JoinedHistoryVisitsTable()
     private var ignoredSchemes = ["about"]
 
-    required public init(files: FileAccessor) {
-        self.files = files
-        self.db = BrowserDB(files: files)!
+    required public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(table)
     }
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -56,6 +56,10 @@ public class SQLiteHistory : History {
                 return nil
             }
         }
+
+        public override func close() {
+            cursor.close()
+        }
     }
 
     public func get(options: QueryOptions?, complete: (data: Cursor) -> Void) {

--- a/Storage/SQL/SQLitePasswords.swift
+++ b/Storage/SQL/SQLitePasswords.swift
@@ -97,8 +97,8 @@ public class SQLitePasswords : Passwords {
     private let table = PasswordsTable<Password>()
     private let db: BrowserDB
 
-    public init(files: FileAccessor) {
-        self.db = BrowserDB(files: files)!
+    public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(table)
     }
 

--- a/Storage/SQL/SQLiteReadingList.swift
+++ b/Storage/SQL/SQLiteReadingList.swift
@@ -8,13 +8,11 @@ import Foundation
  * The SQLite-backed implementation of the ReadingList protocol.
  */
 public class SQLiteReadingList: ReadingList {
-    let files: FileAccessor
     let db: BrowserDB
     let table = ReadingListTable<ReadingListItem>()
 
-    required public init(files: FileAccessor) {
-        self.files = files
-        self.db = BrowserDB(files: files)!
+    required public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(table)
     }
 

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -21,14 +21,12 @@ public class DatabaseError: ErrorType {
 }
 
 public class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
-    let files: FileAccessor
     let db: BrowserDB
     let clients = RemoteClientsTable<RemoteClient>()
     let tabs = RemoteTabsTable<RemoteTab>()
 
-    public init(files: FileAccessor) {
-        self.files = files
-        self.db = BrowserDB(files: files)!
+    public init(db: BrowserDB) {
+        self.db = db
         db.createOrUpdate(clients)
         db.createOrUpdate(tabs)
     }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -47,6 +47,10 @@ public class SwiftData {
     let filename: String
     init(filename: String) {
         self.filename = filename
+
+        // Ensure that multi-thread mode is enabled by default.
+        // See https://www.sqlite.org/threadsafe.html
+        assert(sqlite3_threadsafe() == 2)
     }
 
     /**

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -36,12 +36,9 @@ import Foundation
 import UIKit
 import sqlite3
 
-/// All database operations actually occur serially on this queue. Careful not to deadlock it!
-private let queue = dispatch_queue_create("swiftdata queue", DISPATCH_QUEUE_SERIAL)
-
 /**
- * The public interface for the database.
- * This handles dispatching calls synchronously on the correct thread.
+ * Handle to a SQLite database.
+ * Each instance holds a single connection that is shared across all queries.
  */
 public class SwiftData {
     let filename: String
@@ -49,12 +46,32 @@ public class SwiftData {
     /// Used for testing.
     static var EnableWAL = true
 
+    /// Used for testing.
+    static var ReuseConnections = true
+
+    /// For thread-safe access to the shared connection.
+    private let sharedConnectionQueue: dispatch_queue_t
+
+    /// Shared connection to this database.
+    private var sharedConnection: SQLiteDBConnection?
+
     init(filename: String) {
         self.filename = filename
+        self.sharedConnectionQueue = dispatch_queue_create("SwiftData queue: \(filename)", DISPATCH_QUEUE_SERIAL)
 
         // Ensure that multi-thread mode is enabled by default.
         // See https://www.sqlite.org/threadsafe.html
         assert(sqlite3_threadsafe() == 2)
+    }
+
+    private func getSharedConnection(inout error: NSError?) -> SQLiteDBConnection? {
+        dispatch_sync(sharedConnectionQueue) {
+            if self.sharedConnection == nil {
+                self.sharedConnection = SQLiteDBConnection(filename: self.filename, flags: SwiftData.Flags.ReadWriteCreate.toSQL(), error: &error)
+            }
+        }
+
+        return sharedConnection
     }
 
     /**
@@ -63,13 +80,20 @@ public class SwiftData {
      */
     public func withConnection(flags: SwiftData.Flags, cb: (db: SQLiteDBConnection) -> NSError?) -> NSError? {
         var error: NSError? = nil
-        let task: () -> Void = {
-            if let db = SQLiteDBConnection(filename: self.filename, flags: flags.toSQL(), error: &error) {
-                error = cb(db: db)
+        var connection: SQLiteDBConnection?
+
+        if SwiftData.ReuseConnections {
+            connection = getSharedConnection(&error)
+        } else {
+            connection = SQLiteDBConnection(filename: filename, flags: flags.toSQL(), error: &error)
+        }
+
+        if let connection = connection {
+            dispatch_sync(connection.queue) {
+                error = cb(db: connection)
             }
         }
 
-        dispatch_sync(queue) { task() }
         return error
     }
 
@@ -120,6 +144,7 @@ public class SQLiteDBConnection {
     private var sqliteDB: COpaquePointer = nil
     private let filename: String
     private let debug_enabled = false
+    private let queue: dispatch_queue_t
 
     public var version: Int {
         get {
@@ -134,6 +159,7 @@ public class SQLiteDBConnection {
 
     init?(filename: String, flags: Int32, inout error: NSError?) {
         self.filename = filename
+        queue = dispatch_queue_create("SQLite connection: \(filename)", DISPATCH_QUEUE_SERIAL)
         if let err = openWithFlags(flags) {
             error = err
             return nil

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -142,6 +142,9 @@ public class SQLiteDBConnection {
         if SwiftData.EnableWAL {
             executeQuery("PRAGMA journal_mode=WAL", factory: StringFactory)
         }
+
+        // Retry queries before returning locked errors.
+        sqlite3_busy_timeout(sqliteDB, 3 * 1000)
     }
 
     deinit {

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -45,6 +45,10 @@ private let queue = dispatch_queue_create("swiftdata queue", DISPATCH_QUEUE_SERI
  */
 public class SwiftData {
     let filename: String
+
+    /// Used for testing.
+    static var EnableWAL = true
+
     init(filename: String) {
         self.filename = filename
 
@@ -133,6 +137,10 @@ public class SQLiteDBConnection {
         if let err = openWithFlags(flags) {
             error = err
             return nil
+        }
+
+        if SwiftData.EnableWAL {
+            executeQuery("PRAGMA journal_mode=WAL", factory: StringFactory)
         }
     }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -227,7 +227,7 @@ public class SQLiteDBConnection {
 
     public var version: Int {
         get {
-            let res = executeQuery("PRAGMA user_version", factory: IntFactory)
+            let res = executeQueryUnsafe("PRAGMA user_version", factory: IntFactory)
             return res[0] as? Int ?? 0
         }
 
@@ -245,7 +245,7 @@ public class SQLiteDBConnection {
         }
 
         if SwiftData.EnableWAL {
-            executeQuery("PRAGMA journal_mode=WAL", factory: StringFactory)
+            executeQueryUnsafe("PRAGMA journal_mode=WAL", factory: StringFactory)
         }
 
         // Retry queries before returning locked errors.
@@ -324,6 +324,7 @@ public class SQLiteDBConnection {
     }
 
     /// Queries the database.
+    /// Returns a cursor pre-filled with the complete result set.
     func executeQuery<T>(sqlStr: String, factory: ((SDRow) -> T), withArgs args: [AnyObject?]? = nil) -> Cursor {
         var error: NSError?
         let statement = SQLiteDBStatement(connection: self, query: sqlStr, args: args, error: &error)
@@ -331,7 +332,22 @@ public class SQLiteDBConnection {
             return Cursor(err: error)
         }
 
-        return SDCursor(statement: statement!, factory: factory)
+        return FilledSQLiteCursor(statement: statement!, factory: factory)
+    }
+
+    /**
+     * Queries the database.
+     * Returns a live cursor that holds the query statement and database connection.
+     * Instances of this class *must not* leak outside of the connection queue!
+     */
+    func executeQueryUnsafe<T>(sqlStr: String, factory: ((SDRow) -> T), withArgs args: [AnyObject?]? = nil) -> Cursor {
+        var error: NSError?
+        let statement = SQLiteDBStatement(connection: self, query: sqlStr, args: args, error: &error)
+        if let error = error {
+            return Cursor(err: error)
+        }
+
+        return LiveSQLiteCursor(statement: statement!, factory: factory)
     }
 }
 
@@ -529,21 +545,87 @@ private struct SDError {
     }
 }
 
-/// Wrapper around a statement to help with iterating through the results. This currently
-/// only fetches items when asked for, and caches (all) old requests. Ideally it will
-/// at somepoint fetch a window of items to keep in memory.
-private class SDCursor<T> : Cursor {
-    private var statement: SQLiteDBStatement!
+/// Provides access to the result set returned by a database query.
+/// The entire result set is cached, so this does not retain a reference
+/// to the statement or the database connection.
+private class FilledSQLiteCursor<T>: Cursor {
     // Function for generating objects of type T from a row.
     private let factory: (SDRow) -> T
+
+    // Cache of all items in the result set.
+    private var rows = [T]()
+
+    override private var count: Int {
+        get {
+            return rows.count
+        }
+    }
+
+    private init(statement: SQLiteDBStatement, factory: (SDRow) -> T) {
+        self.factory = factory
+
+        super.init(status: .Success, msg: "success")
+
+        fill(statement)
+    }
+
+    /// Fill the cursor with the set of results and release the statement.
+    private func fill(statement: SQLiteDBStatement) {
+        var count = 0
+        status = CursorStatus.Success
+
+        var columns = [String]()
+        let columnCount = sqlite3_column_count(statement.pointer)
+        for i in 0..<columnCount {
+            let columnName = String.fromCString(sqlite3_column_name(statement.pointer, i))!
+            columns.append(columnName)
+        }
+
+        while true {
+            let sqlStatus = sqlite3_step(statement.pointer)
+
+            if sqlStatus != SQLITE_ROW {
+                if sqlStatus != SQLITE_DONE {
+                    status = CursorStatus.Failure
+                }
+                break
+            }
+
+            count++
+
+            let row = SDRow(statement: statement, columns: columns)
+            let result = self.factory(row)
+            self.rows.append(result)
+        }
+
+        sqlite3_reset(statement.pointer)
+    }
+
+    override private subscript(index: Int) -> Any? {
+        get {
+            if status != .Success {
+                return nil
+            }
+
+            return rows[index]
+        }
+    }
+}
+
+/// Wrapper around a statement to help with iterating through the results.
+private class LiveSQLiteCursor<T>: Cursor {
+    private var statement: SQLiteDBStatement!
+
+    // Function for generating objects of type T from a row.
+    private let factory: (SDRow) -> T
+
     // Status of the previous fetch request.
     private var sqlStatus: Int32 = 0
-    // Cache of perviously fetched results (and their row numbers)
-    var cache = [Int: T]()
+
     // Number of rows in the database
     // XXX - When Cursor becomes an interface, this should be a normal property, but right now
     //       we can't override the Cursor getter for count with a stored property.
-    private let _count: Int
+    private var _count: Int = 0
     override var count: Int {
         get {
             if status != .Success {
@@ -612,25 +694,17 @@ private class SDCursor<T> : Cursor {
                 return nil
             }
 
-            if let row = cache[index] {
-                return row
-            }
-
             self.position = index
             if self.sqlStatus != SQLITE_ROW {
                 return nil
             }
 
             let row = SDRow(statement: statement, columns: self.columns)
-            let res = self.factory(row)
-            self.cache[index] = res
-
-            return res
+            return self.factory(row)
         }
     }
 
     override func close() {
-        cache.removeAll(keepCapacity: false)
         statement = nil
         super.close()
     }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -140,6 +140,85 @@ public class SwiftData {
     }
 }
 
+/**
+ * Wrapper class for a SQLite statement.
+ * This class helps manage the statement lifecycle. By holding a reference to the SQL connection, we ensure
+ * the connection is never deinitialized while the statement is active. This class is responsible for
+ * finalizing the SQL statement once it goes out of scope.
+ */
+private class SQLiteDBStatement {
+    var pointer: COpaquePointer = nil
+    private let connection: SQLiteDBConnection
+
+    init?(connection: SQLiteDBConnection, query: String, args: [AnyObject?]?, error: NSErrorPointer) {
+        self.connection = connection
+
+        var status = sqlite3_prepare_v2(connection.sqliteDB, query, -1, &pointer, nil)
+        if status != SQLITE_OK {
+            if error != nil {
+                error.memory = connection.createErr("During: SQL Prepare \(query)", status: Int(status))
+            }
+            return nil
+        }
+
+        if let args = args {
+            let bindError = bind(args)
+
+            if bindError != nil {
+                if error != nil {
+                    error.memory = bindError
+                }
+                return nil
+            }
+        }
+    }
+
+    /// Binds arguments to the statement.
+    private func bind(objects: [AnyObject?]) -> NSError? {
+        let count = Int(sqlite3_bind_parameter_count(pointer))
+        if (count < objects.count) {
+            return connection.createErr("During: Bind", status: 202)
+        } else if (count > objects.count) {
+            return connection.createErr("During: Bind", status: 201)
+        }
+
+        for (index, obj) in enumerate(objects) {
+            var status: Int32 = SQLITE_OK
+
+            // Double's also pass obj is Int, so order is important here
+            if obj is Double {
+                status = sqlite3_bind_double(pointer, Int32(index+1), obj as! Double)
+            } else if obj is Int {
+                status = sqlite3_bind_int(pointer, Int32(index+1), Int32(obj as! Int))
+            } else if obj is Bool {
+                status = sqlite3_bind_int(pointer, Int32(index+1), (obj as! Bool) ? 1 : 0)
+            } else if obj is String {
+                let negativeOne = UnsafeMutablePointer<Int>(bitPattern: -1)
+                let opaquePointer = COpaquePointer(negativeOne)
+                let transient = CFunctionPointer<((UnsafeMutablePointer<()>) -> Void)>(opaquePointer)
+                status = sqlite3_bind_text(pointer, Int32(index+1), (obj as! String).cStringUsingEncoding(NSUTF8StringEncoding)!, -1, transient)
+            } else if obj is NSData {
+                status = sqlite3_bind_blob(pointer, Int32(index+1), (obj as! NSData).bytes, -1, nil)
+            } else if obj is NSDate {
+                var timestamp = (obj as! NSDate).timeIntervalSince1970
+                status = sqlite3_bind_double(pointer, Int32(index+1), timestamp)
+            } else if obj === nil {
+                status = sqlite3_bind_null(pointer, Int32(index+1))
+            }
+
+            if status != SQLITE_OK {
+                return connection.createErr("During: Bind", status: Int(status))
+            }
+        }
+
+        return nil
+    }
+
+    deinit {
+        sqlite3_finalize(pointer)
+    }
+}
+
 public class SQLiteDBConnection {
     private var sqliteDB: COpaquePointer = nil
     private let filename: String
@@ -228,94 +307,31 @@ public class SQLiteDBConnection {
     }
 
     /// Executes a change on the database.
-    func executeChange(sqlStr: String, withArgs: [AnyObject?]? = nil) -> NSError? {
-        var err: NSError? = nil
-        var pStmt: COpaquePointer = nil
-
-        var status = sqlite3_prepare_v2(sqliteDB, sqlStr, -1, &pStmt, nil)
-        if status != SQLITE_OK {
-            let err = createErr("During: SQL Prepare \(sqlStr)", status: Int(status))
-            sqlite3_finalize(pStmt)
-            return err
+    func executeChange(sqlStr: String, withArgs args: [AnyObject?]? = nil) -> NSError? {
+        var error: NSError?
+        let statement = SQLiteDBStatement(connection: self, query: sqlStr, args: args, error: &error)
+        if let error = error {
+            return error
         }
 
-        if let args = withArgs {
-            if let err = bind(args, stmt: pStmt) {
-                sqlite3_finalize(pStmt)
-                return err
-            }
-        }
-
-        status = sqlite3_step(pStmt)
+        let status = sqlite3_step(statement!.pointer)
 
         if status != SQLITE_DONE && status != SQLITE_OK {
-            err = createErr("During: SQL Step \(sqlStr)", status: Int(status))
+            error = createErr("During: SQL Step \(sqlStr)", status: Int(status))
         }
 
-        sqlite3_finalize(pStmt)
-        return err
+        return error
     }
 
     /// Queries the database.
-    func executeQuery<T>(sqlStr: String, factory: ((SDRow) -> T), withArgs: [AnyObject?]? = nil) -> Cursor {
-        var pStmt: COpaquePointer = nil
-
-        let status = sqlite3_prepare_v2(sqliteDB, sqlStr, -1, &pStmt, nil)
-        if status != SQLITE_OK {
-            let err = createErr("During: SQL Prepare \(sqlStr)", status: Int(status))
-            sqlite3_finalize(pStmt)
-            return Cursor(err: err)
+    func executeQuery<T>(sqlStr: String, factory: ((SDRow) -> T), withArgs args: [AnyObject?]? = nil) -> Cursor {
+        var error: NSError?
+        let statement = SQLiteDBStatement(connection: self, query: sqlStr, args: args, error: &error)
+        if let error = error {
+            return Cursor(err: error)
         }
 
-        if let args = withArgs {
-            if let err = bind(args, stmt: pStmt) {
-                sqlite3_finalize(pStmt)
-                return Cursor(err: err)
-            }
-        }
-
-        return SDCursor(db: self, stmt: pStmt, factory: factory)
-    }
-
-    // Bind objects to a query
-    private func bind(objects: [AnyObject?], stmt: COpaquePointer) -> NSError? {
-        let count = Int(sqlite3_bind_parameter_count(stmt))
-        if (count < objects.count) {
-            return createErr("During: Bind", status: 202)
-        } else if (count > objects.count) {
-            return createErr("During: Bind", status: 201)
-        }
-
-        for (index, obj) in enumerate(objects) {
-            var status: Int32 = SQLITE_OK
-
-            // Double's also pass obj is Int, so order is important here
-            if obj is Double {
-                status = sqlite3_bind_double(stmt, Int32(index+1), obj as! Double)
-            } else if obj is Int {
-                status = sqlite3_bind_int(stmt, Int32(index+1), Int32(obj as! Int))
-            } else if obj is Bool {
-                status = sqlite3_bind_int(stmt, Int32(index+1), (obj as! Bool) ? 1 : 0)
-            } else if obj is String {
-                let negativeOne = UnsafeMutablePointer<Int>(bitPattern: -1)
-                let opaquePointer = COpaquePointer(negativeOne)
-                let transient = CFunctionPointer<((UnsafeMutablePointer<()>) -> Void)>(opaquePointer)
-                status = sqlite3_bind_text(stmt, Int32(index+1), (obj as! String).cStringUsingEncoding(NSUTF8StringEncoding)!, -1, transient)
-            } else if obj is NSData {
-                status = sqlite3_bind_blob(stmt, Int32(index+1), (obj as! NSData).bytes, -1, nil)
-            } else if obj is NSDate {
-                var timestamp = (obj as! NSDate).timeIntervalSince1970
-                status = sqlite3_bind_double(stmt, Int32(index+1), timestamp)
-            } else if obj === nil {
-                status = sqlite3_bind_null(stmt, Int32(index+1))
-            }
-
-            if status != SQLITE_OK {
-                return createErr("During: Binding", status: Int(status))
-            }
-        }
-
-        return nil
+        return SDCursor(statement: statement!, factory: factory)
     }
 }
 
@@ -333,18 +349,14 @@ func StringFactory(row: SDRow) -> String {
 /// and a generator for iterating over columns.
 class SDRow: SequenceType {
     // The sqlite statement this row came from.
-    private let stmt: COpaquePointer
+    private let statement: SQLiteDBStatement
 
     // The columns of this database. The indices of these are assumed to match the indices
     // of the statement.
     private let columnNames: [String]
 
-    // We hold a reference to the connection to keep it from being closed.
-    private let db: SQLiteDBConnection
-
-    private init(connection: SQLiteDBConnection, stmt: COpaquePointer, columns: [String]) {
-        db = connection
-        self.stmt = stmt
+    private init(statement: SQLiteDBStatement, columns: [String]) {
+        self.statement = statement
         self.columnNames = columns
     }
 
@@ -352,23 +364,23 @@ class SDRow: SequenceType {
     private func getValue(index: Int) -> AnyObject? {
         let i = Int32(index)
 
-        let type = sqlite3_column_type(stmt, i)
+        let type = sqlite3_column_type(statement.pointer, i)
         var ret: AnyObject? = nil
 
         switch type {
         case SQLITE_NULL, SQLITE_INTEGER:
-            ret = NSNumber(longLong: sqlite3_column_int64(stmt, i))
+            ret = NSNumber(longLong: sqlite3_column_int64(statement.pointer, i))
         case SQLITE_TEXT:
-            let text = UnsafePointer<Int8>(sqlite3_column_text(stmt, i))
+            let text = UnsafePointer<Int8>(sqlite3_column_text(statement.pointer, i))
             ret = String.fromCString(text)
         case SQLITE_BLOB:
-            let blob = sqlite3_column_blob(stmt, i)
+            let blob = sqlite3_column_blob(statement.pointer, i)
             if blob != nil {
-                let size = sqlite3_column_bytes(stmt, i)
+                let size = sqlite3_column_bytes(statement.pointer, i)
                 ret = NSData(bytes: blob, length: Int(size))
             }
         case SQLITE_FLOAT:
-            ret = Double(sqlite3_column_double(stmt, i))
+            ret = Double(sqlite3_column_double(statement.pointer, i))
         default:
             println("SwiftData Warning -> Column: \(index) is of an unrecognized type, returning nil")
         }
@@ -521,13 +533,11 @@ private struct SDError {
 /// only fetches items when asked for, and caches (all) old requests. Ideally it will
 /// at somepoint fetch a window of items to keep in memory.
 private class SDCursor<T> : Cursor {
-    private let stmt: COpaquePointer
+    private var statement: SQLiteDBStatement!
     // Function for generating objects of type T from a row.
     private let factory: (SDRow) -> T
     // Status of the previous fetch request.
     private var sqlStatus: Int32 = 0
-    // Hold a reference to the connection so that it isn't closed
-    private let db: SQLiteDBConnection
     // Cache of perviously fetched results (and their row numbers)
     var cache = [Int: T]()
     // Number of rows in the database
@@ -555,32 +565,30 @@ private class SDCursor<T> : Cursor {
             // If we're currently somewhere in the list after this position
             // we'll have to jump back to the start.
             if (position < oldValue) {
-                sqlite3_reset(self.stmt)
+                sqlite3_reset(self.statement.pointer)
                 stepStart = -1
             }
 
             // Now step up through the list to the requested position
             for i in stepStart..<position {
-                sqlStatus = sqlite3_step(self.stmt)
+                sqlStatus = sqlite3_step(self.statement.pointer)
             }
         }
     }
 
-    init(db: SQLiteDBConnection, stmt: COpaquePointer, factory: (SDRow) -> T) {
-        // We will hold the db open until we're thrown away
-        self.db = db
-        self.stmt = stmt
+    init(statement: SQLiteDBStatement, factory: (SDRow) -> T) {
         self.factory = factory
+        self.statement = statement
 
         // The only way I know to get a count. Walk through the entire statement to see how many rows there are.
         var count = 0
-        self.sqlStatus = sqlite3_step(self.stmt)
+        self.sqlStatus = sqlite3_step(statement.pointer)
         while self.sqlStatus != SQLITE_DONE {
             count++
-            self.sqlStatus = sqlite3_step(self.stmt)
+            self.sqlStatus = sqlite3_step(statement.pointer)
         }
 
-        sqlite3_reset(self.stmt)
+        sqlite3_reset(statement.pointer)
         self._count = count
 
         super.init(status: .Success, msg: "success")
@@ -589,22 +597,14 @@ private class SDCursor<T> : Cursor {
     // Helper for finding all the column names in this statement.
     private lazy var columns: [String] = {
         // This untangles all of the columns and values for this row when its created
-        let columnCount = sqlite3_column_count(self.stmt)
+        let columnCount = sqlite3_column_count(self.statement.pointer)
         var columns = [String]()
         for var i: Int32 = 0; i < columnCount; ++i {
-            let columnName = String.fromCString(sqlite3_column_name(self.stmt, i))!
+            let columnName = String.fromCString(sqlite3_column_name(self.statement.pointer, i))!
             columns.append(columnName)
         }
         return columns
     }()
-
-    // Finalize the statement when we're destroyed. This will also release our reference
-    // to the database, which will hopefully close it as well.
-    deinit {
-        if status == .Success {
-            sqlite3_finalize(self.stmt)
-        }
-    }
 
     override subscript(index: Int) -> Any? {
         get {
@@ -621,7 +621,7 @@ private class SDCursor<T> : Cursor {
                 return nil
             }
 
-            let row = SDRow(connection: db, stmt: self.stmt, columns: self.columns)
+            let row = SDRow(statement: statement, columns: self.columns)
             let res = self.factory(row)
             self.cache[index] = res
 
@@ -630,8 +630,8 @@ private class SDCursor<T> : Cursor {
     }
 
     override func close() {
-        sqlite3_finalize(self.stmt)
         cache.removeAll(keepCapacity: false)
+        statement = nil
         super.close()
     }
 }

--- a/StorageTests/TestSQLiteReadingList.swift
+++ b/StorageTests/TestSQLiteReadingList.swift
@@ -11,7 +11,7 @@ class TestSQLiteReadingList: XCTestCase {
     override func setUp() {
         let files = MockFiles()
         files.remove("browser.db")
-        readingList = SQLiteReadingList(files: files)
+        readingList = SQLiteReadingList(db: BrowserDB(files: files))
     }
 
     func testInsertAndQueryAndClear() {

--- a/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -73,7 +73,7 @@ class SQLRemoteClientsAndTabsTests: XCTestCase {
     override func setUp() {
         let files = MockFiles()
         files.remove("browser.db")
-        clientsAndTabs = SQLiteRemoteClientsAndTabs(files: files)
+        clientsAndTabs = SQLiteRemoteClientsAndTabs(db: BrowserDB(files: files))
     }
 
 

--- a/StorageTests/TestSwiftData.swift
+++ b/StorageTests/TestSwiftData.swift
@@ -1,0 +1,110 @@
+import Foundation
+import XCTest
+import Storage
+
+class TestSwiftData: XCTestCase {
+    var swiftData: SwiftData!
+
+    override func setUp() {
+        let files = MockFiles()
+        files.remove("testSwiftData.db")
+        let testDB = files.getAndEnsureDirectory()!.stringByAppendingPathComponent("testSwiftData.db")
+        swiftData = SwiftData(filename: testDB)
+
+        // Ensure static flags match expected values.
+        XCTAssert(SwiftData.ReuseConnections, "Reusing database connections")
+        XCTAssert(SwiftData.EnableWAL, "WAL enabled")
+    }
+
+    override func tearDown() {
+        // Restore static flags to their default values.
+        SwiftData.ReuseConnections = true
+        SwiftData.EnableWAL = true
+    }
+
+    func testNoWALOrConnectionReuse() {
+        SwiftData.ReuseConnections = false
+        SwiftData.EnableWAL = false
+        var error = writeDuringRead()
+        XCTAssertEqual(error!.code, 5, "Got 'database is locked' error")
+    }
+
+    func testNoConnectionReuse() {
+        SwiftData.ReuseConnections = false
+        var error = writeDuringRead()
+        XCTAssertEqual(error!.code, 8, "Got 'attempt to write to read-only database' error")
+    }
+
+    func testNoWAL() {
+        SwiftData.EnableWAL = false
+        var error = writeDuringRead()
+        XCTAssertNil(error, "Insertion succeeded")
+    }
+
+    func testDefaultSettings() {
+        var error = writeDuringRead()
+        XCTAssertNil(error, "Insertion succeeded")
+    }
+
+    func testBusyTimeout() {
+        SwiftData.ReuseConnections = false
+        SwiftData.EnableWAL = false
+        var error = writeDuringRead(closeTimeout: 1)
+        XCTAssertNil(error, "Insertion succeeded")
+    }
+
+    func testFilledCursor() {
+        SwiftData.ReuseConnections = false
+        SwiftData.EnableWAL = false
+        var error = writeDuringRead(safeQuery: true)
+        XCTAssertNil(error, "Insertion succeeded")
+    }
+
+    private func writeDuringRead(safeQuery: Bool = false, closeTimeout: UInt64? = nil) -> NSError? {
+        let historyTable = HistoryTable<Site>()
+
+        swiftData.withConnection(SwiftData.Flags.ReadWriteCreate) { db in
+            historyTable.create(db, version: 1)
+            return nil
+        }
+
+        var error = addSite(historyTable, url: "url0", title: "title0")
+        XCTAssertNil(error, "Inserted URL")
+
+        // Query the database and hold the cursor.
+        var historyCursor: Cursor!
+        error = swiftData.withConnection(SwiftData.Flags.ReadOnly) { db in
+            let (query, args) = historyTable.getQueryAndArgs(nil)!
+            if safeQuery {
+                historyCursor = db.executeQuery(query, factory: historyTable.factory!, withArgs: args)
+            } else {
+                historyCursor = db.executeQueryUnsafe(query, factory: historyTable.factory!, withArgs: args)
+            }
+            return nil
+        }
+        XCTAssertNil(error, "Queried database")
+
+        // If we have a live cursor, this will step to the first result.
+        // Stepping through a prepared statement without resetting it will lock the connection.
+        historyCursor[0]
+
+        // Close the cursor after a delay if there's a close timeout set.
+        if let closeTimeout = closeTimeout {
+            let queue = dispatch_queue_create("cursor timeout queue", DISPATCH_QUEUE_SERIAL)
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(closeTimeout * NSEC_PER_SEC)), queue) {
+                historyCursor.close()
+            }
+        }
+
+        return addSite(historyTable, url: "url1", title: "title1")
+    }
+
+    private func addSite(history: HistoryTable<Site>, url: String, title: String) -> NSError? {
+        return swiftData.withConnection(.ReadWrite) { connection -> NSError? in
+            var err: NSError?
+            let site = Site(url: url, title: title)
+            history.insert(connection, item: site, err: &err)
+            return err
+        }
+    }
+}

--- a/StorageTests/TestTableTable.swift
+++ b/StorageTests/TestTableTable.swift
@@ -9,7 +9,7 @@ class TestSchemaTable: XCTestCase {
     // This is a very basic test. Adds an entry. Retrieves it, and then clears the database
     func testTable() {
         let files = MockFiles()
-        var db = BrowserDB(files: files)!
+        var db = BrowserDB(files: files)
 
         // Test creating a table
         var testTable = getCreateTable()


### PR DESCRIPTION
As discussed, there are a number of changes we want to make to our SQLite implementation, including:
  * Cursor caching
  * Enabling WAL
  * Enabling SQLite multi-thread mode
  * Using a single connection per DB
  * Setting a busy handler for locked connections

Some notes:
* Interestingly, SQLite multi-thread mode seems to be enabled by default (according to [this](https://www.sqlite.org/threadsafe.html), a `sqlite_threadsafe()` result of 2 means multi-thread).
* When writing while reading with WAL enabled, I noticed the error changes from 5 (busy) to 8 (readonly). Not sure I fully understand what's happening here, but I added a test to make sure it's consistent.
* Related: I wasn't able to come up with good WAL or multi-thread mode tests. I was thinking either of them might fix the write-with-an-open-connection failure in the test case here, but that wasn't the case. Ideas welcome.