### PR TITLE
Fixes 1152396 - Use WKProcessPool

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -49,8 +49,14 @@ class TabManager {
     var selectedIndex: Int { return _selectedIndex }
     private let defaultNewTabRequest: NSURLRequest
 
+    private var configuration: WKWebViewConfiguration
+
     init(defaultNewTabRequest: NSURLRequest) {
         self.defaultNewTabRequest = defaultNewTabRequest
+
+        // Create a common webview configuration with a shared process pool.
+        configuration = WKWebViewConfiguration()
+        configuration.processPool = WKProcessPool()
     }
 
     var count: Int {
@@ -103,13 +109,13 @@ class TabManager {
         }
     }
 
-    func addTab(var request: NSURLRequest! = nil, configuration: WKWebViewConfiguration = WKWebViewConfiguration()) -> Browser {
+    func addTab(var request: NSURLRequest! = nil, configuration: WKWebViewConfiguration! = nil) -> Browser {
         assert(NSThread.isMainThread())
         if request == nil {
             request = defaultNewTabRequest
         }
 
-        let tab = Browser(configuration: configuration)
+        let tab = Browser(configuration: configuration ?? self.configuration)
         addTab(tab)
         tab.loadRequest(request)
         selectTab(tab)


### PR DESCRIPTION
This patch lets the `TabManager` manage a global `WKWebViewConfiguration` with a single `WKProcessPool`. All tabs that do not explicitly specify a custom `WKWebViewConfiguration` when created will use this shared one.

We only have one `TabManager` instance in the application, which is why I decided to put this logic here.