### PR TITLE
 Bug 1166116 - Domain autocompletion improvements

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -393,9 +393,6 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         })
     }
 
-    func autocompleteTextFieldDidEndEditing(autocompleteTextField: AutocompleteTextField) {
-    }
-
     func autocompleteTextFieldShouldClear(autocompleteTextField: AutocompleteTextField) -> Bool {
         delegate?.urlBar(self, didEnterText: "")
         return true

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -386,11 +386,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
     }
 
     func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField) {
-        // Without the async dispatch below, text selection doesn't work
-        // intermittently and crashes on the iPhone 6 Plus (bug 1124310).
-        dispatch_async(dispatch_get_main_queue(), {
-            autocompleteTextField.selectedTextRange = autocompleteTextField.textRangeFromPosition(autocompleteTextField.beginningOfDocument, toPosition: autocompleteTextField.endOfDocument)
-        })
+        autocompleteTextField.highlightAll()
     }
 
     func autocompleteTextFieldShouldClear(autocompleteTextField: AutocompleteTextField) -> Bool {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -104,6 +104,7 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         editTextField.font = AppConstants.DefaultMediumFont
         editTextField.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         editTextField.layer.borderColor = URLBarViewUX.TextFieldActiveBorderColor.CGColor
+        editTextField.layer.borderWidth = 1
         editTextField.hidden = true
         editTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
         locationContainer.addSubview(editTextField)
@@ -390,14 +391,9 @@ class URLBarView: UIView, BrowserLocationViewDelegate, AutocompleteTextFieldDele
         dispatch_async(dispatch_get_main_queue(), {
             autocompleteTextField.selectedTextRange = autocompleteTextField.textRangeFromPosition(autocompleteTextField.beginningOfDocument, toPosition: autocompleteTextField.endOfDocument)
         })
-
-        autocompleteTextField.layer.borderWidth = 1
-        locationContainer.layer.shadowOpacity = 0
     }
 
     func autocompleteTextFieldDidEndEditing(autocompleteTextField: AutocompleteTextField) {
-        locationContainer.layer.shadowOpacity = 0.05
-        autocompleteTextField.layer.borderWidth = 0
     }
 
     func autocompleteTextFieldShouldClear(autocompleteTextField: AutocompleteTextField) -> Bool {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -35,6 +35,15 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         super.delegate = self
     }
 
+    func highlightAll() {
+        let attributedString = NSMutableAttributedString(string: text)
+        attributedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(0, count(text)))
+        attributedText = attributedString
+
+        enteredTextLength = 0
+        completionActive = true
+    }
+
     private func applyCompletion() {
         if completionActive {
             self.attributedText = NSAttributedString(string: text)
@@ -45,6 +54,11 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private func removeCompletion() {
         if completionActive {
             let enteredText = text.substringToIndex(advance(text.startIndex, enteredTextLength))
+
+            // Workaround for stuck highlight bug.
+            if enteredTextLength == 0 {
+                attributedText = NSAttributedString(string: " ")
+            }
 
             attributedText = NSAttributedString(string: enteredText)
             completionActive = false


### PR DESCRIPTION
There are still a couple of bugs with our domain autocompletion handling:
 1. It's broken for multistage inputs (e.g., Japanese). These keyboards allow you to tap a combination of keys to enter a single character. When our autocompletion kicks in, it breaks any marked text in the input field.
 2. Autocompleted text sometimes shows when it shouldn't. One example: Type "yak", then hit delete. We show an autocomplete suggestion for "yahoo.com", but we shouldn't since we just deleted a character.