### PR TITLE
Bug 1153300 - Navigate back to a new about:home tab on empty tray

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -195,6 +195,11 @@ private class CustomCell: UICollectionViewCell {
         let tab = self.delegate.tabManager.getTab(indexPath.item)
         self.delegate.tabManager.removeTab(tab)
         self.delegate.collectionView.deleteItemsAtIndexPaths([indexPath])
+
+        // Navigate to an about:home tab from an empty tray
+        if self.delegate.tabManager.count == 0 {
+            self.delegate.SELdidClickAddTab()
+        }
     }
 }
 
@@ -558,6 +563,11 @@ extension TabTrayController: SwipeAnimatorDelegate {
             let tab = tabManager.getTab(indexPath.item)
             tabManager.removeTab(tab)
             collectionView.deleteItemsAtIndexPaths([indexPath])
+
+            // Navigate to an about:home tab from an empty tray
+            if tabManager.count == 0 {
+                SELdidClickAddTab()
+            }
         }
     }
 }


### PR DESCRIPTION
opens a new about:home tab on empty tray like on Android; had to add this twice for the 'x' and for the swipe