### PR TITLE
Bug 1151961 - Update Bookmark Favicons

### DIFF
--- a/Storage/Bookmarks.swift
+++ b/Storage/Bookmarks.swift
@@ -22,6 +22,10 @@ public protocol ShareToDestination {
     func shareItem(item: ShareItem)
 }
 
+public protocol SearchableBookmarks {
+    func bookmarksByURL(url: NSURL) -> Deferred<Result<Cursor<BookmarkItem>>>
+}
+
 public struct BookmarkRoots {
     // These match Places on desktop.
     public static let RootGUID =               "root________"
@@ -153,6 +157,7 @@ public protocol BookmarksModelFactory {
     func isBookmarked(url: String, success: Bool -> (), failure: Any -> ())
     func remove(bookmark: BookmarkNode, success: Bool -> (), failure: Any -> ())
     func removeByURL(url: String, success: Bool -> Void, failure: Any -> Void)
+    func clearBookmarks() -> Success
 }
 
 /*
@@ -311,5 +316,9 @@ public class MockMemoryBookmarksStore: BookmarksModelFactory, ShareToDestination
 
     public func removeByURL(url: String, success: (Bool) -> Void, failure: (Any) -> Void) {
         failure("Not implemented")
+    }
+
+    public func clearBookmarks() -> Success {
+        return succeed()
     }
 }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -335,6 +335,12 @@ extension SQLiteHistory: Favicons {
                     return 0
                 }
 
+                // Try to update the favicon ID column in the bookmarks table as well for this favicon
+                // if this site has been bookmarked
+                if let id = id {
+                    conn.executeChange("UPDATE \(TableBookmarks) SET faviconID = ? WHERE url = ?", withArgs: [id, site.url])
+                }
+
                 return id ?? 0
             }
 

--- a/Utils/DeferredUtils.swift
+++ b/Utils/DeferredUtils.swift
@@ -11,7 +11,7 @@ public func >>== <T, U>(x: Deferred<Result<T>>, f: T -> Deferred<Result<U>>) -> 
 }
 
 // A termination case.
-public func >>== <T, U>(x: Deferred<Result<T>>, f: T -> ()) {
+public func >>== <T>(x: Deferred<Result<T>>, f: T -> ()) {
     return x.upon { result in
         if let v = result.successValue {
             f(v)


### PR DESCRIPTION
So I believe this should update the favicon icons for a bookmarked page on each page load since from what I can see the favicon.js script gets run on load which triggers the FaviconManager to save favicons. I just piggyback on that response and update the favicon ID link in the bookmarks table if the page we're on is bookmarked.

Also fixes a bug with the >>== terminal definition where we were passing in a second generic parameter when it only needs one.