### PR TITLE
Bug 1148666 - Reload table after rotating search view

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -325,6 +325,13 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         animateSearchEnginesWithKeyboard(state)
     }
 
+    override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        // The height of the suggestions row may change, so call reloadData() to recalculate cell heights.
+        coordinator.animateAlongsideTransition({ _ in
+            self.tableView.reloadData()
+        }, completion: nil)
+    }
+
     private func animateSearchEnginesWithKeyboard(keyboardState: KeyboardState) {
         layoutSearchEngineScrollView()
 


### PR DESCRIPTION
All of the calculated heights are correct, but we need to tell the table that the cells have changed. `reloadData` seems heavy, and I was hoping we could use something like `reloadRowsAtIndexPaths`, but the height change has a cascading effect on all the other cells.