### PR TITLE
Bug 1164308 - Toolbar has missing icons on iPad and incorrect placement on iPhone

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -130,7 +130,7 @@ class BrowserViewController: UIViewController {
 
     override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
-        updateToolbarStateForTraitCollection(self.traitCollection)
+        updateToolbarStateForTraitCollection(newCollection)
 
         // WKWebView looks like it has a bug where it doesn't invalidate it's visible area when the user
         // performs a device rotation. Since scrolling calls
@@ -177,6 +177,8 @@ class BrowserViewController: UIViewController {
         self.view.addSubview(footer)
         footer.addSubview(snackBars)
         snackBars.backgroundColor = UIColor.clearColor()
+
+        updateToolbarStateForTraitCollection(self.traitCollection)
     }
 
     func startTrackingAccessibilityStatus() {


### PR DESCRIPTION
Added call to updateToolbarState on viewDidLoad since we've moved it to willTransition. Also now passing in correct trait collection in updateToolbarStateForTraitCollection in willTransition