### PR TITLE
Bug 1158020 - Allow deleting bookmarks from the UI

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -286,7 +286,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func removeBookmark(url: String) {
-        var bookmark = BookmarkItem(guid: "", title: "", url: url)
+        var bookmark = BookmarkItem(title: "", url: url)
         profile.bookmarks.remove(bookmark, success: { success in
             self.toolbar?.updateBookmarkStatus(!success)
             self.urlBar.updateBookmarkStatus(!success)

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -75,4 +75,25 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             }
         }
     }
+
+    func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
+        // Intentionally blank. Required to use UITableViewRowActions
+    }
+
+    func tableView(tableView: UITableView, editActionsForRowAtIndexPath indexPath: NSIndexPath) -> [AnyObject]? {
+        let title = NSLocalizedString("Delete", tableName: "BookmarkPanel", comment: "Action button for deleting bookmarks in the bookmarks panel.")
+
+        let delete = UITableViewRowAction(style: UITableViewRowActionStyle.Default, title: title, handler: { (action, indexPath) in
+            if let bookmark = self.source?.current[indexPath.row] {
+                self.profile.bookmarks.remove(bookmark, success: { success in
+                    self.source?.reloadData({ model in
+                        self.source = model
+                        self.tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Left)
+                    }, failure: self.onModelFailure)
+                }, failure: self.onModelFailure)
+            }
+        })
+
+        return [delete]
+    }
 }

--- a/Storage/SQL/BookmarksSqlite.swift
+++ b/Storage/SQL/BookmarksSqlite.swift
@@ -162,16 +162,17 @@ class BookmarkTable<T> : GenericTable<BookmarkNode> {
             if let type = options?.filterType {
                 switch(type) {
                 case .ExactUrl:
-                        args.append(filter)
-                        return ("\(sql) WHERE bookmarkUrl = ?", args)
+                    args.append(filter)
+                    return ("\(sql) WHERE bookmarkUrl = ?", args)
+                case .Guid:
+                    args.append(filter)
+                    return ("\(sql) WHERE guid = ?", args)
                 default:
-                    break
+                    // Default to search by parent folder.id
+                    args.append(filter)
+                    return ("\(sql) WHERE parent = ?", args)
                 }
             }
-
-            // Default to search by guid (i.e. for a folder)
-            args.append(filter)
-            return ("\(sql) WHERE guid = ?", args)
         }
 
         return (sql, args)

--- a/Storage/SQL/BookmarksSqlite.swift
+++ b/Storage/SQL/BookmarksSqlite.swift
@@ -88,8 +88,20 @@ class BookmarkTable<T> : GenericTable<BookmarkNode> {
         }
         args.append(item.title)
         args.append(item.favicon?.id)
-        args.append(item.guid)
-        return ("UPDATE \(name) SET url = ?, title = ?, faviconId = ? WHERE guid = ?", args)
+        args.append(item.parent)
+
+        if let id = item.id {
+            // If we knew the exact item ID, use it.
+            args.append(id)
+            return ("UPDATE \(name) SET url = ?, title = ?, faviconId = ?, parent = ? WHERE id = ?", args)
+        } else if let bookmark = item as? BookmarkItem {
+            // If the caller didn't know an ID, but only knew a url, they probably want to remove any bookmarks with the url.
+            args.append(bookmark.url)
+            return ("UPDATE \(name) SET url = ?, title = ?, faviconId = ?, parent = ? WHERE url = ?", args)
+        }
+
+        // If the caller passed a folder with no id. This shouldn't be hit.
+        return nil
     }
 
     override func getDeleteAndArgs(inout item: BookmarkNode?) -> (String, [AnyObject?])? {

--- a/Storage/SQL/BookmarksSqlite.swift
+++ b/Storage/SQL/BookmarksSqlite.swift
@@ -74,8 +74,9 @@ class BookmarkTable<T> : GenericTable<BookmarkNode> {
 
         args.append(item.title)
         args.append(item.favicon?.id)
+        args.append(item.parent)
 
-        return ("INSERT INTO \(name) (guid, url, title, faviconId) VALUES (?,?,?,?)", args)
+        return ("INSERT INTO \(name) (guid, url, title, faviconId, parent) VALUES (?,?,?,?,?)", args)
     }
 
     override func getUpdateAndArgs(inout item: BookmarkNode) -> (String, [AnyObject?])? {

--- a/Storage/SQL/BookmarksSqlite.swift
+++ b/Storage/SQL/BookmarksSqlite.swift
@@ -19,7 +19,14 @@ class BookmarkTable<T> : GenericTable<BookmarkNode> {
 
 
     override func create(db: SQLiteDBConnection, version: Int) -> Bool {
-        return super.create(db, version: version) && favicons.create(db, version: version) && joinedFavicons.create(db, version: version)
+        var created = super.create(db, version: version) && favicons.create(db, version: version) && joinedFavicons.create(db, version: version)
+        // insert a default places folder.
+        var err: NSError? = nil
+        let folder = BookmarkFolder(title: BookmarkRoots.PLACES_FOLDER_GUID)
+        folder.guid = BookmarkRoots.PLACES_FOLDER_GUID
+        folder.parent = 0
+        insert(db, item: folder, err: &err)
+        return created
     }
 
     override func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {


### PR DESCRIPTION
Argh. This turns out to be more complex than it should be. The crux of the problem is a tiny little bug. When we query for the "root" bookmarks right now, we query for those with a parentGuid = nil (although I don't think we quite even do that). We then store them in a folder with guid = PLACES_FOLDER_GUID. Later, if you try to reload that cursor, we query for those with parentGuid = BookmarkRoots.PLACES_FOLDER_GUID, which returns nothing (because we don't actually store parents right now).

Some of these issues are just things that aren't hooked up (storing parents) but a bunch of them just stem from us conflating ids and guids. Neither of those need to actually ever be exposed anywhere anyway. This fixes that. i.e.

1.) Guids and IDs aren't exposed outside storage. You don't need to know about them.
2.) All the API's using guids are done away with. Guids are for sync AFAIK. We have stable ids in our DB, so we don't need 'em.
3.) We create a default "folder" for Places when the db is created. We needs it id so that everything that gets added (right now) can be put inside it. Parent can now never be null (even Places points to 0, which is a non-bookmark).
4.) We actually store the parent id when we add a bookmark.