### PR TITLE
1136219 - Hide the carets upon entering the Awesomescreen

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -333,7 +333,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         // Without the async dispatch below, text selection doesn't work
         // intermittently and crashes on the iPhone 6 Plus (bug 1124310).
         dispatch_async(dispatch_get_main_queue(), {
-            autocompleteTextField.selectedTextRange = autocompleteTextField.textRangeFromPosition(autocompleteTextField.beginningOfDocument, toPosition: autocompleteTextField.endOfDocument)
+            autocompleteTextField.selectAll()
         })
 
         autocompleteTextField.layer.borderWidth = 1

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -121,7 +121,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     /// Clear any highlighted text and turn off the autocompleting flag.
     private func clearAutocomplete() {
         if autocompleting {
-            attributedText = NSMutableAttributedString(string: enteredText as String)
+            let attributedString = NSMutableAttributedString(string: enteredText as String)
+            attributedString.addAttribute(NSBackgroundColorAttributeName, value: UIColor.clearColor(), range: NSMakeRange(0, enteredText.length))
+            attributedText = attributedString
+
             acceptingSuggestions = false
             autocompleting = false
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -96,6 +96,20 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         autocompleting = enteredText != suggestion
     }
 
+    /// Select all text in the field using the special autocomplete highlight style.
+    func selectAll() {
+        clearAutocomplete()
+
+        // Create the attributed string with the autocompletion highlight.
+        let attributedString = NSMutableAttributedString(string: self.text)
+        attributedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(0, count(self.text)))
+        attributedText = attributedString
+
+        // Clear the selection, mark the field as being autocompleted so that we can type over it
+        selectedTextRange = nil
+        autocompleting = true
+    }
+
     /// Finalize any highlighted text.
     private func finishAutocomplete() {
         if autocompleting {


### PR DESCRIPTION
This patch introduces a `AutocompleteTextField.selectAll()` method and calls that when you enter the Awesome Screen. This results in the initial text being selected as in Safari: with the text highlighted but without the carrots. You can immediately start typing over the text.