### PR TITLE
Bug 1161071 - Improve location bar and toolbar scrolling

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -116,6 +116,8 @@ class BrowserViewController: UIViewController {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         webViewContainer = UIView()
         view.addSubview(webViewContainer)
 
@@ -123,8 +125,8 @@ class BrowserViewController: UIViewController {
         urlBar = URLBarView()
         urlBar.setTranslatesAutoresizingMaskIntoConstraints(false)
         urlBar.delegate = self
-        header = wrapInEffect(urlBar, parent: view)
         urlBar.browserToolbarDelegate = self
+        header = wrapInEffect(urlBar, parent: view, backgroundColor: nil)
 
         searchLoader = SearchLoader(history: profile.history, urlBar: urlBar)
 
@@ -138,14 +140,10 @@ class BrowserViewController: UIViewController {
         self.view.addSubview(footer)
         footer.addSubview(snackBars)
         snackBars.backgroundColor = UIColor.clearColor()
-
-        super.viewDidLoad()
     }
 
     override func viewWillAppear(animated: Bool) {
-        if (tabManager.count == 0) {
-            tabManager.addTab()
-        }
+        super.viewWillAppear(animated)
 
         // On iPhone, if we are about to show the On-Boarding, blank out the browser so that it does
         // not flash before we present. This change of alpha also participates in the animation when
@@ -154,7 +152,9 @@ class BrowserViewController: UIViewController {
             self.view.alpha = (profile.prefs.intForKey(IntroViewControllerSeenProfileKey) != nil) ? 1.0 : 0.0
         }
 
-        super.viewWillAppear(animated)
+        if (tabManager.count == 0) {
+            tabManager.addTab()
+        }
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -223,10 +223,15 @@ class BrowserViewController: UIViewController {
     }
 
     private func wrapInEffect(view: UIView, parent: UIView) -> UIView {
+        return self.wrapInEffect(view, parent: parent, backgroundColor: UIColor.clearColor())
+    }
+
+    private func wrapInEffect(view: UIView, parent: UIView, backgroundColor: UIColor?) -> UIView {
         let effect = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.ExtraLight))
         effect.setTranslatesAutoresizingMaskIntoConstraints(false)
-
-        view.backgroundColor = UIColor.clearColor()
+        if let background = backgroundColor {
+            view.backgroundColor = backgroundColor
+        }
         effect.addSubview(view)
 
         parent.addSubview(effect)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -70,6 +70,8 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
     }
 
     private func initViews() {
+        self.backgroundColor = URLBarViewUX.BackgroundColor
+
         curveShape = CurveView()
         self.addSubview(curveShape);
 
@@ -539,6 +541,15 @@ private let H_M4 = 0.961
 
 /* Code for drawing the urlbar curve */
 private class CurveView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.opaque = false
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.opaque = false
+    }
 
     func getWidthForHeight(height: Double) -> Double {
         return height * ASPECT_RATIO
@@ -562,24 +573,20 @@ private class CurveView: UIView {
     private func getPath() -> UIBezierPath {
         let path = UIBezierPath()
         self.drawFromTop(path)
-        path.addLineToPoint(CGPoint(x: self.frame.width, y: AppConstants.ToolbarHeight + AppConstants.StatusBarHeight))
-        path.addLineToPoint(CGPoint(x: self.frame.width, y: -10))
-        path.addLineToPoint(CGPoint(x: 0, y: -10))
+        path.addLineToPoint(CGPoint(x: 0, y: AppConstants.ToolbarHeight + AppConstants.StatusBarHeight))
         path.addLineToPoint(CGPoint(x: 0, y: AppConstants.StatusBarHeight))
         path.closePath()
         return path
     }
 
-    override class func layerClass() -> AnyClass {
-        return CAShapeLayer.self
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        if let layer = layer as? CAShapeLayer {
-            layer.path = self.getPath().CGPath
-            layer.fillColor = URLBarViewUX.BackgroundColor.CGColor
-        }
+    private override func drawRect(rect: CGRect) {
+        let context = UIGraphicsGetCurrentContext()
+        CGContextSaveGState(context)
+        CGContextClearRect(context, rect)
+        CGContextSetFillColorWithColor(context, UIColor.whiteColor().CGColor)
+        self.getPath().fill()
+        CGContextDrawPath(context, kCGPathFill)
+        CGContextRestoreGState(context)
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -9,7 +9,6 @@ import SnapKit
 
 private struct URLBarViewUX {
     // The color shown behind the tabs count button, and underneath the (mostly transparent) status bar.
-    static let BackgroundColor = UIColor(red: 0.21, green: 0.23, blue: 0.25, alpha: 1)
     static let TextFieldBorderColor = UIColor.blackColor().colorWithAlphaComponent(0.05)
     static let TextFieldActiveBorderColor = UIColor(rgb: 0x4A90E2)
     static let LocationLeftPadding = 5
@@ -23,6 +22,10 @@ private struct URLBarViewUX {
 
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0
+
+    static func backgroundColorWithAlpha(alpha: CGFloat) -> UIColor {
+        return UIColor(red: 0.21, green: 0.23, blue: 0.25, alpha: alpha)
+    }
 }
 
 protocol URLBarDelegate: class {
@@ -70,10 +73,10 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
     }
 
     private func initViews() {
-        self.backgroundColor = URLBarViewUX.BackgroundColor
-
         curveShape = CurveView()
         self.addSubview(curveShape);
+
+        self.backgroundColor = URLBarViewUX.backgroundColorWithAlpha(0)
 
         locationContainer = UIView()
         locationContainer.setTranslatesAutoresizingMaskIntoConstraints(false)
@@ -166,7 +169,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
     private func makeTabsButton(count: Int) -> UIButton {
         let tabsButton = InsetButton()
         tabsButton.setTitle(count.description, forState: UIControlState.Normal)
-        tabsButton.setTitleColor(URLBarViewUX.BackgroundColor, forState: UIControlState.Normal)
+        tabsButton.setTitleColor(URLBarViewUX.backgroundColorWithAlpha(1), forState: UIControlState.Normal)
         tabsButton.titleLabel?.layer.backgroundColor = UIColor.whiteColor().CGColor
         tabsButton.titleLabel?.layer.cornerRadius = 2
         tabsButton.titleLabel?.font = AppConstants.DefaultSmallFontBold
@@ -270,6 +273,12 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         updateLayoutForEditing(editing: true)
 
         delegate?.urlBar(self, didEnterText: text)
+    }
+
+    func updateAlphaForSubviews(alpha: CGFloat) {
+        self.tabsButton.alpha = alpha
+        self.locationContainer.alpha = alpha
+        self.backgroundColor = URLBarViewUX.backgroundColorWithAlpha(1 - alpha)
     }
 
     func updateTabCount(count: Int) {
@@ -543,12 +552,17 @@ private let H_M4 = 0.961
 private class CurveView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.opaque = false
+        self.commonInit()
     }
 
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        self.commonInit()
+    }
+
+    func commonInit() {
         self.opaque = false
+        self.contentMode = .Redraw
     }
 
     func getWidthForHeight(height: Double) -> Double {
@@ -573,17 +587,19 @@ private class CurveView: UIView {
     private func getPath() -> UIBezierPath {
         let path = UIBezierPath()
         self.drawFromTop(path)
-        path.addLineToPoint(CGPoint(x: 0, y: AppConstants.ToolbarHeight + AppConstants.StatusBarHeight))
+        path.addLineToPoint(CGPoint(x: self.frame.width, y: AppConstants.ToolbarHeight + AppConstants.StatusBarHeight))
+        path.addLineToPoint(CGPoint(x: self.frame.width, y: 0))
+        path.addLineToPoint(CGPoint(x: 0, y: 0))
         path.addLineToPoint(CGPoint(x: 0, y: AppConstants.StatusBarHeight))
         path.closePath()
         return path
     }
 
-    private override func drawRect(rect: CGRect) {
+    override func drawRect(rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()
         CGContextSaveGState(context)
         CGContextClearRect(context, rect)
-        CGContextSetFillColorWithColor(context, UIColor.whiteColor().CGColor)
+        CGContextSetFillColorWithColor(context, URLBarViewUX.backgroundColorWithAlpha(1).CGColor)
         self.getPath().fill()
         CGContextDrawPath(context, kCGPathFill)
         CGContextRestoreGState(context)


### PR DESCRIPTION
* I changed the way we render the CurveView. Instead of being the dark area about the location bar, the curve view is now the white background behind the location bar. This let's us fade out this area and display content behind it if we need to in the future.
* Replaced the layer transform logic on the header/reader/footer views with constraint logic. I'm not really a fan of all the offset/constraint state I'm storing in the BrowserViewController but there doesn't seem to be a way to get a constraint's current constant value using SnapKit :(
* Fixed the timing on the show/hide toolbar animations. Instead of having a fixed duration when we're partially displaying the toolbars, the timing is now based on the distance the toolbar needs to animate in order for it to be open/closed so the animation timing is always consistent.
* Added a parallax drawer effect when scrolling the reader mode bar. Also moved it's z position so it's beneath the header view instead.