### PR TITLE
Mark as Read/Unread Button Fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1457,7 +1457,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
             if let url = self.tabManager.selectedTab?.displayURL?.absoluteString, result = profile.readingList?.getRecordWithURL(url) {
                 if let successValue = result.successValue, record = successValue {
                     profile.readingList?.updateRecord(record, unread: false) // TODO Check result, can this fail?
-                    readerModeBar.unread = true
+                    readerModeBar.unread = false
                 }
             }
 

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -109,17 +109,32 @@ class ReaderModeBarView: UIView {
         delegate?.readerModeBar(self, didSelectButton: added ? .RemoveFromReadingList : .AddToReadingList)
     }
 
+    private func updateUnread(unread: Bool) {
+        var buttonType: ReaderModeBarButtonType = unread ? .MarkAsRead : .MarkAsUnread
+        if !added {
+            buttonType = .MarkAsUnread
+        }
+        readStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
+
+        readStatusButton.enabled = added
+        readStatusButton.alpha = added ? 1.0 : 0.6
+    }
+
     var unread: Bool = true {
         didSet {
-            let buttonType: ReaderModeBarButtonType = unread ? .MarkAsRead : .MarkAsUnread
-            readStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
+            updateUnread(unread)
         }
+    }
+
+    private func updateAdded(added: Bool) {
+        let buttonType: ReaderModeBarButtonType = added ? .RemoveFromReadingList : .AddToReadingList
+        listStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
     }
 
     var added: Bool = false {
         didSet {
-            let buttonType: ReaderModeBarButtonType = added ? .RemoveFromReadingList : .AddToReadingList
-            listStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
+            updateAdded(added)
+            updateUnread(unread)
         }
     }
 }


### PR DESCRIPTION
This patch contains two fixes:

* Fixes 1164190 - Mark as Read/Unread button does not work in ReaderModeBar
* Fixes 1164182 - Disable the Read/Unread button for articles not added to the reading list

This should land on top of https://github.com/mozilla/firefox-ios/pull/453