### PR TITLE
Bug 1152858 - Tab tray thumbnails don't fill tiles

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		E4F21AA61A13C4A300B0FAAA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4F21AA51A13C4A300B0FAAA /* Images.xcassets */; };
 		E4F480F51A954660003C0444 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2D811A8D98380040E6B5 /* SWXMLHash.framework */; };
 		E4F481041A95466A003C0444 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2D811A8D98380040E6B5 /* SWXMLHash.framework */; };
+		E6D5390B1AFD112400B11BF3 /* WKWebViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D5390A1AFD112400B11BF3 /* WKWebViewExtensions.swift */; };
 		F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21D91A090F8100AAB793 /* ClientTests.swift */; };
 		F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84B21E51A0910F600AAB793 /* AppDelegate.swift */; };
 		F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B21EF1A0910F600AAB793 /* Images.xcassets */; };
@@ -1387,6 +1388,7 @@
 		E4ECCD8C1AB091470005E717 /* Reader.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Reader.xcassets; sourceTree = "<group>"; };
 		E4ECCDAD1AB131770005E717 /* FiraSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Medium.ttf"; sourceTree = "<group>"; };
 		E4F21AA51A13C4A300B0FAAA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		E6D5390A1AFD112400B11BF3 /* WKWebViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WKWebViewExtensions.swift; sourceTree = "<group>"; };
 		F84B21BE1A090F8100AAB793 /* Client.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Client.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D31A090F8100AAB793 /* FennecAurora.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FennecAurora.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F84B21D81A090F8100AAB793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1617,6 +1619,7 @@
 				2F13E77E1AC0BFF200D75081 /* StringExtensions.swift */,
 				D35275151AA8D13B00E9C906 /* UIColorExtensions.swift */,
 				0BB5B2BB1AC0AB9F0052877D /* UIImage+Extensions.swift */,
+				E6D5390A1AFD112400B11BF3 /* WKWebViewExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3695,6 +3698,7 @@
 				0BB5B30B1AC0AD1F0052877D /* PasswordHelper.swift in Sources */,
 				0BD19A651A2530840084FBA7 /* Locking.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
+				E6D5390B1AFD112400B11BF3 /* WKWebViewExtensions.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				0BEFED8C1AC21C1E002E0A0C /* SDWebThumbnails.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1152,7 +1152,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     return
                 }
 
-                if let screenshot = self.screenshotHelper.takeScreenshot(tab, aspectRatio: CGFloat(ThumbnailCellUX.ImageAspectRatio), quality: 0.5) {
+                if let screenshot = self.screenshotHelper.takeThumbnailScreenshot(tab, aspectRatio: CGFloat(ThumbnailCellUX.ImageAspectRatio), quality: 0.5) {
                     let thumbnail = Thumbnail(image: screenshot)
                     self.profile.thumbnails.set(url, thumbnail: thumbnail, complete: nil)
                 }
@@ -1478,7 +1478,7 @@ private class BrowserScreenshotHelper: ScreenshotHelper {
         self.controller = controller
     }
 
-    func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
+    private func takeScreenshot(#captureWebViewContent: Bool, tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
         if let url = tab.url {
             if url.absoluteString == HomeURL {
                 if let homePanel = controller?.homePanelController {
@@ -1486,11 +1486,24 @@ private class BrowserScreenshotHelper: ScreenshotHelper {
                 }
             } else {
                 let offset = CGPointMake(0, -tab.webView.scrollView.contentInset.top)
-                return tab.webView.screenshot(aspectRatio, offset: offset, quality: quality)
+
+                if captureWebViewContent {
+                    return tab.webView.contentScreenshot(offset: offset, quality: quality)
+                } else {
+                    return tab.webView.screenshot(aspectRatio, offset: offset, quality: 0.5)
+                }
             }
         }
 
         return nil
+    }
+
+    func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
+        return self.takeScreenshot(captureWebViewContent: true, tab: tab, aspectRatio: aspectRatio, quality: quality)
+    }
+
+    func takeThumbnailScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
+        return self.takeScreenshot(captureWebViewContent: false, tab: tab, aspectRatio: aspectRatio, quality: quality)
     }
 }
 

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -9,4 +9,6 @@ import Foundation
  */
 protocol ScreenshotHelper {
     func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage?
+
+    func takeThumbnailScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage?
 }

--- a/Utils/Extensions/WKWebViewExtensions.swift
+++ b/Utils/Extensions/WKWebViewExtensions.swift
@@ -1,0 +1,34 @@
+//
+//  WKWebViewExtensions.swift
+//  Client
+//
+//  Created by Steph Leroux on 2015-05-08.
+//  Copyright (c) 2015 Mozilla. All rights reserved.
+//
+
+import WebKit
+import UIKit
+
+extension WKWebView {
+    private func contentScreenshot(size: CGSize, offset: CGPoint? = nil, quality: CGFloat = 1) -> UIImage? {
+        assert(0...1 ~= quality)
+        let offset = offset ?? CGPointMake(0, 0)
+
+        let savedFrame = scrollView.frame
+        scrollView.frame = CGRect(origin: offset, size: size)
+
+        UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.mainScreen().scale * quality)
+        scrollView.layer.renderInContext(UIGraphicsGetCurrentContext())
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        scrollView.frame = savedFrame
+        return image
+    }
+
+    func contentScreenshot(offset: CGPoint? = nil, quality: CGFloat = 1) -> UIImage? {
+        let height = UIScreen.mainScreen().bounds.height * 2
+        let size = CGSize(width: scrollView.contentSize.width, height: height)
+        return self.contentScreenshot(size, offset: offset, quality: quality)
+    }
+}


### PR DESCRIPTION
I added an extension method to WKWebView that let's us take the content within the scroll view as the snapshot instead of just what's visible within the view's current frame.