### PR TITLE
Bug 1157843 - Use a weak ref for tabTrayController

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -15,8 +15,8 @@ protocol TabManagerDelegate: class {
 }
 
 // We can't use a WeakList here because this is a protocol.
-struct WeakTabManagerDelegate {
-    var value : TabManagerDelegate?
+class WeakTabManagerDelegate {
+    weak var value : TabManagerDelegate?
 
     init (value: TabManagerDelegate) {
         self.value = value


### PR DESCRIPTION
This uses the weak ref (but with a class so that the world doesn't crash). I assume that's because you don't really want to pass around weak-ref objects by value. I'm surprised you can do it even...