### PR TITLE
Bug 1165103 - Use a separate AppDelegate for Aurora builds

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ACB4381AD33EBA00748D50 /* WeakList.swift */; };
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
 		D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B451B054F8600641031 /* TestAppDelegate.swift */; };
+		D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */; };
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CE1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
@@ -1270,6 +1271,7 @@
 		D3ACB4381AD33EBA00748D50 /* WeakList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakList.swift; sourceTree = "<group>"; };
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D3BE7B451B054F8600641031 /* TestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
+		D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuroraAppDelegate.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D247311ABCEA1700771C7E /* ThumbnailTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailTests.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
@@ -2362,6 +2364,7 @@
 				E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */,
 				D3BE7B251B054D4400641031 /* main.swift */,
 				D3BE7B451B054F8600641031 /* TestAppDelegate.swift */,
+				D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -3664,6 +3667,7 @@
 				D38B2D431A8D96D00040E6B5 /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */,
 				0B62EFD21AD63CD100ACB9CD /* Clearables.swift in Sources */,
+				D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */,
 				E4CD9E911A6897FB00318571 /* ReaderMode.swift in Sources */,
 				D38B2D371A8D96D00040E6B5 /* GCDWebServerRequest.m in Sources */,
 				D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -2,22 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import UIKit
-import Alamofire
-import MessageUI
 import Shared
-
-public let AuroraBundleIdentifier = "org.mozilla.ios.FennecAurora"
-
-public func isAuroraChannel() -> Bool {
-    return NSBundle.mainBundle().bundleIdentifier == AuroraBundleIdentifier
-}
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var browserViewController: BrowserViewController!
 
-    private let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+    let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
 
     func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Set the Firefox UA for browsing.
@@ -51,10 +42,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-#if MOZ_CHANNEL_AURORA
-        checkForAuroraUpdate()
-        registerFeedbackNotification()
-#endif
         return true
     }
 
@@ -66,43 +53,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window!.makeKeyAndVisible()
         return true
     }
-
-#if MOZ_CHANNEL_AURORA
-    var naggedAboutAuroraUpdate = false
-    func applicationDidBecomeActive(application: UIApplication) {
-        if !naggedAboutAuroraUpdate {
-            checkForAuroraUpdate()
-        }
-    }
-
-    func application(application: UIApplication, applicationWillTerminate app: UIApplication) {
-        unregisterFeedbackNotification()
-    }
-    
-    func applicationWillResignActive(application: UIApplication) {
-        unregisterFeedbackNotification()
-    }
-
-    private func registerFeedbackNotification() {
-        NSNotificationCenter.defaultCenter().addObserverForName(
-            UIApplicationUserDidTakeScreenshotNotification,
-            object: nil,
-            queue: NSOperationQueue.mainQueue()) { (notification) -> Void in
-                if let window = self.window {
-                    UIGraphicsBeginImageContext(window.bounds.size)
-                    window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates: true)
-                    let image = UIGraphicsGetImageFromCurrentImageContext()
-                    UIGraphicsEndImageContext()
-                    self.sendFeedbackMailWithImage(image)
-                }
-        }
-    }
-    
-    private func unregisterFeedbackNotification() {
-        NSNotificationCenter.defaultCenter().removeObserver(self,
-            name: UIApplicationUserDidTakeScreenshotNotification, object: nil)
-    }
-#endif
 
     private func setUpWebServer(profile: Profile) {
         let server = WebServer.sharedInstance
@@ -138,85 +88,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SDWebImageDownloader.sharedDownloader().setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
     }
 }
