### PR TITLE
Bug 1167521 - Adjust the deceleration rate for faster scrolling

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -31,7 +31,7 @@ class Browser: NSObject, WKScriptMessageHandler {
         webView.allowsBackForwardNavigationGestures = true
         webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
         webView.backgroundColor = UIColor.lightGrayColor()
-        webView.scrollView.layer.masksToBounds = false
+        webView.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
 
         // Turning off masking allows the web content to flow outside of the scrollView's frame
         // which allows the content appear beneath the toolbars in the BrowserViewController


### PR DESCRIPTION
Web views on iOS have a higher deceleration rate than normal scroll views. The system-standard deceleration rate makes it nicer to browser mobile-friendly sites; they are long columns of content and benefit from less friction when vertically scrolling.

(If you don't want this PR I understand. Empirically I've found low-friction scrolling to be one of the selling points of mobile browsers like Opera Coast though.)