### PR TITLE
Fixes 1163282 - Crashes when restoring tab selection

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -248,8 +248,12 @@ extension TabManager {
             self.addTab(request: NSURLRequest(URL: url), flushToDisk: false)
         }
 
-        let selectedIndex: Int = coder.decodeIntegerForKey("selectedIndex")
-        self.selectTab(self.tabs[selectedIndex])
+        let selectedIndex = coder.decodeIntegerForKey("selectedIndex")
+        if selectedIndex >= 0 && selectedIndex < tabs.count {
+            selectTab(tabs[selectedIndex])
+        } else if let firstTab = tabs.first {
+            selectTab(firstTab)
+        }
         storeChanges()
     }
 }


### PR DESCRIPTION
This patch makes sure that the restored `selectedIndex` is in range of the tabs we have. If it is not then we open the first tab, if available. (It is unclear how this could happen though, but I think we got crashes on this code. So this makes it more robust.)