### PR TITLE
Bug 1163120 - Zombies

### DIFF
--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -29,11 +29,11 @@ class ContextMenuHelper: NSObject, BrowserHelper, UIGestureRecognizerDelegate {
         let path = NSBundle.mainBundle().pathForResource("ContextMenu", ofType: "js")!
         let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as! String
         let userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: false)
-        browser.webView.configuration.userContentController.addUserScript(userScript)
+        browser.webView!.configuration.userContentController.addUserScript(userScript)
 
         // Add a gesture recognizer that disables the built-in context menu gesture recognizer.
         gestureRecognizer.delegate = self
-        browser.webView.addGestureRecognizer(gestureRecognizer)
+        browser.webView!.addGestureRecognizer(gestureRecognizer)
     }
 
     func scriptMessageHandlerName() -> String? {

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -17,7 +17,7 @@ class FaviconManager : BrowserHelper {
         if let path = NSBundle.mainBundle().pathForResource("Favicons", ofType: "js") {
             if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as? String {
                 var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
-                browser.webView.configuration.userContentController.addUserScript(userScript)
+                browser.webView!.configuration.userContentController.addUserScript(userScript)
             }
         }
     }
@@ -33,7 +33,7 @@ class FaviconManager : BrowserHelper {
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
         let manager = SDWebImageManager.sharedManager()
         self.browser?.favicons.removeAll(keepCapacity: false)
-        if let url = browser?.webView.URL?.absoluteString {
+        if let url = browser?.webView!.URL?.absoluteString {
             let site = Site(url: url, title: "")
             if let icons = message.body as? [String: Int] {
                 for icon in icons {

--- a/Client/Frontend/Browser/PasswordHelper.swift
+++ b/Client/Frontend/Browser/PasswordHelper.swift
@@ -30,7 +30,7 @@ class PasswordHelper: BrowserHelper {
         if let path = NSBundle.mainBundle().pathForResource("PasswordHelper", ofType: "js") {
             if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as? String {
                 var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
-                browser.webView.configuration.userContentController.addUserScript(userScript)
+                browser.webView!.configuration.userContentController.addUserScript(userScript)
             }
         }
     }
@@ -175,7 +175,7 @@ class PasswordHelper: BrowserHelper {
 
             let json = JSON(jsonObj)
             let src = "window.__firefox__.passwords.inject(\(json.toString()))"
-            self.browser?.webView.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
+            self.browser?.webView?.evaluateJavaScript(src, completionHandler: { (obj, err) -> Void in
             })
         })
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -518,7 +518,8 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
         // We're only doing one update here, but using a batch update lets us delay selecting the tab
         // until after its insert animation finishes.
         self.collectionView.performBatchUpdates({ _ in
-            self.tabManager.addTab()
+            let tab = self.tabManager.addTab()
+            self.tabManager.selectTab(tab)
         }, completion: { finished in
             if finished {
                 self.presentingViewController!.dismissViewControllerAnimated(true, completion: nil)
@@ -549,6 +550,7 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
             } else {
                 cell.favicon.image = UIImage(named: "defaultFavicon")
             }
+
             cell.background.image = tab.screenshot
         }
 
@@ -769,6 +771,7 @@ extension TabTrayController: TabManagerDelegate {
             self.collectionView.deleteItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
             if tabManager.count == 0 {
                 newTab = tabManager.addTab()
+                tabManager.selectTab(newTab)
             }
         }, completion: { finished in
             if finished {

--- a/Client/Frontend/Reader/ReadabilityBrowserHelper.swift
+++ b/Client/Frontend/Reader/ReadabilityBrowserHelper.swift
@@ -23,7 +23,7 @@ class ReadabilityBrowserHelper: BrowserHelper {
            let readabilityBrowserHelperSource = NSMutableString(contentsOfFile: readabilityBrowserHelperPath, encoding: NSUTF8StringEncoding, error: nil) {
             readabilityBrowserHelperSource.replaceOccurrencesOfString("%READABILITYJS%", withString: readabilitySource as String, options: NSStringCompareOptions.LiteralSearch, range: NSMakeRange(0, readabilityBrowserHelperSource.length))
             var userScript = WKUserScript(source: readabilityBrowserHelperSource as String, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
-            browser.webView.configuration.userContentController.addUserScript(userScript)
+            browser.webView!.configuration.userContentController.addUserScript(userScript)
         }
     }
 

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -38,7 +38,7 @@ class ReadabilityOperation: NSOperation, WKNavigationDelegate, ReadabilityBrowse
         dispatch_async(dispatch_get_main_queue(), { () -> Void in
             let configuration = WKWebViewConfiguration()
             self.browser = Browser(configuration: configuration)
-            self.browser.webView.navigationDelegate = self
+            self.browser.navigationDelegate = self
 
             if let readabilityBrowserHelper = ReadabilityBrowserHelper(browser: self.browser) {
                 readabilityBrowserHelper.delegate = self
@@ -47,7 +47,6 @@ class ReadabilityOperation: NSOperation, WKNavigationDelegate, ReadabilityBrowse
 
             // Load the page in the webview. This either fails with a navigation error, or we get a readability
             // callback. Or it takes too long, in which case the semaphore times out.
-
             self.browser.loadRequest(NSURLRequest(URL: self.url))
         })
 

--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -214,7 +214,7 @@ class ReaderMode: BrowserHelper {
         if let path = NSBundle.mainBundle().pathForResource("Readability", ofType: "js") {
             if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as? String {
                 var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
-                browser.webView.configuration.userContentController.addUserScript(userScript)
+                browser.webView!.configuration.userContentController.addUserScript(userScript)
             }
         }
 
@@ -222,7 +222,7 @@ class ReaderMode: BrowserHelper {
         if let path = NSBundle.mainBundle().pathForResource("ReaderMode", ofType: "js") {
             if let source = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as? String {
                 var userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
-                browser.webView.configuration.userContentController.addUserScript(userScript)
+                browser.webView!.configuration.userContentController.addUserScript(userScript)
             }
         }
     }
@@ -266,7 +266,7 @@ class ReaderMode: BrowserHelper {
     var style: ReaderModeStyle = DefaultReaderModeStyle {
         didSet {
             if state == ReaderModeState.Active {
-                browser!.webView.evaluateJavaScript("\(ReaderModeNamespace).setStyle(\(style.encode()))", completionHandler: {
+                browser!.webView?.evaluateJavaScript("\(ReaderModeNamespace).setStyle(\(style.encode()))", completionHandler: {
                     (object, error) -> Void in
                     return
                 })

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -208,7 +208,6 @@ public class BrowserProfile: Profile {
         return self.makePrefs()
     }()
 
-
     lazy var readingList: ReadingListService? = {
         return ReadingListService(profileStoragePath: self.files.rootPath)
     }()


### PR DESCRIPTION
This lets a Browser exist without a webView. The webView within it can be created/destroyed by calling zombify()/resurrect(). While its a zombie, it holds on to (some) information that's given to it so that it can handle it later when its resurrected. i.e. the last load request. A navigation delegate. I started to make userScripts that were loaded work like that as well, but decided it was easier for callers to just be careful about re-registering themselves when the tabs were resurrected. There's a delegate interface for notifications when tabs are zombified or resurrected.

Tabs are automatically "resurrected" when they're created (unless you specify not to), or when they're selected. Zombie tabs load the thumbnails from thumbnail storage. 

I also... couldn't resist and made a few other little changes. This completely zombifies all unselected tabs on memory warnings. Seems like something we should do? It also removes selecting tabs from the addTab method, since the two seem like orthogonal things to me. i.e. Ideally you'd just call:
tabManager.selectedTab = tabManager.addTab(url)