### PR TITLE
Fixes 1164160 - Local server pages don't restore properly on resume

### DIFF
--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -18,7 +18,7 @@ class WebServer {
     }
 
     func start() -> Bool {
-        return server.running || server.startWithPort(0, bonjourName: nil)
+        return server.running || server.startWithOptions([GCDWebServerOption_Port: 0, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true], error: nil)
     }
 
     /// Convenience method to register a dynamic handler. Will be mounted at $base/$module/$resource
@@ -49,5 +49,13 @@ class WebServer {
     /// Return a full url, as an NSURL, for a resource in a module. No check is done to find out if the resource actually exist.
     func URLForResource(resource: String, module: String) -> NSURL {
         return NSURL(string: "\(base)/\(module)/\(resource)")!
+    }
+
+    func updateLocalURL(url: NSURL) -> NSURL? {
+        let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
+        if components?.host == "localhost" && components?.scheme == "http" {
+            components?.port = WebServer.sharedInstance.server.port
+        }
+        return components?.URL
     }
 }

--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -55,20 +55,17 @@ struct ReaderModeUtils {
     }
 
     static func isReaderModeURL(url: NSURL) -> Bool {
-        let baseReaderModeURL: String = WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
-        if let absoluteString = url.absoluteString {
-            return absoluteString.hasPrefix(baseReaderModeURL)
+        if let scheme = url.scheme, host = url.host, path = url.path {
+            return scheme == "http" && host == "localhost" && path == "/reader-mode/page"
         }
         return false
     }
 
     static func decodeURL(url: NSURL) -> NSURL? {
-        let baseReaderModeURL: String = WebServer.sharedInstance.URLForResource("page", module: "reader-mode")
-        if let absoluteString = url.absoluteString {
-            if absoluteString.hasPrefix(baseReaderModeURL) {
-                let encodedURL = absoluteString.substringFromIndex(advance(absoluteString.startIndex, baseReaderModeURL.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) + 5)) // TODO Actually parse the url
-                if let decodedURL = encodedURL.stringByRemovingPercentEncoding {
-                    return NSURL(string: decodedURL)
+        if ReaderModeUtils.isReaderModeURL(url) {
+            if let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false), queryItems = components.queryItems where queryItems.count == 1 {
+                if let queryItem = queryItems.first as? NSURLQueryItem, value = queryItem.value {
+                    return NSURL(string: value)
                 }
             }
         }


### PR DESCRIPTION
Although this is a relatively small patch, it fixes the following bugs:

* 1164160 - Local server pages don't restore properly on resume
* 1168687 - Screenshots do not restore on resume
* 1167310 - Do not store tab state at startup
* 1166491 - Session encoding unsafely unwraps web view's URL

These are combined in a rewrite of the code that implements the `UIStateRestoration` functions. That code may seem a bit overly verbose and pedantic. This is on purpose because this code must be very robust to not fail on startup.