### PR TITLE
Bug 1167233 - Don't assume we have a tab when navigation ends

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -194,6 +194,10 @@ class TabManager : NSObject {
         }
         assert(count == prevCount - 1, "Tab removed")
 
+        // There's still some time between this and the webView being destroyed.
+        // We don't want to pick up any stray events.
+        tab.webView?.navigationDelegate = nil
+
         for delegate in delegates {
             delegate.get()?.tabManager(self, didRemoveTab: tab, atIndex: index)
         }


### PR DESCRIPTION
This is a little bit of a hacky way to fix this. I think this happens because we're using Deferreds here now and call:

all(clearables.map({ clearable.clear() }))

All of our "clearable" things are cleared concurrently, and we wind up doing more than one removeAllTabs() call at the same time, which can also result in calls creating a new empty tab. Somehow in that mess, didFinishNavigation can be called with a webView that has no tab attached. I played for awhile with locking TabManager.tabs, but its a bit messy (i.e. our ReadWriteLock thats in the codebase now isn't smart about grabbing a read lock while you have a write one, which makes for easy deadlocks).