### PR TITLE
Bug 1147157 (Hotfix 2) - position:fixed elements break layout on orientation change

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -127,11 +127,11 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+    override func traitCollectionDidChange(traitCollection: UITraitCollection?) {
         updateToolbarStateForTraitCollection(self.traitCollection)
         showToolbars(animated: false)
 
-        super.traitCollectionDidChange(previousTraitCollection)
+        super.traitCollectionDidChange(traitCollection)
     }
 
     override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
Renamed previousTraitCollection to traitCollection to make the function more clear as it pertains to it's use