### PR TITLE
Bug 1125835 - Error pages

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		0B75AEA91AC20FB20015E5DC /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0B75AEAA1AC20FBC0015E5DC /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
 		0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8E0FF31A932BD500161DC3 /* ImageIO.framework */; };
+		0BA1E00E1B03FB0B007675AF /* NetError.html in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E00D1B03FB0B007675AF /* NetError.html */; };
+		0BA1E02E1B046F1E007675AF /* ErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */; };
+		0BA1E0301B051A07007675AF /* NetError.css in Resources */ = {isa = PBXBuildFile; fileRef = 0BA1E02F1B051A07007675AF /* NetError.css */; };
 		0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		0BA84AE11AE57095009C4D0C /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BA84ADA1AE57095009C4D0C /* SnapKit.framework */; };
 		0BA84AE21AE570A1009C4D0C /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BA84ADA1AE57095009C4D0C /* SnapKit.framework */; };
@@ -1054,6 +1057,9 @@
 		0B6544B01A96C59E000DD202 /* SDWebImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDWebImage.xcodeproj; path = Carthage/Checkouts/SDWebImage/SDWebImage.xcodeproj; sourceTree = "<group>"; };
 		0B6FBAB11AC1F830007EC669 /* numberedPage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = numberedPage.html; sourceTree = "<group>"; };
 		0B8E0FF31A932BD500161DC3 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		0BA1E00D1B03FB0B007675AF /* NetError.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = NetError.html; sourceTree = "<group>"; };
+		0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPageHelper.swift; sourceTree = "<group>"; };
+		0BA1E02F1B051A07007675AF /* NetError.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = NetError.css; sourceTree = "<group>"; };
 		0BA84AB61AE5706F009C4D0C /* SnapKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SnapKit.xcodeproj; path = Carthage/Checkouts/Snap/SnapKit.xcodeproj; sourceTree = "<group>"; };
 		0BA896491A250E6500C1010C /* ProfileTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileTest.swift; sourceTree = "<group>"; };
 		0BA8964A1A250E6500C1010C /* TestBookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBookmarks.swift; sourceTree = "<group>"; };
@@ -2110,6 +2116,13 @@
 				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
+				59A68CCB63E2A565CB03F832 /* SearchViewController.swift */,
+				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
+				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
+				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
+				D34510871ACF415700EC27F0 /* SearchLoader.swift */,
+				0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -2384,6 +2397,8 @@
 				0BD75AD21AF2EE5A00B48915 /* suggestedsites.json */,
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
 				F84B22391A0914A300AAB793 /* Fonts */,
+				0BA1E00D1B03FB0B007675AF /* NetError.html */,
+				0BA1E02F1B051A07007675AF /* NetError.css */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -3291,6 +3306,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BA1E0301B051A07007675AF /* NetError.css in Resources */,
 				E4B7B77E1A793CF20022C5E0 /* FiraSans-SemiBold.ttf in Resources */,
 				F84B220B1A0910F600AAB793 /* Images.xcassets in Resources */,
 				E49943F71AE69EDD00BF9DE4 /* Intro.xcassets in Resources */,
@@ -3319,6 +3335,7 @@
 				D3BA7E0C1B0E902A00153782 /* ContextMenu.js in Resources */,
 				E4B7B7681A793CF20022C5E0 /* FiraSans-Bold.ttf in Resources */,
 				E4B7B7781A793CF20022C5E0 /* FiraSans-Italic.ttf in Resources */,
+				0BA1E00E1B03FB0B007675AF /* NetError.html in Resources */,
 				E4A961381AC06FA50069AD6F /* ReaderViewLoading.html in Resources */,
 				E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */,
 				E4424B3C1AC71FB400F44C38 /* FiraSans-Book.ttf in Resources */,
@@ -3735,6 +3752,7 @@
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */,
 				D3BE7B261B054D4400641031 /* main.swift in Sources */,
