### PR TITLE
Bug 1166018: do not stop system audio on start

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Shared
+import AVFoundation
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
@@ -21,6 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.
         setUpWebServer(profile)
+
+        // for aural progress bar: play even with silent switch on, and do not stop audio from other apps (like music)
+        AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, withOptions: AVAudioSessionCategoryOptions.MixWithOthers, error: nil)
 
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.backgroundColor = UIColor.whiteColor()


### PR DESCRIPTION
We want to:
- play even when silent mode is on (-> Playback category)
- not stop audio from other apps like music (-> MixWithOthers)

As the aural progress bar is currently the only place where we play any
audio, let's put the code there. Other candidate, should the need arise,
is e.g. the app delegate.

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)