### PR TITLE
Bug 1161324: Provide aural feedback for loading webpage with VoiceOver

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -261,6 +261,8 @@
 		59A68D66379CFA85C4EAF00B /* TwoLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A68B1F857A8638598A63A0 /* TwoLineCell.swift */; };
 		59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A6839879D615FC1C0D71CE /* BookmarksPanel.swift */; };
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
+		6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */; };
+		6BB2FD991B017DAB001A189B /* AuralProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */; };
 		D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* TabTrayController.swift */; };
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -1203,6 +1205,7 @@
 		59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPanel.swift; sourceTree = "<group>"; };
 		59A68B1F857A8638598A63A0 /* TwoLineCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLineCell.swift; sourceTree = "<group>"; };
 		59A68CCB63E2A565CB03F832 /* SearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuralProgressBar.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
@@ -1959,6 +1962,7 @@
 				D38A1BED1A9FA2CA00F6A386 /* SiteTableViewControllerHeader.xib */,
 				D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */,
 				0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */,
+				6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -3674,6 +3678,7 @@
 				0BEFED8C1AC21C1E002E0A0C /* SDWebThumbnails.swift in Sources */,
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
+				6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */,
 				D38B2D341A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
@@ -3746,6 +3751,7 @@
 				D38B2D3B1A8D96D00040E6B5 /* GCDWebServerResponse.m in Sources */,
 				D38B2D411A8D96D00040E6B5 /* GCDWebServerFileRequest.m in Sources */,
 				0BEFED8D1AC21C31002E0A0C /* SDWebThumbnails.swift in Sources */,
+				6BB2FD991B017DAB001A189B /* AuralProgressBar.swift in Sources */,
 				D38B2D471A8D96D00040E6B5 /* GCDWebServerURLEncodedFormRequest.m in Sources */,
 				D38B2D4A1A8D96D00040E6B5 /* GCDWebServerDataResponse.m in Sources */,
 				0BAC7A9B1AC4B3F2006018CB /* AppConstants.swift in Sources */,