+				0BA1E02E1B046F1E007675AF /* ErrorPageHelper.swift in Sources */,
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
 				59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */,
 				D30B0F301AA7D66300C01CA3 /* ThumbnailCell.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -61,6 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func setUpWebServer(profile: Profile) {
         let server = WebServer.sharedInstance
         ReaderModeHandlers.register(server, profile: profile)
+        ErrorPageHelper.register(server)
         server.start()
     }
 

--- a/Client/Assets/NetError.css
+++ b/Client/Assets/NetError.css
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+body {
+    background-color: white;
+    padding: 0 65px;
+    color: #333;
+    font-size: 16px;
+    -webkit-text-size-adjust: none;
+    font-family: "Helvetica Neue Medium" sans-serif;
+}
+
+h1 {
+    color: #333;
+    font-size: 16px;
+    -webkit-text-size-adjust: none;
+    font-family: "Helvetica Neue Medium" sans-serif;
+    font-weight: 300;
+}
+
+#decoration {
+    /* Add a set of stripes at the top of pages */
+    background-image: repeating-linear-gradient(-65deg,      #eee,  #eee 10px,
+                                                       white 10px, white 20px,
+                                                                    #eee 20px);
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 32px;
+    width: 100%;
+}
+
+a {
+    color: rgb(76, 158, 255);
+    text-decoration: none;
+}
+
+#errorShortDesc {
+    /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
+    margin: 20px 0 0;
+}
+
+button {
+    /* Force buttons to display: block here to try and enfoce collapsing margins */
+    display: block;
+    width: 100%;
+    border: none;
+    padding: 1rem;
+    font-family: "Helvetica Neue Medium" sans-serif;
+    background-color: rgb(76, 158, 255);
+    color: white;
+    font-size: 16px;
+    font-weight: 300;
+    border-radius: 5px;
+    background-image: none;
+    margin: 10px 0 0;
+    position: -webkit-sticky;
+    bottom: 5px;
+}
+
+#errorPageContainer {
+    /* If the page is greater than 550px center the content.
+     * This number should be kept in sync with the media query for tablets below */
+    max-width: 550px;
+    margin: 0 auto;
+    -webkit-transform: translateY(127px);
+    padding-bottom: 10px;
+
+    min-height: calc(100% - 127px - 10px);
+    display: flex;
+    flex-direction: column;
+}
+
+/* On large screen devices (hopefully a 7+ inch tablet, we already center content (see #errorPageContainer above).
+ Apply tablet specific styles here */
+@media (min-width: 550px) {
+    #errorTitle,
+    #errorShortDescText {
+        width: 50%;
+    }
+
+    button {
+        position: absolute;
+        top: -0.5em;
+        right: 0px;
+        bottom: auto;
+        padding-left: 5%;
+        padding-right: 5%;
+        min-width: 40%;
+        width: auto;
+    }
+
+    /* If the tablet is tall as well, add some padding to make content feel a bit more centered */
+    @media (min-height: 550px) {
+        #errorPageContainer {
+            padding-top: 64px;
+            min-height: calc(100% - 64px);
+        }
+    }
+}
+
+#errorLongContent {
+    font-family: "Helvetica Neue Light" sans-serif;
+    color: #ccc;
+    font-size: 12px;
+}
+
+#errorLongDesc {
+    margin-bottom: 78px;
+}

--- a/Client/Assets/NetError.css
+++ b/Client/Assets/NetError.css
@@ -26,8 +26,8 @@ h1 {
     font-weight: 300;
 }
 
+/* Add a set of stripes at the top of pages */
 #decoration {
-    /* Add a set of stripes at the top of pages */
     background-image: repeating-linear-gradient(-65deg,      #eee,  #eee 10px,
                                                        white 10px, white 20px,
                                                                     #eee 20px);
@@ -96,14 +96,6 @@ button {
         padding-right: 5%;
         min-width: 40%;
         width: auto;
-    }
-
-    /* If the tablet is tall as well, add some padding to make content feel a bit more centered */
-    @media (min-height: 550px) {
-        #errorPageContainer {
-            padding-top: 64px;
-            min-height: calc(100% - 64px);
-        }
     }
 }
 

