### PR TITLE
Bug 1160469: Fix accessibility of remote tabs header (device) views

### DIFF
--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -135,11 +135,15 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
             let timestamp = clientTabs.approximateLastSyncTime()
             let label = NSLocalizedString("Last synced: %@", comment: "Remote tabs last synced time")
             view.detailTextLabel.text = String(format: label, String(timestamp))
+            let image: UIImage?
             if client.type == "desktop" {
-                view.imageView.image = UIImage(named: "deviceTypeDesktop")
+                image = UIImage(named: "deviceTypeDesktop")
+                image?.accessibilityLabel = NSLocalizedString("computer", comment: "Accessibility label for Desktop Computer (PC) image in remote tabs list")
             } else {
-                view.imageView.image = UIImage(named: "deviceTypeMobile")
+                image = UIImage(named: "deviceTypeMobile")
+                image?.accessibilityLabel = NSLocalizedString("mobile device", comment: "Accessibility label for Mobile Device image in remote tabs list")
             }
+            view.imageView.image = image
             view.mergeAccessibilityLabels()
             return view
         }

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -140,6 +140,7 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
             } else {
                 view.imageView.image = UIImage(named: "deviceTypeMobile")
             }
+            view.mergeAccessibilityLabels()
             return view
         }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -240,8 +240,7 @@ class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(RowIdentifier, forIndexPath: indexPath) as! TwoLineCollectionViewCell
         cell.textLabel.text = site.title.isEmpty ? site.url : site.title
         cell.detailTextLabel.text = site.url
-        cell.isAccessibilityElement = true
-        cell.accessibilityLabel = "\(cell.textLabel.text!), \(cell.detailTextLabel.text!)"
+        cell.mergeAccessibilityLabels()
         if let icon = site.icon {
             cell.imageView.sd_setImageWithURL(NSURL(string: icon.url)!)
         } else {

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -34,6 +34,10 @@ class TwoLineTableViewCell: UITableViewCell {
     func setLines(text: String?, detailText: String?) {
         twoLineHelper.setLines(text, detailText: detailText)
     }
+
+    func mergeAccessibilityLabels(views: [AnyObject?]? = nil) {
+        twoLineHelper.mergeAccessibilityLabels(views)
+    }
 }
 
 class TwoLineCollectionViewCell: UICollectionViewCell {
@@ -66,6 +70,10 @@ class TwoLineCollectionViewCell: UICollectionViewCell {
 
     func setLines(text: String?, detailText: String?) {
         twoLineHelper.setLines(text, detailText: detailText)
+    }
+
+    func mergeAccessibilityLabels(views: [AnyObject?]? = nil) {
+        twoLineHelper.mergeAccessibilityLabels(views)
     }
 }
 
@@ -115,6 +123,10 @@ class TwoLineHeaderFooterView: UITableViewHeaderFooterView {
         super.layoutSubviews()
         twoLineHelper.layoutSubviews()
     }
+
+    func mergeAccessibilityLabels(views: [AnyObject?]? = nil) {
+        twoLineHelper.mergeAccessibilityLabels(views)
+    }
 }
 
 private class TwoLineCellHelper {
@@ -162,5 +174,34 @@ private class TwoLineCellHelper {
             textLabel.text = text
             detailTextLabel.text = detailText
         }
+    }
+
+    func mergeAccessibilityLabels(labels: [AnyObject?]?) {
+        let labels = labels ?? [textLabel, imageView, detailTextLabel]
+
+        let label = labels.map({ (var label: AnyObject?) -> NSAttributedString? in
+            if let view = label as? UIView {
+                label = view.valueForKey("accessibilityLabel")
+            }
+
+            if let attrString = label as? NSAttributedString {
+                return attrString
+            } else if let string = label as? String {
+                return NSAttributedString(string: string)
+            } else {
+                return nil
+            }
+        }).filter({
+            $0 != nil
+        }).reduce(NSMutableAttributedString(string: ""), combine: {
+            if ($0.length > 0) {
+                $0.appendAttributedString(NSAttributedString(string: ", "))
+            }
+            $0.appendAttributedString($1!)
+            return $0
+        })
+
+        container.isAccessibilityElement = true
+        container.setValue(NSAttributedString(attributedString: label), forKey: "accessibilityLabel")
     }
 }


### PR DESCRIPTION
[Bug 1160469](https://bugzilla.mozilla.org/show_bug.cgi?id=1160469): header view is now one accessibility element (which automatically made it an accessibility heading), device images are now labeled, and "infrastructure" is in place to effectively handle attributed accessibility strings on cells (eyeing language attribute ;-) )

Patches donated by [A11Y LTD.](http://a11y.ltd.uk)