### PR TITLE
Fixes 1165745 - Reading View Caching Issues

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1284,6 +1284,12 @@ extension BrowserViewController: WKNavigationDelegate {
                     self.profile.thumbnails.set(url, thumbnail: thumbnail, complete: nil)
                 }
             }
+
+            // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore
+            // because that event wil not always fire due to unreliable page caching. This will either let us know that
+            // the currently loaded page can be turned into reading mode or if the page already is in reading mode. We
+            // ignore the result because we are being called back asynchronous when the readermode status changes.
+            webView.evaluateJavaScript("_firefox_ReaderMode.checkReadability()", completionHandler: nil)
         }
 
         if tab == tabManager.selectedTab {

--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -157,7 +157,3 @@ window.addEventListener('load', function(event) {
         _firefox_ReaderMode.configureReader();
     }
 });
-
-window.addEventListener('pageshow', function(event) {
-    _firefox_ReaderMode.checkReadability();
-});


### PR DESCRIPTION
This patch moves the call to `checkReadability()` from the `pageShow` event handler to the native code. This is because the event works unreliable because of caching issues. (This is likely a bug in WebKit since `pageShow` should always fire, even on cached pages)