### PR TITLE
Bug 1162739 - Don't show suggested sites if we don't have a successful history cursor

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -259,6 +259,10 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
     }
 
     @objc func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        if data.status != .Success {
+            return 0
+        }
+
         // If there aren't enough data items to fill the grid, look for items in suggested sites.
         if let layout = collectionView.collectionViewLayout as? TopSitesLayout {
             if data.count < layout.thumbnailCount {
@@ -331,6 +335,10 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
     }
 
     subscript(index: Int) -> Site? {
+        if data.status != .Success {
+            return nil
+        }
+
         if index >= data.count {
             return suggestedSites[index - data.count]
         }


### PR DESCRIPTION
I opted to not show these at all if we don't have a History cursor that's in .Success. That could be odd. i.e. if history fails to load, do we want to show suggested sites or not, but I think its probably right.

Also, someone added a Closed state at some point that's... vague, but I really wish Cursor's didn't have a close method either... I'm not sure if we'd ever get a Closed cursor here (again, its kinda a vague status).