--- a/Client/Assets/NetError.html
+++ b/Client/Assets/NetError.html
@@ -1,0 +1,57 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>%error_title%</title>
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+    <link rel="stylesheet" href="NetError.css" type="text/css" media="all" />
+
+    <!-- If the location of the favicon is changed here, the FAVICON_ERRORPAGE_URL symbol in
+         toolkit/components/places/src/nsFaviconService.h should be updated. -->
+    <link rel="icon" type="image/png" id="favicon" href="chrome://global/skin/icons/warning-16.png"/>
+
+    <script type="application/javascript">
+      // If the user swipes back and forth to this tab, we want to make sure we make an attempt to reload the original page.
+      var fresh = true;
+      window.addEventListener('popstate', function () {
+        if (fresh)
+          fresh = false;
+        else
+          location.reload();
+      });
+    </script>
+  </head>
+
+  <body dir="&locale.dir;">
+
+    <!-- PAGE CONTAINER (for styling purposes only) -->
+    <div id="errorPageContainer">
+
+      <!-- Error Title -->
+      <div id="errorTitle">
+        <h1 id="errorTitleText">%error_title%</h1>
+      </div>
+
+      <!-- LONG CONTENT (the section most likely to require scrolling) -->
+      <div id="errorLongContent">
+
+        <!-- Short Description -->
+        <div id="errorShortDesc">
+          <p id="errorShortDescText">%short_description%</p>
+        </div>
+
+        <!-- Long Description (Note: See netError.dtd for used XHTML tags) -->
+        <div id="errorLongDesc">%long_description%</div>
+        <div id="actions">%actions%</div>
+      </div>
+
+    </div>
+  </div>
+  <div id="decoration"></div>
+
+  <script type="application/javascript">initPage();</script>
+
+  </body>
+</html>

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -104,7 +104,15 @@ class Browser: NSObject, WKScriptMessageHandler {
     var displayURL: NSURL? {
         if let url = webView.URL {
             if url.scheme != "about" {
-                return ReaderModeUtils.isReaderModeURL(url) ? ReaderModeUtils.decodeURL(url) : url
+                if ReaderModeUtils.isReaderModeURL(url) {
+                    return ReaderModeUtils.decodeURL(url)
+                }
+
+                if ErrorPageHelper.isErrorPageURL(url) {
+                    return ErrorPageHelper.decodeURL(url)
+                }
+
+                return url
             }
         }
         return nil

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1386,34 +1386,25 @@ extension BrowserViewController: WKUIDelegate {
         presentViewController(alertController, animated: true, completion: nil)
     }
 
-    func errorToHTML(error: NSError) -> String {
-        var html = "<html>"
-        html += "<p>localizedDescription: \(error.localizedDescription)</p>"
-        html += "<p>localizedFailureReason: \(error.localizedFailureReason)</p>"
-        html += "<p>localizedRecoverySuggestion: \(error.localizedRecoverySuggestion)</p>"
-        html += "<p>localizedRecoveryOptions: \(error.localizedRecoveryOptions)</p>"
-        html += "</html>"
-        println(html)
-        return html
-    }
-
     /// Invoked when an error occurs during a committed main frame navigation.
     func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
-        println("DIDFAILNAVIGATION:")
-        println(error)
-        println(error.userInfo)
+        if error.code == Int(CFNetworkErrors.CFURLErrorCancelled.rawValue) {
+            return
+        }
+
         if let url = error.userInfo?["NSErrorFailingURLKey"] as? NSURL {
-            webView.loadHTMLString(errorToHTML(error), baseURL: url)
+            ErrorPageHelper().showPage(error, forUrl: url, inWebView: webView)
         }
     }
 
     /// Invoked when an error occurs while starting to load data for the main frame.
     func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
-        println("DIDFAILPROVISIONALNAVIGATION:")
-        println(error)
-        println(error.userInfo)
+        if error.code == Int(CFNetworkErrors.CFURLErrorCancelled.rawValue) {
+            return
+        }
+
         if let url = error.userInfo?["NSErrorFailingURLKey"] as? NSURL {
-            webView.loadHTMLString(errorToHTML(error), baseURL: url)
+            ErrorPageHelper().showPage(error, forUrl: url, inWebView: webView)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1385,6 +1385,37 @@ extension BrowserViewController: WKUIDelegate {
         }))
         presentViewController(alertController, animated: true, completion: nil)
     }
