### PR TITLE
Bug 1169392 - Progress Bar Regression Fix

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -164,8 +164,6 @@ class URLBarView: UIView {
 
     private func commonInit() {
         backgroundColor = URLBarViewUX.backgroundColorWithAlpha(0)
-        clipsToBounds = true
-
         addSubview(curveShape);
 
         locationContainer.addSubview(locationView)


### PR DESCRIPTION
Regression was being caused by the URLBarView clipping out the progress bar since it's technically out of bounds.