-
-
-#if MOZ_CHANNEL_AURORA
-private let AuroraPropertyListURL = "https://pvtbuilds.mozilla.org/ios/FennecAurora.plist"
-private let AuroraDownloadPageURL = "https://pvtbuilds.mozilla.org/ios/index.html"
-
-private let AppUpdateTitle = NSLocalizedString("New version available", comment: "Prompt title for application update")
-private let AppUpdateMessage = NSLocalizedString("There is a new version available of Firefox Aurora. Tap OK to go to the download page.", comment: "Prompt message for application update")
-private let AppUpdateCancel = NSLocalizedString("Not Now", comment: "Label for button to cancel application update prompt")
-private let AppUpdateOK = NSLocalizedString("OK", comment: "Label for OK button in the application update prompt")
-
-extension AppDelegate: UIAlertViewDelegate {
-    private func checkForAuroraUpdate() {
-        if isAuroraChannel() {
-            if let localVersion = localVersion() {
-                fetchLatestAuroraVersion() { version in
-                    if let remoteVersion = version {
-                        if localVersion.compare(remoteVersion as String, options: NSStringCompareOptions.NumericSearch) == NSComparisonResult.OrderedAscending {
-                            self.naggedAboutAuroraUpdate = true
-
-                            let alert = UIAlertView(title: AppUpdateTitle, message: AppUpdateMessage, delegate: self, cancelButtonTitle: AppUpdateCancel, otherButtonTitles: AppUpdateOK)
-                            alert.show()
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private func localVersion() -> NSString? {
-        return NSBundle.mainBundle().objectForInfoDictionaryKey(String(kCFBundleVersionKey)) as? NSString
-    }
-
-    private func fetchLatestAuroraVersion(completionHandler: NSString? -> Void) {
-        Alamofire.request(.GET, AuroraPropertyListURL).responsePropertyList(options: NSPropertyListReadOptions.allZeros, completionHandler: { (_, _, object, _) -> Void in
-            if let plist = object as? NSDictionary {
-                if let items = plist["items"] as? NSArray {
-                    if let item = items[0] as? NSDictionary {
-                        if let metadata = item["metadata"] as? NSDictionary {
-                            if let remoteVersion = metadata["bundle-version"] as? String {
-                                completionHandler(remoteVersion)
-                                return
-                            }
-                        }
-                    }
-                }
-            }
-            completionHandler(nil)
-        })
-    }
-
-    func alertView(alertView: UIAlertView, clickedButtonAtIndex buttonIndex: Int) {
-        if buttonIndex == 1 {
-            UIApplication.sharedApplication().openURL(NSURL(string: AuroraDownloadPageURL)!)
-        }
-    }
-}
-    
-extension AppDelegate: MFMailComposeViewControllerDelegate {
-    func sendFeedbackMailWithImage(image: UIImage) {
-        if (MFMailComposeViewController.canSendMail()) {
-            if let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey(String(kCFBundleVersionKey)) as? NSString {
-                let mailComposeViewController = MFMailComposeViewController()
-                mailComposeViewController.mailComposeDelegate = self
-                mailComposeViewController.setSubject("Feedback on iOS client version v\(appVersion) (\(buildNumber))")
-                mailComposeViewController.setToRecipients(["ios-feedback@mozilla.com"])
-                
-                let imageData = UIImagePNGRepresentation(image)
-                mailComposeViewController.addAttachmentData(imageData, mimeType: "image/png", fileName: "feedback.png")
-                window?.rootViewController?.presentViewController(mailComposeViewController, animated: true, completion: nil)
-            }
-        }
-    }
-    
-    func mailComposeController(mailComposeViewController: MFMailComposeViewController!, didFinishWithResult result: MFMailComposeResult, error: NSError!) {
-        mailComposeViewController.dismissViewControllerAnimated(true, completion: nil)
-    }
-}
-#endif
 
 extension AppDelegate: UIApplicationDelegate {
     func application(application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {

--- a/Client/Application/AuroraAppDelegate.swift
+++ b/Client/Application/AuroraAppDelegate.swift
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Alamofire
+import MessageUI
+
+private let AuroraPropertyListURL = "https://pvtbuilds.mozilla.org/ios/FennecAurora.plist"
+private let AuroraDownloadPageURL = "https://pvtbuilds.mozilla.org/ios/index.html"
+
+private let AppUpdateTitle = NSLocalizedString("New version available", comment: "Prompt title for application update")
+private let AppUpdateMessage = NSLocalizedString("There is a new version available of Firefox Aurora. Tap OK to go to the download page.", comment: "Prompt message for application update")
+private let AppUpdateCancel = NSLocalizedString("Not Now", comment: "Label for button to cancel application update prompt")
+private let AppUpdateOK = NSLocalizedString("OK", comment: "Label for OK button in the application update prompt")
+
+class AuroraAppDelegate: AppDelegate {
+    private var naggedAboutAuroraUpdate = false
+
+    override func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
+        super.application(application, willFinishLaunchingWithOptions: launchOptions)
+
+        checkForAuroraUpdate()
+        registerFeedbackNotification()
+
+        return true
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        if !naggedAboutAuroraUpdate {
+            checkForAuroraUpdate()
+        }
+    }
+
+    func application(application: UIApplication, applicationWillTerminate app: UIApplication) {
+        unregisterFeedbackNotification()
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        unregisterFeedbackNotification()
+    }
+
+    private func registerFeedbackNotification() {
+        NSNotificationCenter.defaultCenter().addObserverForName(
+            UIApplicationUserDidTakeScreenshotNotification,
+            object: nil,
+            queue: NSOperationQueue.mainQueue()) { (notification) -> Void in
+                if let window = self.window {
+                    UIGraphicsBeginImageContext(window.bounds.size)
+                    window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates: true)
+                    let image = UIGraphicsGetImageFromCurrentImageContext()
+                    UIGraphicsEndImageContext()
+                    self.sendFeedbackMailWithImage(image)
+                }
+        }
+    }
+
+    private func unregisterFeedbackNotification() {
+        NSNotificationCenter.defaultCenter().removeObserver(self,
+            name: UIApplicationUserDidTakeScreenshotNotification, object: nil)
+    }
+}
+
+extension AuroraAppDelegate: UIAlertViewDelegate {
+    private func checkForAuroraUpdate() {
+        if let localVersion = localVersion() {
+            fetchLatestAuroraVersion() { version in
+                if let remoteVersion = version {
+                    if localVersion.compare(remoteVersion as String, options: NSStringCompareOptions.NumericSearch) == NSComparisonResult.OrderedAscending {
+                        self.naggedAboutAuroraUpdate = true
+
+                        let alert = UIAlertView(title: AppUpdateTitle, message: AppUpdateMessage, delegate: self, cancelButtonTitle: AppUpdateCancel, otherButtonTitles: AppUpdateOK)
+                        alert.show()
+                    }
+                }
+            }
+        }
+    }
+
+    private func localVersion() -> NSString? {
+        return NSBundle.mainBundle().objectForInfoDictionaryKey(String(kCFBundleVersionKey)) as? NSString
+    }
+
+    private func fetchLatestAuroraVersion(completionHandler: NSString? -> Void) {
+        Alamofire.request(.GET, AuroraPropertyListURL).responsePropertyList(options: NSPropertyListReadOptions.allZeros, completionHandler: { (_, _, object, _) -> Void in
+            if let plist = object as? NSDictionary {
+                if let items = plist["items"] as? NSArray {
+                    if let item = items[0] as? NSDictionary {
+                        if let metadata = item["metadata"] as? NSDictionary {
+                            if let remoteVersion = metadata["bundle-version"] as? String {
+                                completionHandler(remoteVersion)
+                                return
+                            }
+                        }
+                    }
+                }
+            }
+            completionHandler(nil)
+        })
+    }
+
+    func alertView(alertView: UIAlertView, clickedButtonAtIndex buttonIndex: Int) {
+        if buttonIndex == 1 {
+            UIApplication.sharedApplication().openURL(NSURL(string: AuroraDownloadPageURL)!)
+        }
+    }
+}
+
+extension AuroraAppDelegate: MFMailComposeViewControllerDelegate {
+    private func sendFeedbackMailWithImage(image: UIImage) {
+        if (MFMailComposeViewController.canSendMail()) {
+            if let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey(String(kCFBundleVersionKey)) as? NSString {
+                let mailComposeViewController = MFMailComposeViewController()
+                mailComposeViewController.mailComposeDelegate = self
+                mailComposeViewController.setSubject("Feedback on iOS client version v\(appVersion) (\(buildNumber))")
+                mailComposeViewController.setToRecipients(["ios-feedback@mozilla.com"])
+
+                let imageData = UIImagePNGRepresentation(image)
+                mailComposeViewController.addAttachmentData(imageData, mimeType: "image/png", fileName: "feedback.png")
+                window?.rootViewController?.presentViewController(mailComposeViewController, animated: true, completion: nil)
+            }
+        }
+    }
+
+    func mailComposeController(mailComposeViewController: MFMailComposeViewController!, didFinishWithResult result: MFMailComposeResult, error: NSError!) {
+        mailComposeViewController.dismissViewControllerAnimated(true, completion: nil)
+    }
+}

--- a/Client/Application/main.swift
+++ b/Client/Application/main.swift
@@ -2,6 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-let isRunningTest = NSClassFromString("XCTestCase") != nil
-let appDelegate = isRunningTest ? TestAppDelegate.self : AppDelegate.self
+private var appDelegate: AppDelegate.Type
+
+if AppConstants.IsRunningTest {
+    appDelegate = TestAppDelegate.self
+} else {
+    switch AppConstants.BuildChannel {
+    case .Aurora:
+        appDelegate = AuroraAppDelegate.self
+    case .Developer:
+        appDelegate = AppDelegate.self
+    }
+}
+
 UIApplicationMain(Process.argc, Process.unsafeArgv, NSStringFromClass(UIApplication.self), NSStringFromClass(appDelegate))

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -336,7 +336,7 @@ private class VersionSetting : Setting {
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        if !isAuroraChannel() {
+        if AppConstants.BuildChannel != .Aurora {
             DebugSettingsClickCount += 1
             if DebugSettingsClickCount >= 5 {
                 DebugSettingsClickCount = 0
@@ -429,7 +429,7 @@ class SettingsTableViewController: UITableViewController {
 
         let privacyTitle = NSLocalizedString("Privacy", comment: "Privacy section title")
         let accountDebugSettings: [Setting]
-        if !isAuroraChannel() {
+        if AppConstants.BuildChannel != .Aurora {
             accountDebugSettings = [
                 // Debug settings:
                 RequirePasswordDebugSetting(settings: self),

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+public enum AppBuildChannel {
+    case Developer
+    case Aurora
+}
+
 public struct AppConstants {
     static var StatusBarHeight: CGFloat {
         if UIScreen.mainScreen().traitCollection.verticalSizeClass == .Compact {
@@ -26,4 +31,12 @@ public struct AppConstants {
     static let PanelBackgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.6)
     static let HighlightBlue = UIColor(red:0.3, green:0.62, blue:1, alpha:1)
     static let BorderColor = UIColor.blackColor().colorWithAlphaComponent(0.25)
+
+#if MOZ_CHANNEL_AURORA
+    static let BuildChannel = AppBuildChannel.Aurora
+#else
+    static let BuildChannel = AppBuildChannel.Developer
+#endif
+
+    static let IsRunningTest = NSClassFromString("XCTestCase") != nil
 }


### PR DESCRIPTION
Follows the same `AppDelegate` pattern being used in [bug 1162999](https://bugzilla.mozilla.org/show_bug.cgi?id=1162999).