### PR TITLE
Bug 1169750 - Fixed TabButton constraint errors / Bug 1160833 - Tab count goes to 0 after closing last tab

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -762,22 +762,23 @@ extension TabTrayController: TabManagerDelegate {
     }
 
     func tabManager(tabManager: TabManager, didAddTab tab: Browser, atIndex index: Int) {
-        self.collectionView.insertItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+        self.collectionView.performBatchUpdates({ _ in
+            self.collectionView.insertItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+        }, completion: { finished in
+            if finished {
+                tabManager.selectTab(tabManager[index])
+                self.presentingViewController!.dismissViewControllerAnimated(true, completion: nil)
+            }
+        })
     }
 
     func tabManager(tabManager: TabManager, didRemoveTab tab: Browser, atIndex index: Int) {
         var newTab: Browser? = nil
         self.collectionView.performBatchUpdates({ _ in
             self.collectionView.deleteItemsAtIndexPaths([NSIndexPath(forItem: index, inSection: 0)])
+        }, completion: { finished in
             if tabManager.count == 0 {
                 newTab = tabManager.addTab()
-                tabManager.selectTab(newTab)
-            }
-        }, completion: { finished in
-            if finished {
-                if let newTab = newTab {
-                    self.presentingViewController!.dismissViewControllerAnimated(true, completion: nil)
-                }
             }
         })
     }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -89,6 +89,7 @@ class URLBarView: UIView {
 
     private lazy var tabsButton: UIButton = {
         var tabsButton = InsetButton()
+        tabsButton.setTranslatesAutoresizingMaskIntoConstraints(false)
         tabsButton.setTitle("0", forState: UIControlState.Normal)
         tabsButton.setTitleColor(URLBarViewUX.backgroundColorWithAlpha(1), forState: UIControlState.Normal)
         tabsButton.titleLabel?.layer.backgroundColor = UIColor.whiteColor().CGColor
@@ -297,7 +298,6 @@ class URLBarView: UIView {
     }
 
     func updateTabCount(count: Int) {
-
         // make a 'clone' of the tabs button
         let newTabsButton = InsetButton()
         newTabsButton.setTitleColor(AppConstants.AppBackgroundColor, forState: UIControlState.Normal)
@@ -305,16 +305,16 @@ class URLBarView: UIView {
         newTabsButton.titleLabel?.layer.cornerRadius = 2
         newTabsButton.titleLabel?.font = AppConstants.DefaultSmallFontBold
         newTabsButton.titleLabel?.textAlignment = NSTextAlignment.Center
+        newTabsButton.setTitle(count.description, forState: .Normal)
+        addSubview(newTabsButton)
         newTabsButton.titleLabel?.snp_makeConstraints { make in
             make.size.equalTo(URLBarViewUX.TabsButtonHeight)
         }
-
-        if let anchor = tabsButton.titleLabel?.layer.anchorPoint {
-            newTabsButton.titleLabel?.layer.anchorPoint = anchor
+        newTabsButton.snp_makeConstraints { make in
+            make.centerY.equalTo(self.locationContainer)
+            make.trailing.equalTo(self)
+            make.size.equalTo(AppConstants.ToolbarHeight)
         }
-
-        newTabsButton.setTitle(count.description, forState: .Normal)
-        addSubview(newTabsButton)
 
         // Force layout pass so we have our frames calculated for the transform math
         setNeedsLayout()


### PR DESCRIPTION
Fixed the race condition that was occurring when inserting/deleting the tabs from the TabTrayCollection view. Removed autoresizing constraints for InsetButtons.