### PR TITLE
Bug 1134532 - Use a custom gesture recognizer

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -31,6 +31,7 @@ class Browser: NSObject, WKScriptMessageHandler {
         webView.allowsBackForwardNavigationGestures = true
         webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
         webView.backgroundColor = UIColor.lightGrayColor()
+        webView.scrollView.layer.masksToBounds = false
 
         super.init()
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -826,9 +826,9 @@ extension BrowserViewController: UIScrollViewDelegate {
             let scrollingSize = scrollView.contentSize.height - scrollView.frame.size.height
 
             if !tab.loading &&
-                scrollingSize > scrollView.frame.size.height &&
-                scrollView.contentOffset.y > 0 &&
-                scrollView.contentOffset.y < scrollingSize  {
+                true && //scrollingSize > scrollView.frame.size.height &&
+                true && //scrollView.contentOffset.y > 0 &&
+                true { // scrollView.contentOffset.y < scrollingSize  {
                 self.scrollFooter(dy)
                 self.scrollHeader(dy)
                 self.scrollReader(dy)

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -55,6 +55,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
This uses a GestureRecognizer to detect drags on the view. Note, we aren't really detecting a gesture. Its just the only way I've found to listen to generic touches on the view. The goal is to ignore "prevent" messages sent by touch events in the page. Generally that works, but occasionally the touch listener gets stuck in an Ended state and all panning/clicking in the webview is broken. To work around that, I don't ignore all touch event messages, and let the ones through that fire in the Ended state. Other than that, there aren't many changes to the existing code here. This allows the headers to pan on/off on twitter and google maps as well (i.e. short pages and iframe pages).