+
+    func errorToHTML(error: NSError) -> String {
+        var html = "<html>"
+        html += "<p>localizedDescription: \(error.localizedDescription)</p>"
+        html += "<p>localizedFailureReason: \(error.localizedFailureReason)</p>"
+        html += "<p>localizedRecoverySuggestion: \(error.localizedRecoverySuggestion)</p>"
+        html += "<p>localizedRecoveryOptions: \(error.localizedRecoveryOptions)</p>"
+        html += "</html>"
+        println(html)
+        return html
+    }
+
+    /// Invoked when an error occurs during a committed main frame navigation.
+    func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
+        println("DIDFAILNAVIGATION:")
+        println(error)
+        println(error.userInfo)
+        if let url = error.userInfo?["NSErrorFailingURLKey"] as? NSURL {
+            webView.loadHTMLString(errorToHTML(error), baseURL: url)
+        }
+    }
+
+    /// Invoked when an error occurs while starting to load data for the main frame.
+    func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
+        println("DIDFAILPROVISIONALNAVIGATION:")
+        println(error)
+        println(error.userInfo)
+        if let url = error.userInfo?["NSErrorFailingURLKey"] as? NSURL {
+            webView.loadHTMLString(errorToHTML(error), baseURL: url)
+        }
+    }
 }
 
 extension BrowserViewController: ReaderModeDelegate, UIPopoverPresentationControllerDelegate {

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -1,10 +1,6 @@
-//
-//  ErrorPageHelper.swift
-//  Client
-//
-//  Created by Wes Johnston on 5/13/15.
-//  Copyright (c) 2015 Mozilla. All rights reserved.
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
 import WebKit

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -144,6 +144,15 @@ class ErrorPageHelper {
     }
 
     func showPage(error: NSError, forUrl url: NSURL, inWebView webView: WKWebView) {
+        // Don't show error pages for error pages.
+        if ErrorPageHelper.isErrorPageURL(url) {
+            let previousUrl = ErrorPageHelper.decodeURL(url)
+            if let index = find(ErrorPageHelper.redirecting, previousUrl) {
+                ErrorPageHelper.redirecting.removeAtIndex(index)
+            }
+            return
+        }
+
         // Add this page to the redirecting list. This will cause the server to actually show the error page
         // (instead of redirecting to the original URL).
         ErrorPageHelper.redirecting.append(url)

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -1,0 +1,169 @@
+//
+//  ErrorPageHelper.swift
+//  Client
+//
+//  Created by Wes Johnston on 5/13/15.
+//  Copyright (c) 2015 Mozilla. All rights reserved.
+//
+
+import Foundation
+import WebKit
+import Shared
+
+class ErrorPageHelper {
+    // When an error page is intentionally loaded, its added to this set. If its in the set, we show
+    // it as an error page. If its not, we assume someone is trying to reload this page somehow, and
+    // we'll instead redirect back to the original URL.
+    private static var redirecting = [NSURL]()
+
+    class func cfErrorToName(err: CFNetworkErrors) -> String {
+        switch err {
+        case .CFHostErrorHostNotFound: return "CFHostErrorHostNotFound"
+        case .CFHostErrorUnknown: return "CFHostErrorUnknown"
+        case .CFSOCKSErrorUnknownClientVersion: return "CFSOCKSErrorUnknownClientVersion"
+        case .CFSOCKSErrorUnsupportedServerVersion: return "CFSOCKSErrorUnsupportedServerVersion"
+        case .CFSOCKS4ErrorRequestFailed: return "CFSOCKS4ErrorRequestFailed"
+        case .CFSOCKS4ErrorIdentdFailed: return "CFSOCKS4ErrorIdentdFailed"
+        case .CFSOCKS4ErrorIdConflict: return "CFSOCKS4ErrorIdConflict"
+        case .CFSOCKS4ErrorUnknownStatusCode: return "CFSOCKS4ErrorUnknownStatusCode"
+        case .CFSOCKS5ErrorBadState: return "CFSOCKS5ErrorBadState"
+        case .CFSOCKS5ErrorBadResponseAddr: return "CFSOCKS5ErrorBadResponseAddr"
+        case .CFSOCKS5ErrorBadCredentials: return "CFSOCKS5ErrorBadCredentials"
+        case .CFSOCKS5ErrorUnsupportedNegotiationMethod: return "CFSOCKS5ErrorUnsupportedNegotiationMethod"
+        case .CFSOCKS5ErrorNoAcceptableMethod: return "CFSOCKS5ErrorNoAcceptableMethod"
+        case .CFFTPErrorUnexpectedStatusCode: return "CFFTPErrorUnexpectedStatusCode"
+        case .CFErrorHTTPAuthenticationTypeUnsupported: return "CFErrorHTTPAuthenticationTypeUnsupported"
+        case .CFErrorHTTPBadCredentials: return "CFErrorHTTPBadCredentials"
+        case .CFErrorHTTPConnectionLost: return "CFErrorHTTPConnectionLost"
+        case .CFErrorHTTPParseFailure: return "CFErrorHTTPParseFailure"
+        case .CFErrorHTTPRedirectionLoopDetected: return "CFErrorHTTPRedirectionLoopDetected"
+        case .CFErrorHTTPBadURL: return "CFErrorHTTPBadURL"
+        case .CFErrorHTTPProxyConnectionFailure: return "CFErrorHTTPProxyConnectionFailure"
+        case .CFErrorHTTPBadProxyCredentials: return "CFErrorHTTPBadProxyCredentials"
+        case .CFErrorPACFileError: return "CFErrorPACFileError"
+        case .CFErrorPACFileAuth: return "CFErrorPACFileAuth"
+        case .CFErrorHTTPSProxyConnectionFailure: return "CFErrorHTTPSProxyConnectionFailure"
+        case .CFStreamErrorHTTPSProxyFailureUnexpectedResponseToCONNECTMethod: return "CFStreamErrorHTTPSProxyFailureUnexpectedResponseToCONNECTMethod"
+
+        case .CFURLErrorBackgroundSessionInUseByAnotherProcess: return "CFURLErrorBackgroundSessionInUseByAnotherProcess"
+        case .CFURLErrorBackgroundSessionWasDisconnected: return "CFURLErrorBackgroundSessionWasDisconnected"
+        case .CFURLErrorUnknown: return "CFURLErrorUnknown"
+        case .CFURLErrorCancelled: return "CFURLErrorCancelled"
+        case .CFURLErrorBadURL: return "CFURLErrorBadURL"
+        case .CFURLErrorTimedOut: return "CFURLErrorTimedOut"
+        case .CFURLErrorUnsupportedURL: return "CFURLErrorUnsupportedURL"
+        case .CFURLErrorCannotFindHost: return "CFURLErrorCannotFindHost"
+        case .CFURLErrorCannotConnectToHost: return "CFURLErrorCannotConnectToHost"
+        case .CFURLErrorNetworkConnectionLost: return "CFURLErrorNetworkConnectionLost"
+        case .CFURLErrorDNSLookupFailed: return "CFURLErrorDNSLookupFailed"
+        case .CFURLErrorHTTPTooManyRedirects: return "CFURLErrorHTTPTooManyRedirects"
+        case .CFURLErrorResourceUnavailable: return "CFURLErrorResourceUnavailable"
+        case .CFURLErrorNotConnectedToInternet: return "CFURLErrorNotConnectedToInternet"
+        case .CFURLErrorRedirectToNonExistentLocation: return "CFURLErrorRedirectToNonExistentLocation"
+        case .CFURLErrorBadServerResponse: return "CFURLErrorBadServerResponse"
+        case .CFURLErrorUserCancelledAuthentication: return "CFURLErrorUserCancelledAuthentication"
+        case .CFURLErrorUserAuthenticationRequired: return "CFURLErrorUserAuthenticationRequired"
+        case .CFURLErrorZeroByteResource: return "CFURLErrorZeroByteResource"
+        case .CFURLErrorCannotDecodeRawData: return "CFURLErrorCannotDecodeRawData"
+        case .CFURLErrorCannotDecodeContentData: return "CFURLErrorCannotDecodeContentData"
+        case .CFURLErrorCannotParseResponse: return "CFURLErrorCannotParseResponse"
+        case .CFURLErrorInternationalRoamingOff: return "CFURLErrorInternationalRoamingOff"
+        case .CFURLErrorCallIsActive: return "CFURLErrorCallIsActive"
+        case .CFURLErrorDataNotAllowed: return "CFURLErrorDataNotAllowed"
+        case .CFURLErrorRequestBodyStreamExhausted: return "CFURLErrorRequestBodyStreamExhausted"
+        case .CFURLErrorFileDoesNotExist: return "CFURLErrorFileDoesNotExist"
+        case .CFURLErrorFileIsDirectory: return "CFURLErrorFileIsDirectory"
+        case .CFURLErrorNoPermissionsToReadFile: return "CFURLErrorNoPermissionsToReadFile"
+        case .CFURLErrorDataLengthExceedsMaximum: return "CFURLErrorDataLengthExceedsMaximum"
+        case .CFURLErrorSecureConnectionFailed: return "CFURLErrorSecureConnectionFailed"
+        case .CFURLErrorServerCertificateHasBadDate: return "CFURLErrorServerCertificateHasBadDate"
+        case .CFURLErrorServerCertificateUntrusted: return "CFURLErrorServerCertificateUntrusted"
+        case .CFURLErrorServerCertificateHasUnknownRoot: return "CFURLErrorServerCertificateHasUnknownRoot"
+        case .CFURLErrorServerCertificateNotYetValid: return "CFURLErrorServerCertificateNotYetValid"
+        case .CFURLErrorClientCertificateRejected: return "CFURLErrorClientCertificateRejected"
+        case .CFURLErrorClientCertificateRequired: return "CFURLErrorClientCertificateRequired"
+        case .CFURLErrorCannotLoadFromNetwork: return "CFURLErrorCannotLoadFromNetwork"
+        case .CFURLErrorCannotCreateFile: return "CFURLErrorCannotCreateFile"
+        case .CFURLErrorCannotOpenFile: return "CFURLErrorCannotOpenFile"
+        case .CFURLErrorCannotCloseFile: return "CFURLErrorCannotCloseFile"
+        case .CFURLErrorCannotWriteToFile: return "CFURLErrorCannotWriteToFile"
+        case .CFURLErrorCannotRemoveFile: return "CFURLErrorCannotRemoveFile"
+        case .CFURLErrorCannotMoveFile: return "CFURLErrorCannotMoveFile"
+        case .CFURLErrorDownloadDecodingFailedMidStream: return "CFURLErrorDownloadDecodingFailedMidStream"
+        case .CFURLErrorDownloadDecodingFailedToComplete: return "CFURLErrorDownloadDecodingFailedToComplete"
+
+        case .CFHTTPCookieCannotParseCookieFile: return "CFHTTPCookieCannotParseCookieFile"
+        case .CFNetServiceErrorUnknown: return "CFNetServiceErrorUnknown"
+        case .CFNetServiceErrorCollision: return "CFNetServiceErrorCollision"
+        case .CFNetServiceErrorNotFound: return "CFNetServiceErrorNotFound"
+        case .CFNetServiceErrorInProgress: return "CFNetServiceErrorInProgress"
+        case .CFNetServiceErrorBadArgument: return "CFNetServiceErrorBadArgument"
+        case .CFNetServiceErrorCancel: return "CFNetServiceErrorCancel"
+        case .CFNetServiceErrorInvalid: return "CFNetServiceErrorInvalid"
+        case .CFNetServiceErrorTimeout: return "CFNetServiceErrorTimeout"
+        case .CFNetServiceErrorDNSServiceFailure: return "CFNetServiceErrorDNSServiceFailure"
+        default: return "Unknown"
+        }
+    }
+
+    class func register(server: WebServer) {
+        server.registerHandlerForMethod("GET", module: "errors", resource: "error.html", handler: { (request) -> GCDWebServerResponse! in
+            let urlString = request.query["url"] as? String
+            let url = (NSURL(string: urlString?.unescape() ?? "") ?? NSURL(string: ""))!
+
+            if let index = find(self.redirecting, url) {
+                self.redirecting.removeAtIndex(index)
+
+                let errCode = (request.query["code"] as! String).toInt()
+                let errDescription = request.query["description"] as! String
+                var errDomain = request.query["domain"] as! String
+                if let code = CFNetworkErrors(rawValue: Int32(errCode!)) {
+                    errDomain = self.cfErrorToName(code)
+                }
+
+                let tryAgain = NSLocalizedString("Try again", tableName: "errorPages", comment: "Shown in error pages on a button that will try to load the page again")
+
+                let asset = NSBundle.mainBundle().pathForResource("NetError", ofType: "html")
+                let response = GCDWebServerDataResponse(HTMLTemplate: asset, variables: [
+                    "error_code": "\(errCode ?? -1)",
+                    "error_title": errDescription ?? "",
+                    "long_description": nil ?? "",
+                    "short_description": errDomain,
+                    "actions": "<button onclick='window.location.reload()'>\(tryAgain)</button>" // This
+                ])
+                response.setValue("no cache", forAdditionalHeader: "Pragma")
+                response.setValue("no-cache,must-revalidate", forAdditionalHeader: "Cache-Control")
+                response.setValue(NSDate().description, forAdditionalHeader: "Expires")
+                return response
+            } else {
+                return GCDWebServerDataResponse(redirect: url, permanent: false)
+            }
+        })
+
+        server.registerHandlerForMethod("GET", module: "errors", resource: "NetError.css", handler: { (request) -> GCDWebServerResponse! in
+            let path = NSBundle(forClass: self).pathForResource("NetError", ofType: "css")!
+            let data = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil)! as String
+            return GCDWebServerDataResponse(data: NSData(contentsOfFile: path), contentType: "text/css")
+        })
+    }
+
+    func showPage(error: NSError, forUrl url: NSURL, inWebView webView: WKWebView) {
+        // Add this page to the redirecting list. This will cause the server to actually show the error page
+        // (instead of redirecting to the original URL).
+        ErrorPageHelper.redirecting.append(url)
+
+        let errorUrl = "\(WebServer.sharedInstance.base)/errors/error.html?url=\(url.absoluteString?.escape() ?? String())&code=\(error.code)&domain=\(error.domain)&description=\(error.localizedDescription.escape())"
+        let request = NSURLRequest(URL: errorUrl.asURL!)
+        webView.loadRequest(request)
+    }
+
+    class func isErrorPageURL(url: NSURL) -> Bool {
+        return startsWith(url.absoluteString!, "\(WebServer.sharedInstance.base)/errors/error.html")
+    }
+
+    class func decodeURL(url: NSURL) -> NSURL {
+        let query = url.getQuery()
+        let queryUrl = query["url"]
+        return NSURL(string: query["url"]?.unescape() ?? "")!
+    }
+}

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -38,14 +38,14 @@ class GenericTable<T>: BaseTable {
 
     func create(db: SQLiteDBConnection, version: Int) -> Bool {
         if let err = db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(rows))") {
-            log.error("Error creating \(name) - \(err)")
+            log.error("Error creating \(self.name) - \(err)")
             return false
         }
         return true
     }
 
     func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
