### PR TITLE
Fixes 1168537 - Export strings files with the trans-unit id as key instead of the source string

### DIFF
--- a/scripts/xliff-to-strings.py
+++ b/scripts/xliff-to-strings.py
@@ -47,22 +47,15 @@ def export_xliff_file(file_node, export_path, target_language):
         os.makedirs(directory)
     with open(export_path, "w") as fp:
         for trans_unit_node in file_node.xpath("x:body/x:trans-unit", namespaces=NS):
-            sources = trans_unit_node.xpath("x:source", namespaces=NS)
+            trans_unit_id = trans_unit_node.get("id")
             targets = trans_unit_node.xpath("x:target", namespaces=NS)
 
-            # Special hack for en-US. If we don't create an en-US.lproj file,
-            # the  system will not default to the base strings but instead
-            # pick some random locale it seems. This needs to be verified. Not
-            # sure if our bug or iOS bug.
-            if target_language == "en-US":
-                targets = sources
-
-            if len(sources) == 1 and len(targets) == 1:
+            if trans_unit_id is not None and len(targets) == 1:
                 notes = trans_unit_node.xpath("x:note", namespaces=NS)
                 if len(notes) == 1:
                     line = u"/* %s */\n" % notes[0].text
                     fp.write(line.encode("utf8"))
-                source_text = sources[0].text.replace("'", "\\'")
+                source_text = trans_unit_id.replace("'", "\\'")
                 target_text = targets[0].text.replace("'", "\\'")
                 line = u"\"%s\" = \"%s\";\n\n" % (source_text, target_text)
                 fp.write(line.encode("utf8"))


### PR DESCRIPTION
When exporting strings files `(xliff-to-strings.py)`, use the `trans-unit[id]` as the string key. Right now we use `trans-unit.source` but that is not correct.