### PR TITLE
Bug 1147625 - Cache screenshots on Browser

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -22,6 +22,7 @@ class Browser: NSObject, WKScriptMessageHandler {
     var browserDelegate: BrowserDelegate? = nil
     var bars = [SnackBar]()
     var favicons = [Favicon]()
+    var screenshot: UIImage?
 
     init(configuration: WKWebViewConfiguration) {
         configuration.userContentController = WKUserContentController()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -332,7 +332,11 @@ extension BrowserViewController: URLBarDelegate {
         controller.tabManager = tabManager
         controller.transitioningDelegate = self
         controller.modalPresentationStyle = .Custom
-        controller.screenshotHelper = screenshotHelper
+
+        if let tab = tabManager.selectedTab {
+            tab.screenshot = screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1)
+        }
+
         presentViewController(controller, animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -332,7 +332,6 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
     private let CellIdentifier = "CellIdentifier"
     var collectionView: UICollectionView!
     var profile: Profile!
-    var screenshotHelper: ScreenshotHelper!
     var numberOfColumns: Int!
 
     var navBar: UINavigationBar!
@@ -443,7 +442,7 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
         }
 
         let screenshotAspectRatio = cell.frame.width / TabTrayControllerUX.CellHeight
-        cell.background.image = screenshotHelper.takeScreenshot(tab, aspectRatio: screenshotAspectRatio, quality: 1)
+        cell.background.image = tab.screenshot
         cell.closeTab.addTarget(cell, action: "SELdidPressClose", forControlEvents: UIControlEvents.TouchUpInside)
 
         // calling setupFrames here fixes reused cells which don't get resized on rotation
@@ -505,10 +504,7 @@ extension TabTrayController: Transitionable {
             options.moving = transitionCell
         }
 
-        if let browser = browser {
-            transitionCell.background.image = screenshotHelper.takeScreenshot(browser, aspectRatio: 0, quality: 1)
-        }
-
+        transitionCell.background.image = browser?.screenshot
         transitionCell.titleText.text = browser?.displayTitle
         if let favIcon = browser?.displayFavicon {
             transitionCell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)


### PR DESCRIPTION
Cache the screenshot on each Browser. This should give us a minor perf win, and should also prevent gray thumbnails from showing up in the tab tray.

One drawback with this approach is that screenshots are tied to the orientation of the phone. If a tab's screenshot is cached, then we switch to another tab, and then rotate the phone, the screenshot will be zoomed/clipped. The animation is also janky when clicking it since it won't line up with the webview in the actual orientation. This is a tricky problem to solve, though, and Chrome has the same issue, so I wouldn't consider this a blocker.