### PR TITLE
Bugs 1160781, 1161179, 1161210, 1161254: various accessibility issues

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -803,11 +803,13 @@ extension BrowserViewController: TabManagerDelegate {
         // and having multiple views with the same label confuses tests.
         if let wv = previous?.webView {
             wv.accessibilityLabel = nil
+            wv.accessibilityElementsHidden = true
         }
 
         if let wv = selected?.webView {
             wv.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the web view")
             webViewContainer.addSubview(wv)
+            wv.accessibilityElementsHidden = false
             if let url = wv.URL?.absoluteString {
                 profile.bookmarks.isBookmarked(url, success: { bookmarked in
                     self.toolbar?.updateBookmarkStatus(bookmarked)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -223,6 +223,7 @@ class BrowserViewController: UIViewController {
                     self.homePanelController!.view.alpha = 1
                 }, completion: { _ in
                     self.webViewContainer.accessibilityElementsHidden = true
+                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
             })
 
             addChildViewController(homePanelController!)
@@ -241,6 +242,7 @@ class BrowserViewController: UIViewController {
                     self.homePanelController = nil
                     self.webViewContainer.accessibilityElementsHidden = false
                     self.toolbar?.hidden = false
+                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
                 })
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -319,11 +319,12 @@ class BrowserViewController: UIViewController {
     }
 
     override func accessibilityPerformEscape() -> Bool {
-        if let selectedTab = tabManager.selectedTab {
-            if selectedTab.canGoBack {
-                tabManager.selectedTab?.goBack()
-               return true
-            }
+        if urlBar.isEditing {
+            urlBar.SELdidClickCancel()
+            return true
+        } else if let selectedTab = tabManager.selectedTab where selectedTab.canGoBack {
+            selectedTab.goBack()
+            return true
         }
         return false
     }

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -11,8 +11,8 @@ enum ReaderModeBarButtonType {
 
     private var localizedDescription: String {
         switch self {
-        case .MarkAsRead: return NSLocalizedString("Mark as read", comment: "Name for Mark as read button in reader mode")
-        case .MarkAsUnread: return NSLocalizedString("Mark as unread", comment: "Name for Mark as unread button in reader mode")
+        case .MarkAsRead: return NSLocalizedString("Mark as Read", comment: "Name for Mark as read button in reader mode")
+        case .MarkAsUnread: return NSLocalizedString("Mark as Unread", comment: "Name for Mark as unread button in reader mode")
         case .Settings: return NSLocalizedString("Display Settings", comment: "Name for display settings button in reader mode. Display in the meaning of presentation, not monitor.")
         case .AddToReadingList: return NSLocalizedString("Add to Reading List", comment: "Name for button adding current article to reading list in reader mode")
         case .RemoveFromReadingList: return NSLocalizedString("Remove from Reading List", comment: "Name for button removing current article from reading list in reader mode")

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -510,11 +510,6 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         finishEditing()
     }
 
-    override func accessibilityPerformEscape() -> Bool {
-        self.SELdidClickCancel()
-        return true
-    }
-
     /* BrowserToolbarProtocol */
     func updateBackStatus(canGoBack: Bool) {
         backButton.enabled = canGoBack


### PR DESCRIPTION
[Bug 1160781 - Browser view controller's accessibility "escape gesture" audit](https://bugzilla.mozilla.org/show_bug.cgi?id=1160781)
[Bug 1161179 - With multiple tabs, VoiceOver sometimes visits elements from non-displayed tabs.](https://bugzilla.mozilla.org/show_bug.cgi?id=1161179)
[Bug 1161210 - Accessibility screen changed notification should be posted on transitions between BVC and HomePanelVC](https://bugzilla.mozilla.org/show_bug.cgi?id=1161210)
[Bug 1161254 - Reader mode accessibility strings capitalization should be consistent with other UI](https://bugzilla.mozilla.org/show_bug.cgi?id=1161254)

Patches donated by [A11Y LTD.](http://a11y.ltd.uk)