### PR TITLE
Fixes 1159373 - Disable long press back/forward for backforward list

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -70,7 +70,7 @@ public class BrowserToolbarHelper {
         toolbar.backButton.setImage(UIImage(named: "back"), forState: .Normal)
         toolbar.backButton.setImage(UIImage(named: "backPressed"), forState: .Highlighted)
         toolbar.backButton.accessibilityLabel = NSLocalizedString("Back", comment: "Accessibility Label for the browser toolbar Back button")
-        toolbar.backButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
+        //toolbar.backButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
         var longPressGestureBackButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBack:")
         toolbar.backButton.addGestureRecognizer(longPressGestureBackButton)
         toolbar.backButton.contentEdgeInsets = NavButtonInset
@@ -79,7 +79,7 @@ public class BrowserToolbarHelper {
         toolbar.forwardButton.setImage(UIImage(named: "forward"), forState: .Normal)
         toolbar.forwardButton.setImage(UIImage(named: "forwardPressed"), forState: .Highlighted)
         toolbar.forwardButton.accessibilityLabel = NSLocalizedString("Forward", comment: "Accessibility Label for the browser toolbar Forward button")
-        toolbar.forwardButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
+        //toolbar.forwardButton.accessibilityHint = NSLocalizedString("Double tap and hold to open history", comment: "")
         var longPressGestureForwardButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressForward:")
         toolbar.forwardButton.addGestureRecognizer(longPressGestureForwardButton)
         toolbar.forwardButton.addTarget(self, action: "SELdidClickForward", forControlEvents: UIControlEvents.TouchUpInside)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -471,10 +471,11 @@ extension BrowserViewController: BrowserToolbarDelegate {
     }
 
     func browserToolbarDidLongPressBack(browserToolbar: BrowserToolbarProtocol, button: UIButton) {
-        let controller = BackForwardListViewController()
-        controller.listData = tabManager.selectedTab?.backList
-        controller.tabManager = tabManager
-        presentViewController(controller, animated: true, completion: nil)
+// See 1159373 - Disable long press back/forward for backforward list
+//        let controller = BackForwardListViewController()
+//        controller.listData = tabManager.selectedTab?.backList
+//        controller.tabManager = tabManager
+//        presentViewController(controller, animated: true, completion: nil)
     }
 
     func browserToolbarDidPressReload(browserToolbar: BrowserToolbarProtocol, button: UIButton) {
@@ -490,10 +491,11 @@ extension BrowserViewController: BrowserToolbarDelegate {
     }
 
     func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbarProtocol, button: UIButton) {
-        let controller = BackForwardListViewController()
-        controller.listData = tabManager.selectedTab?.forwardList
-        controller.tabManager = tabManager
-        presentViewController(controller, animated: true, completion: nil)
+// See 1159373 - Disable long press back/forward for backforward list
+//        let controller = BackForwardListViewController()
+//        controller.listData = tabManager.selectedTab?.forwardList
+//        controller.tabManager = tabManager
+//        presentViewController(controller, animated: true, completion: nil)
     }
 
     func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbarProtocol, button: UIButton) {


### PR DESCRIPTION
I have simply uncommented the code for now and not actually removed all it's traces. Because we will very likely reintroduce this for a quick followup release.