--- a/Client/Frontend/Widgets/AuralProgressBar.swift
+++ b/Client/Frontend/Widgets/AuralProgressBar.swift
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AVFoundation
+
+private struct AuralProgressBarUX {
+    static let TickPeriod = 1.0
+    static let TickDuration = 0.03
+    // VoiceOver's second tone of "screen changed" sound is approx. 1107-8 kHz, so make it C#6 which is 1108.73
+    static let VoiceOverScreenChangedSecondToneFrequency = 1108.73
+    // VoiceOver "screen changed" sound is two tones, let's denote them g1 and c2 (that is dominant and tonic). Then make TickFrequency to be f1 to make it subdominant and create a cadence (but it is quite spoiled by the pitch-varying progress sounds...). f1 is 5th halftone in a scale c1-c2.
+    static let TickFrequency = AuralProgressBarUX.VoiceOverScreenChangedSecondToneFrequency * exp2(-1 + 5.0/12.0)
+    static let TickVolume = 0.2
+    static let ProgressDuration = 0.02
+    static let ProgressStartFrequency = AuralProgressBarUX.TickFrequency
+    static let ProgressEndFrequency = AuralProgressBarUX.TickFrequency * 2
+    static let ProgressVolume = 0.03
+    static let TickProgressPanSpread = 0.25
+}
+
+class AuralProgressBar {
+    private class UI {
+        let engine: AVAudioEngine
+        let progressPlayer: AVAudioPlayerNode
+        let tickPlayer: AVAudioPlayerNode
+        // lazy initialize tickBuffer because of memory consumption (~350 kB)
+        var _tickBuffer: AVAudioPCMBuffer?
+        var tickBuffer: AVAudioPCMBuffer {
+            if _tickBuffer == nil {
+                _tickBuffer = UI.tone(tickPlayer.outputFormatForBus(0), pitch: AuralProgressBarUX.TickFrequency, volume: AuralProgressBarUX.TickVolume, duration: AuralProgressBarUX.TickDuration, period: AuralProgressBarUX.TickPeriod)
+            }
+            return _tickBuffer!
+        }
+
+        init() {
+            engine = AVAudioEngine()
+
+            tickPlayer = AVAudioPlayerNode()
+            tickPlayer.pan = -Float(AuralProgressBarUX.TickProgressPanSpread)
+            engine.attachNode(tickPlayer)
+            engine.connect(tickPlayer, to: engine.mainMixerNode, format: nil)
+
+            progressPlayer = AVAudioPlayerNode()
+            progressPlayer.pan = +Float(AuralProgressBarUX.TickProgressPanSpread)
+            engine.attachNode(progressPlayer)
+            engine.connect(progressPlayer, to: engine.mainMixerNode, format: nil)
+        }
+
+        func start() {
+            engine.startAndReturnError(nil)
+            tickPlayer.play()
+            progressPlayer.play()
+            tickPlayer.scheduleBuffer(tickBuffer, atTime: nil, options: AVAudioPlayerNodeBufferOptions.Loops) { () -> Void in
+            }
+        }
+
+        func stop() {
+            progressPlayer.stop()
+            tickPlayer.stop()
+            engine.stop()
+        }
+
+        func playProgress(var progress: Double) {
+            // using exp2 and log2 instead of exp and log as "log" clashes with XCGLogger.log
+            let pitch = AuralProgressBarUX.ProgressStartFrequency * exp2(log2(AuralProgressBarUX.ProgressEndFrequency/AuralProgressBarUX.ProgressStartFrequency) * progress)
+            let buffer = UI.tone(progressPlayer.outputFormatForBus(0), pitch: pitch, volume: AuralProgressBarUX.ProgressVolume, duration: AuralProgressBarUX.ProgressDuration)
+            progressPlayer.scheduleBuffer(buffer, atTime: nil, options: .Interrupts) { () -> Void in
+            }
+        }
+
+        class func tone(format: AVAudioFormat, pitch: Double, volume: Double, duration: Double, period: Double? = nil) -> AVAudioPCMBuffer {
+            // adjust durations to the nearest lower multiple of one pitch frequency's semiperiod to have tones end gracefully with 0 value
+            let duration = Double(Int(duration * 2*pitch)) / (2*pitch)
+            let pitchFrames = Int(duration * format.sampleRate)
+            let frames = Int((period ?? duration) * format.sampleRate)
+            let buffer = AVAudioPCMBuffer(PCMFormat: format, frameCapacity: AVAudioFrameCount(frames))
+            buffer.frameLength = buffer.frameCapacity
+            for channel in 0..<Int(format.channelCount) {
+                var channelData = buffer.floatChannelData[channel]
+                var i = 0
+                for frame in 0..<frames {
+                    // TODO: consider some attack-sustain-release to make the tones sound little less "sharp" and robotic
+                    var val = 0.0
+                    if frame < pitchFrames {
+                        val = volume * sin(pitch*Double(frame)*2*M_PI/format.sampleRate)
+                    }
+                    channelData[i] = Float(val)
+                    i += buffer.stride
+                }
+            }
+            return buffer
+        }
+    }
+
+    private let ui = UI()
+
+    var progress: Double? {
+        didSet {
+            if !hidden {
+                if oldValue == nil && progress != nil {
+                    ui.start()
+                } else if oldValue != nil && progress == nil {
+                    ui.stop()
+                }
+
+                if let progress = progress {
+                    ui.playProgress(progress)
+                }
+            }
+        }
+    }
+
+    var hidden: Bool = true {
+        didSet {
+            if hidden != oldValue {
+                if hidden {
+                    ui.stop()
+                    ui._tickBuffer = nil
+                } else {
+                    if let progress = progress {
+                        ui.start()
+                        ui.playProgress(progress)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Bug 1161324 - Aural feedback with VoiceOver needed when loading a webpage](https://bugzilla.mozilla.org/show_bug.cgi?id=1161324)

Care is taken so that the feedback is played only when VoiceOver is on. It was inspired in part by Safari's "ticking" with VoiceOver (`tickPlayer`), in part by NVDA's "rising" progress (`progressPlayer`). We do both approaches as they serve different purposes:
- periodic fixed-pitch ticking communicated that the page is being loaded, that something is in progress
- non-periodic, rising-pitch progress ticking communicates current value of progress

Progress 0% has same pitch as the periodic ticking, progress 100% is one octave higher.

The fixed-pitch ticking's pitch is chosen to make a "tune" (cadence) with VoiceOver's "screen changed" sound. Would work best without the progress ticking as that is by definition out of tune.

P.S.: AVAudioEngine is fun.

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)