### PR TITLE
Bug 1166740 - Fixed regression where scrolling was stopped when nav bars are hidden

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -836,8 +836,6 @@ class ScrollRecognizer : UIGestureRecognizer {
     }
 
     override func touchesBegan(touches: Set<NSObject>!, withEvent event: UIEvent!) {
-        super.touchesBegan(touches, withEvent: event)
-
         if touches.count == 1 {
             if let touch = touches.first as? UITouch {
                 previousScroll = touch.locationInView(browserViewController?.view)
@@ -846,10 +844,11 @@ class ScrollRecognizer : UIGestureRecognizer {
             // If a second finer comes down, we'll stop dragging
             endDragging()
         }
+
+        super.touchesBegan(touches, withEvent: event)
     }
 
     override func touchesMoved(touches: Set<NSObject>!, withEvent event: UIEvent!) {
-        super.touchesMoved(touches, withEvent: event)
 
         if let tab = browserViewController?.tabManager.selectedTab,
            let scrollView = view as? UIScrollView,
@@ -886,13 +885,15 @@ class ScrollRecognizer : UIGestureRecognizer {
 
             self.previousScroll = offset
         }
+
+        super.touchesMoved(touches, withEvent: event)
     }
 
     override func touchesEnded(touches: Set<NSObject>!, withEvent event: UIEvent!) {
-        super.touchesEnded(touches, withEvent: event)
         if previousScroll != nil && touches.count == 1 {
             endDragging()
         }
+        super.touchesEnded(touches, withEvent: event)
     }
 
     private func endDragging() {


### PR DESCRIPTION
Super strange that the ordering of super worked on the simulator but not on device...