### PR TITLE
Bug 1163282 - Crashes when restoring tab selection

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -249,7 +249,9 @@ extension TabManager {
         }
 
         let selectedIndex: Int = coder.decodeIntegerForKey("selectedIndex")
-        self.selectTab(self.tabs[selectedIndex])
+        if (selectedIndex >= 0) {
+            self.selectTab(tabs[selectedIndex])
+        }
         storeChanges()
     }
 }


### PR DESCRIPTION
When selectedIndex was -1 (= no tab selected) self.selectTab(tabs[selectedIndex]) would crash