### PR TITLE
Bug 1159953 - Reset the app state after every test

### DIFF
--- a/UITests/BookmarkingTests.swift
+++ b/UITests/BookmarkingTests.swift
@@ -86,6 +86,9 @@ class BookmarkingTests: KIFTestCase, UITextFieldDelegate {
         XCTAssertEqual(cell.textLabel!.text!, url1, "Cell shows url")
 
         tester().tapViewWithAccessibilityLabel("Cancel")
+    }
 
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
     }
 }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -68,6 +68,21 @@ extension KIFUITestActor {
     // TODO: Click element, etc.
 }
 
+class BrowserUtils {
+    /// Close all tabs and open a single about:home tab to restore the browser to startup state.
+    class func resetToAboutHome(tester: KIFUITestActor) {
+        tester.tapViewWithAccessibilityLabel("Show Tabs")
+        let tabsView = tester.waitForViewWithAccessibilityLabel("Tabs Tray").subviews.first as! UICollectionView
+        while tabsView.numberOfItemsInSection(0) > 0 {
+            let cell = tabsView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 0))!
+            tester.swipeViewWithAccessibilityLabel(cell.accessibilityLabel, inDirection: KIFSwipeDirection.Left)
+            tester.waitForAbsenceOfViewWithAccessibilityLabel(cell.accessibilityLabel)
+
+        }
+        tester.tapViewWithAccessibilityLabel("Add Tab")
+    }
+}
+
 class SimplePageServer {
     class func getPageData(name: String, ext: String = "html") -> String {
         var pageDataPath = NSBundle(forClass: self).pathForResource(name, ofType: ext)!

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -39,4 +39,8 @@ class HistoryTests: KIFTestCase {
 
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
+
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
 }

--- a/UITests/NavigationTests.swift
+++ b/UITests/NavigationTests.swift
@@ -32,4 +32,8 @@ class NavigationTests: KIFTestCase, UITextFieldDelegate {
         tester().tapViewWithAccessibilityLabel("Forward")
         tester().waitForWebViewElementWithAccessibilityLabel("Page 2")
     }
+
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
 }

--- a/UITests/SearchSettingsUITests.swift
+++ b/UITests/SearchSettingsUITests.swift
@@ -14,6 +14,12 @@ class SearchSettingsUITests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Search")
     }
 
+    private func navigateFromSearchSettings() {
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("about:home")
+    }
+
     // Given that we're at the Search Settings sheet, select the named search engine as the default.
     // Afterwards, we're still at the Search Settings sheet.
     private func selectDefaultSearchEngineName(engineName: String) {
@@ -48,5 +54,6 @@ class SearchSettingsUITests: KIFTestCase {
         XCTAssertEqual("Amazon.com", getDefaultSearchEngineName())
         selectDefaultSearchEngineName("Yahoo")
         XCTAssertEqual("Yahoo", getDefaultSearchEngineName())
+        navigateFromSearchSettings()
     }
 }

--- a/UITests/ViewMemoryLeakTests.swift
+++ b/UITests/ViewMemoryLeakTests.swift
@@ -16,10 +16,7 @@ class ViewMemoryLeakTests: KIFTestCase, UITextFieldDelegate {
     }
 
     override func tearDown() {
-        // Go back to about:home to reset the UI state between tests.
-        tester().tapViewWithAccessibilityIdentifier("url")
-        let url = "about:home\n"
-        tester().clearTextFromAndThenEnterText(url, intoViewWithAccessibilityLabel: "Address and Search")
+        BrowserUtils.resetToAboutHome(tester())
     }
 
     func testAboutHomeDisposed() {


### PR DESCRIPTION
This is enough to get the UI tests passing again. It's not perfect (for example, the profile isn't cleared between runs), but we can make this more robust as needed.