-        log.debug("Update table \(name) from \(from) to \(to)")
+        log.debug("Update table \(self.name) from \(from) to \(to)")
         return false
     }
 
@@ -59,7 +59,7 @@ class GenericTable<T>: BaseTable {
         let args =  [AnyObject?]()
         let err = db.executeChange(sqlStr, withArgs: args)
         if err != nil {
-            log.error("Error dropping \(name): \(err)")
+            log.error("Error dropping \(self.name): \(err)")
         }
         return err == nil
     }

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -19,4 +19,21 @@ extension NSURL {
         components.queryItems = (components.queryItems ?? []) + [item]
         return components.URL!
     }
+
+    public func getQuery() -> [String: String] {
+        var results = [String: String]()
+        var keyValues = self.query?.componentsSeparatedByString("&")
+
+        if keyValues?.count > 0 {
+            for pair in keyValues! {
+                let kv = pair.componentsSeparatedByString("=")
+                if kv.count > 1 {
+                    results[kv[0]] = kv[1]
+                }
+            }
+        }
+
+        return results
+    }
+
 }

--- a/Utils/Extensions/StringExtensions.swift
+++ b/Utils/Extensions/StringExtensions.swift
@@ -37,6 +37,21 @@ public extension String {
         return false
     }
 
+    func escape() -> String {
+        var raw: NSString = self
+        var str = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+            raw,
+            "[].",":/?&=;+!@#$()',*",
+            CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding))
+        return str as! String
+    }
+
+    func unescape() -> String {
+        var raw: NSString = self
+        var str = CFURLCreateStringByReplacingPercentEscapes(kCFAllocatorDefault, raw, "[].")
+        return str as! String
+    }
+
     public var asURL: NSURL? {
         return NSURL(string: self)
     }


### PR DESCRIPTION
This uses a little trickery for errors pages using the local server. Essentially it maintains a list of explicitly requested loads. If the page is in that list, the error page is shown (and then its removed from the list). If a page isn't in the list, we pull the original url out of its url and redirect to it.

To handle back and forward navigation, we also listen for "popstate" events in the document. If they happen, we know that we're being shown from the cache via back-foward navigation and we also force a reload of the page (which will force a redirect via the mechanism I talked about above).

I'm not using a ton of the info WkWebView gives us here beyond a localized description. We could bring in more later. I made "actions" injectable into the page so that we could potentially add special ones for special cases. The HTML/CSS is a heavily redacted and modified version of Android/Desktop's.