### PR TITLE
Fixes 1167288 - Startup crash in Browser.historyList

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -40,13 +40,17 @@ class Browser: NSObject, WKScriptMessageHandler {
         super.init()
     }
 
-    class func toTab(browser: Browser) -> RemoteTab {
-        return RemoteTab(clientGUID: nil,
-            URL: browser.displayURL ?? NSURL(),
-            title: browser.displayTitle,
-            history: browser.historyList,
-            lastUsed: Timestamp(),
-            icon: nil)
+    class func toTab(browser: Browser) -> RemoteTab? {
+        if let displayURL = browser.displayURL {
+            return RemoteTab(clientGUID: nil,
+                URL: displayURL,
+                title: browser.displayTitle,
+                history: browser.historyList,
+                lastUsed: Timestamp(),
+                icon: nil)
+        } else {
+            return nil
+        }
     }
 
     var loading: Bool {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -225,7 +225,8 @@ class TabManager : NSObject {
     }
 
     private func storeChanges() {
-        let storedTabs: [RemoteTab] = tabs.map(Browser.toTab)
+        // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
+        let storedTabs: [RemoteTab] = optFilter(tabs.map(Browser.toTab))
         storage?.insertOrUpdateTabs(storedTabs)
     }
 }


### PR DESCRIPTION
This patch makes sure we do not included not-yet-loaded tabs in `storeChanges()` by checking if the tab's `url` property is non-nil.