### PR TITLE
Bug 1164828 - Set search icons to a fixed size in the settings panel

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -11,6 +11,7 @@ class SearchSettingsTableViewController: UITableViewController {
     private let NumberOfItemsInSectionDefault = 2
     private let SectionOrder = 1
     private let NumberOfSections = 2
+    private let IconSize = CGSize(width: OpenSearchEngine.PreferredIconSize, height: OpenSearchEngine.PreferredIconSize)
 
     var model: SearchEngines!
 
@@ -38,7 +39,7 @@ class SearchSettingsTableViewController: UITableViewController {
                 cell.accessibilityLabel = NSLocalizedString("Default Search Engine", comment: "Accessibility label for default search engine setting.")
                 cell.accessibilityValue = engine.shortName
                 cell.textLabel?.text = engine.shortName
-                cell.imageView?.image = engine.image
+                cell.imageView?.image = engine.image?.createScaled(IconSize)
 
             case ItemDefaultSuggestions:
                 cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: nil)
@@ -69,7 +70,7 @@ class SearchSettingsTableViewController: UITableViewController {
             cell.editingAccessoryView = toggle
 
             cell.textLabel?.text = engine.shortName
-            cell.imageView?.image = engine.image
+            cell.imageView?.image = engine.image?.createScaled(IconSize)
         }
 
         // So that the seperator line goes all the way to the left edge.

--- a/Utils/Extensions/UIImage+Extensions.swift
+++ b/Utils/Extensions/UIImage+Extensions.swift
@@ -15,6 +15,14 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return image
     }
+
+    func createScaled(size: CGSize) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        drawInRect(CGRect(origin: CGPoint(x: 0, y: 0), size: size))
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return scaledImage
+    }
 }
 
 public class ImageOperation : NSObject, SDWebImageOperation {


### PR DESCRIPTION
For whatever reason, it's apparently impossible to resize `UIImageView` inside of a `UITableViewCell`. So rather than resizing the `UIImageView`, this scales the `UIImage` itself. Feels kind of heavy, so I'm happy to entertain any alternatives...

In case you wanted to try this out, just change your phone's/simulator's language to something other than English, and you should see some engines that aren't aligned correctly (without this PR applied).