### PR TITLE
Bugs 1164231, 1152697: Make long-press actions available as native accessibility actions

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = 746B6A781B277C1800EA83E3 /* SessionRestore.html */; };
 		746D4E571B1E7132008F789F /* HashchangeHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 746D4E561B1E7132008F789F /* HashchangeHelper.js */; };
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
+		6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE4ACF81B0657180092AEBE /* Accessibility.swift */; };
 		D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* TabTrayController.swift */; };
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -1363,6 +1364,7 @@
 		746D4E561B1E7132008F789F /* HashchangeHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = HashchangeHelper.js; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
 		74C295261B21152000862FE3 /* AboutHomeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutHomeHandler.swift; sourceTree = "<group>"; };
+		6BE4ACF81B0657180092AEBE /* Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
@@ -2369,6 +2371,7 @@
 				287DA9D51AE06D220055AC35 /* Extensions */,
 				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
+				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
 				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
 				287DAA1E1AE06E5D0055AC35 /* DeviceInfo.swift */,
@@ -3814,6 +3817,7 @@
 				D339C2831AD354B400C087BD /* Loader.swift in Sources */,
 				288501FB1AC0F63800E7F670 /* NSScannerExtensions.swift in Sources */,
 				E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */,
+				6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
 				281B2C081ADF4F29002917DC /* DeferredUtils.swift in Sources */,
 				2FDE87521ABA3EA0005317B1 /* TimeConstants.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -153,7 +153,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: "SELlongPressReaderModeButton:"))
         addSubview(readerModeButton)
         readerModeButton.isAccessibilityElement = true
-        readerModeButton.accessibilityLabel = NSLocalizedString("Reader Mode", comment: "Accessibility label for the reader mode button")
+        readerModeButton.accessibilityLabel = NSLocalizedString("Reader View", comment: "Accessibility label for the Reader View button")
         readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: NSLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list."), target: self, selector: "SELreaderModeCustomAction")]
 
         accessibilityElements = [editTextFieldListenerView, lockImageView, editTextField, readerModeButton]
@@ -354,7 +354,6 @@ private class ReaderModeButton: UIButton {
         super.init(frame: frame)
         setImage(UIImage(named: "reader.png"), forState: UIControlState.Normal)
         setImage(UIImage(named: "reader_active.png"), forState: UIControlState.Selected)
-        accessibilityLabel = NSLocalizedString("Reader", comment: "Browser function that presents simplified version of the page with bigger text.")
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -11,7 +11,8 @@ protocol BrowserLocationViewDelegate {
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView)
     func browserLocationViewDidLongPressLocation(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView)
-    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView)
+    /// :returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied
+    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView) -> Bool
     func browserLocationViewLocationAccessibilityActions(browserLocationView: BrowserLocationView) -> [UIAccessibilityCustomAction]?
 }
 
@@ -153,6 +154,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         addSubview(readerModeButton)
         readerModeButton.isAccessibilityElement = true
         readerModeButton.accessibilityLabel = NSLocalizedString("Reader Mode", comment: "Accessibility label for the reader mode button")
+        readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: NSLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list."), target: self, selector: "SELreaderModeCustomAction")]
 
         accessibilityElements = [editTextFieldListenerView, lockImageView, editTextField, readerModeButton]
     }
@@ -234,6 +236,10 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
             editTextFieldListenerView.hidden = true
             editTextField.becomeFirstResponder()
         }
+    }
+
+    func SELreaderModeCustomAction() -> Bool {
+        return delegate?.browserLocationViewDidLongPressReaderMode(self) ?? false
     }
 
     var url: NSURL? {

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -12,6 +12,7 @@ protocol BrowserLocationViewDelegate {
     func browserLocationViewDidLongPressLocation(browserLocationView: BrowserLocationView)
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView)
     func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView)
+    func browserLocationViewLocationAccessibilityActions(browserLocationView: BrowserLocationView) -> [UIAccessibilityCustomAction]?
 }
 
 private struct BrowserLocationViewUX {
@@ -122,6 +123,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         editTextField.layer.backgroundColor = UIColor.whiteColor().CGColor
         editTextField.font = UIConstants.DefaultMediumFont
         editTextField.isAccessibilityElement = true
+        editTextField.accessibilityActionsSource = self
         editTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
         editTextField.attributedPlaceholder = BrowserLocationView.PlaceholderText
         editTextField.toolbarTextFieldDelegate = self
@@ -332,6 +334,15 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
     }
 }
 
+extension BrowserLocationView: AccessibilityActionsSource {
+    func accessibilityCustomActionsForView(view: UIView) -> [UIAccessibilityCustomAction]? {
+        if view === editTextField {
+            return delegate?.browserLocationViewLocationAccessibilityActions(self)
+        }
+        return nil
+    }
+}
+
 private class ReaderModeButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -370,6 +381,19 @@ private class ReaderModeButton: UIButton {
 class ToolbarTextField: AutocompleteTextField, UITextFieldDelegate {
 
     var toolbarTextFieldDelegate: UITextFieldDelegate?
+
+    weak var accessibilityActionsSource: AccessibilityActionsSource?
+    override var accessibilityCustomActions: [AnyObject]! {
+        get {
+            if !editing {
+                return accessibilityActionsSource?.accessibilityCustomActionsForView(self)
+            }
+            return super.accessibilityCustomActions
+        }
+        set {
+            super.accessibilityCustomActions = newValue
+        }
+    }
 
     override init(frame: CGRect) {
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -738,15 +738,17 @@ extension BrowserViewController: URLBarDelegate {
         }
     }
 
-    func urlBarDidLongPressReaderMode(urlBar: URLBarView) {
+    func urlBarDidLongPressReaderMode(urlBar: URLBarView) -> Bool {
         if let tab = tabManager.selectedTab {
             if var url = tab.displayURL {
                 if let absoluteString = url.absoluteString {
                     let result = profile.readingList?.createRecordWithURL(absoluteString, title: tab.title ?? "", addedBy: UIDevice.currentDevice().name) // TODO Check result, can this fail?
+                    return true
                     // TODO Followup bug, provide some form of 'this has been added' feedback?
                 }
             }
         }
+        return false
     }
 
     func locationActionsForURLBar(urlBar: URLBarView) -> [AccessibleAction] {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -739,15 +739,22 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidLongPressReaderMode(urlBar: URLBarView) -> Bool {
-        if let tab = tabManager.selectedTab {
-            if var url = tab.displayURL {
-                if let absoluteString = url.absoluteString {
-                    let result = profile.readingList?.createRecordWithURL(absoluteString, title: tab.title ?? "", addedBy: UIDevice.currentDevice().name) // TODO Check result, can this fail?
-                    return true
-                    // TODO Followup bug, provide some form of 'this has been added' feedback?
-                }
+        if let tab = tabManager.selectedTab,
+               url = tab.displayURL,
+               absoluteString = url.absoluteString,
+               result = profile.readingList?.createRecordWithURL(absoluteString, title: tab.title ?? "", addedBy: UIDevice.currentDevice().name)
+        {
+            switch result {
+            case .Success:
+                UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString("Added page to Reading List", comment: "Accessibility message e.g. spoken by VoiceOver after the current page gets added to the Reading List using the Reader View button, e.g. by long-pressing it or by its accessibility custom action."))
+                // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1158503 provide some form of 'this has been added' visual feedback?
+            case .Failure(let error):
+                UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString("Could not add page to Reading List. Maybe it's already there?", comment: "Accessibility message e.g. spoken by VoiceOver after the user wanted to add current page to the Reading List and this was not done, likely because it already was in the Reading List, but perhaps also because of real failures."))
+                log.error("readingList.createRecordWithURL(url: \"\(absoluteString)\", ...) failed with error: \(error)")
             }
+            return true
         }
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString("Could not add page to Reading list", comment: "Accessibility message e.g. spoken by VoiceOver after adding current webpage to the Reading List failed."))
         return false
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -35,7 +35,8 @@ private struct URLBarViewUX {
 protocol URLBarDelegate: class {
     func urlBarDidPressTabs(urlBar: URLBarView)
     func urlBarDidPressReaderMode(urlBar: URLBarView)
-    func urlBarDidLongPressReaderMode(urlBar: URLBarView)
+    /// :returns: whether the long-press was handled by the delegate; i.e. return `false` when the conditions for even starting handling long-press were not satisfied
+    func urlBarDidLongPressReaderMode(urlBar: URLBarView) -> Bool
     func urlBarDidPressStop(urlBar: URLBarView)
     func urlBarDidPressReload(urlBar: URLBarView)
     func urlBarDidBeginEditing(urlBar: URLBarView)
@@ -535,8 +536,8 @@ extension URLBarView: BrowserToolbarProtocol {
 }
 
 extension URLBarView: BrowserLocationViewDelegate {
-    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView) {
-        delegate?.urlBarDidLongPressReaderMode(self)
+    func browserLocationViewDidLongPressReaderMode(browserLocationView: BrowserLocationView) -> Bool {
+        return delegate?.urlBarDidLongPressReaderMode(self) ?? false
     }
 
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -41,6 +41,7 @@ protocol URLBarDelegate: class {
     func urlBarDidBeginEditing(urlBar: URLBarView)
     func urlBarDidEndEditing(urlBar: URLBarView)
     func urlBarDidLongPressLocation(urlBar: URLBarView)
+    func urlBarLocationAccessibilityActions(urlBar: URLBarView) -> [UIAccessibilityCustomAction]?
     func urlBarDidPressScrollToTop(urlBar: URLBarView)
     func urlBar(urlBar: URLBarView, didEnterText text: String)
     func urlBar(urlBar: URLBarView, didSubmitText text: String)
@@ -561,6 +562,10 @@ extension URLBarView: BrowserLocationViewDelegate {
 
     func browserLocationViewDidTapReaderMode(browserLocationView: BrowserLocationView) {
         delegate?.urlBarDidPressReaderMode(self)
+    }
+
+    func browserLocationViewLocationAccessibilityActions(browserLocationView: BrowserLocationView) -> [UIAccessibilityCustomAction]? {
+        return delegate?.urlBarLocationAccessibilityActions(self)
     }
 }
 

--- a/ReadingList/ReadingListSQLStorage.swift
+++ b/ReadingList/ReadingListSQLStorage.swift
@@ -83,7 +83,8 @@ class ReadingListSQLStorage: ReadingListStorage {
 
     func createRecordWithURL(url: String, title: String, addedBy: String) -> Result<ReadingListClientRecord> {
         let items = db["items"]
-        if let id = items.insert(ItemColumns.ClientLastModified <- ReadingListNow(), ItemColumns.Url <- url, ItemColumns.Title <- title, ItemColumns.AddedBy <- addedBy) {
+        let (id, statement) = items.insert(ItemColumns.ClientLastModified <- ReadingListNow(), ItemColumns.Url <- url, ItemColumns.Title <- title, ItemColumns.AddedBy <- addedBy)
+        if let id = id {
             if let item = items.filter(ItemColumns.ClientId == id).first {
                 if let record = ReadingListClientRecord(row: rowToDictionary(item)) {
                     return Result(success: record)
@@ -94,6 +95,9 @@ class ReadingListSQLStorage: ReadingListStorage {
                 return Result(failure: ReadingListStorageError("Can't get first item from results"))
             }
         } else {
+            if let reason = statement.reason {
+                return Result(failure: ReadingListStorageError("Can't insert: \(reason)"))
+            }
             return Result(failure: ReadingListStorageError("Can't insert"))
         }
     }

--- a/UITests/ReaderViewUITests.swift
+++ b/UITests/ReaderViewUITests.swift
@@ -31,7 +31,7 @@ class ReaderViewUITests: KIFTestCase, UITextFieldDelegate {
         tester().tapViewWithAccessibilityIdentifier("url")
         let url = "\(webRoot)/readerContent.html"
         tester().clearTextFromAndThenEnterText("\(url)\n", intoViewWithAccessibilityLabel: "Address and Search")
-        tester().tapViewWithAccessibilityLabel("Reader Mode")
+        tester().tapViewWithAccessibilityLabel("Reader View")
     }
 
     func addToReadingList() {

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -23,7 +23,7 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
 
         // Add it to the reading list
-        tester().tapViewWithAccessibilityLabel("Reader Mode")
+        tester().tapViewWithAccessibilityLabel("Reader View")
         tester().tapViewWithAccessibilityLabel("Add to Reading List")
 
         // Open a new page

--- a/Utils/Accessibility.swift
+++ b/Utils/Accessibility.swift
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+public protocol AccessibilityActionsSource: class {
+    func accessibilityCustomActionsForView(view: UIView) -> [UIAccessibilityCustomAction]?
+}
+
+public class AccessibleAction {
+    public let name: String
+    public let handler: () -> Bool
+
+    public init(name: String, handler: () -> Bool) {
+        self.name = name
+        self.handler = handler
+    }
+}
+
+extension AccessibleAction { // UIAccessibilityCustomAction
+    @objc private func SELperformAccessibilityAction() -> Bool {
+        return handler()
+    }
+
+    public var accessibilityCustomAction: UIAccessibilityCustomAction {
+        return UIAccessibilityCustomAction(name: name, target: self, selector: "SELperformAccessibilityAction")
+    }
+}
+
+
+extension AccessibleAction { // UIAlertAction
+    private var alertActionHandler: (UIAlertAction!) -> Void {
+        return { (_: UIAlertAction!) -> Void in self.handler() }
+    }
+
+    public func alertAction(#style: UIAlertActionStyle) -> UIAlertAction {
+        return UIAlertAction(title: name, style: style, handler: alertActionHandler)
+    }
+}


### PR DESCRIPTION
[Bug 1164231 - Provide long-press actions as accessibility custom actions](https://bugzilla.mozilla.org/show_bug.cgi?id=1164231)
[Bug 1152697 - When saving a page to the reading list, post a VoiceOver announcement when the action finished successfully](https://bugzilla.mozilla.org/show_bug.cgi?id=1152697)

If you think the last commit is too wild, I can rework it to just
announce success on success and generic "Failed to add to Reading List"
otherwise. But I don't know of better solution right now except for
reworking `ReadingListStorageError` to represent all possible failures
as enum cases with suitable associated values, which is beyond the scope
of the proposed change.

Patches donated by [A11Y LTD.](http://a11y.ltd.uk)