### PR TITLE
Bug 1164486 - Application is leaking Browser instances

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1320,7 +1320,7 @@ extension BrowserViewController: WKNavigationDelegate {
             webView.evaluateJavaScript("_firefox_ReaderMode.checkReadability()", completionHandler: nil)
         }
 
-        if tab == tabManager.selectedTab {
+        if tab === tabManager.selectedTab {
             UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
             // must be followed by LayoutChanged, as ScreenChanged will make VoiceOver
             // cursor land on the correct initial element, but if not followed by LayoutChanged,
@@ -1391,7 +1391,7 @@ extension BrowserViewController: ReaderModeDelegate, UIPopoverPresentationContro
     func readerMode(readerMode: ReaderMode, didChangeReaderModeState state: ReaderModeState, forBrowser browser: Browser) {
         // If this reader mode availability state change is for the tab that we currently show, then update
         // the button. Otherwise do nothing and the button will be updated when the tab is made active.
-        if tabManager.selectedTab == browser {
+        if tabManager.selectedTab === browser {
             log.debug("New readerModeState: \(state.rawValue)")
             urlBar.updateReaderModeState(state)
         }

--- a/UITests/ViewMemoryLeakTests.swift
+++ b/UITests/ViewMemoryLeakTests.swift
@@ -78,6 +78,22 @@ class ViewMemoryLeakTests: KIFTestCase, UITextFieldDelegate {
         XCTAssertNil(tabCell, "Tab tray cell disposed")
     }
 
+    func testWebViewDisposed() {
+        weak var webView = tester().waitForViewWithAccessibilityLabel("Web content")
+        XCTAssertNotNil(webView, "webView found")
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        let tabsView = tester().waitForViewWithAccessibilityLabel("Tabs Tray").subviews.first as! UICollectionView
+        let cell = tabsView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 0))!
+        tester().swipeViewWithAccessibilityLabel(cell.accessibilityLabel, inDirection: KIFSwipeDirection.Left)
+        tester().waitForTappableViewWithAccessibilityLabel("Show Tabs")
+
+        tester().runBlock { _ in
+            return (webView == nil) ? KIFTestStepResult.Success : KIFTestStepResult.Wait
+        }
+        XCTAssertNil(webView, "webView disposed")
+    }
+
     private func getChildViewController(parent: UIViewController, childClass: String) -> UIViewController {
         let childControllers = parent.childViewControllers.filter { child in
             let description = NSString(string: child.description)


### PR DESCRIPTION
Looks like script message handlers are strongly held, and `Browser` *is* the message handler, so we have a `Browser` -> `WKWebView` -> `Browser` ref cycle. To break it, we can decouple the helper handling into a separate class that doesn't strongly hold the `WKWebView`.

Included a test to check for leaking web views (which fails without this fix, as expected).