### PR TITLE
Bug 1162724 - Tab tray close fixes

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -20,7 +20,7 @@ private struct TabTrayControllerUX {
     static let TabTitleTextFont = AppConstants.DefaultSmallFontBold
     static let CloseButtonSize = CGFloat(18.0)
     static let CloseButtonMargin = CGFloat(6.0)
-    static let CloseButtonEdgeInset = CGFloat(3.0)
+    static let CloseButtonEdgeInset = CGFloat(10)
     static let NumberOfColumnsCompact = 1
     static let NumberOfColumnsRegular = 3
 }
@@ -136,10 +136,10 @@ private class CustomCell: UICollectionViewCell {
 
         innerStroke.frame = background.frame
 
-        closeButton.frame = CGRect(x: backgroundHolder.frame.width - TabTrayControllerUX.CloseButtonSize - TabTrayControllerUX.CloseButtonMargin,
-            y: (TabTrayControllerUX.TextBoxHeight - TabTrayControllerUX.CloseButtonSize) / 2,
-            width: TabTrayControllerUX.CloseButtonSize,
-            height: TabTrayControllerUX.CloseButtonSize)
+        closeButton.snp_makeConstraints { make in
+            make.size.equalTo(title.snp_height)
+            make.trailing.centerY.equalTo(title)
+        }
 
         verticalCenter(titleText)
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -37,7 +37,7 @@ private class CustomCell: UICollectionViewCell {
     let title: UIVisualEffectView
     let innerStroke: InnerStrokedView
     let favicon: UIImageView
-    let closeTab: UIButton
+    let closeButton: UIButton
     var animator: SwipeAnimator!
 
     weak var delegate: CustomCellDelegate?
@@ -77,11 +77,11 @@ private class CustomCell: UICollectionViewCell {
         self.titleText.numberOfLines = 1
         self.titleText.font = TabTrayControllerUX.TabTitleTextFont
 
-        self.closeTab = UIButton()
-        self.closeTab.setImage(UIImage(named: "stop"), forState: UIControlState.Normal)
-        self.closeTab.imageEdgeInsets = UIEdgeInsetsMake(TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset)
+        self.closeButton = UIButton()
+        self.closeButton.setImage(UIImage(named: "stop"), forState: UIControlState.Normal)
+        self.closeButton.imageEdgeInsets = UIEdgeInsetsMake(TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset)
 
-        self.title.addSubview(self.closeTab)
+        self.title.addSubview(self.closeButton)
         self.title.addSubview(self.titleText)
         self.title.addSubview(self.favicon)
 
@@ -136,7 +136,7 @@ private class CustomCell: UICollectionViewCell {
 
         innerStroke.frame = background.frame
 
-        closeTab.frame = CGRect(x: backgroundHolder.frame.width - TabTrayControllerUX.CloseButtonSize - TabTrayControllerUX.CloseButtonMargin,
+        closeButton.frame = CGRect(x: backgroundHolder.frame.width - TabTrayControllerUX.CloseButtonSize - TabTrayControllerUX.CloseButtonMargin,
             y: (TabTrayControllerUX.TextBoxHeight - TabTrayControllerUX.CloseButtonSize) / 2,
             width: TabTrayControllerUX.CloseButtonSize,
             height: TabTrayControllerUX.CloseButtonSize)
@@ -475,7 +475,7 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
         }
 
         let screenshotAspectRatio = cell.frame.width / TabTrayControllerUX.CellHeight
-        cell.closeTab.addTarget(cell, action: "SELdidPressClose", forControlEvents: UIControlEvents.TouchUpInside)
+        cell.closeButton.addTarget(cell, action: "SELdidPressClose", forControlEvents: UIControlEvents.TouchUpInside)
 
         // calling setupFrames here fixes reused cells which don't get resized on rotation
         // TODO: is there a better way?


### PR DESCRIPTION
Switches the close button to use constraints. Now the button hugs the top right and uses the full height.

We should probably switch as much of this code as we can to autolayout since it's generally easier to work with, but I'll save that for future patches.