### PR TITLE
Bug 1162736 - Toolbar hides when navigating away from HomePanel

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -239,6 +239,8 @@ class BrowserViewController: UIViewController {
     }
 
     override func updateViewConstraints() {
+        super.updateViewConstraints()
+
         statusBarOverlay.snp_remakeConstraints { make in
             make.top.left.right.equalTo(self.view)
             make.height.equalTo(topLayoutGuide.length)
@@ -303,15 +305,12 @@ class BrowserViewController: UIViewController {
         homePanelController?.view.snp_remakeConstraints { make in
             make.top.equalTo(self.urlBar.snp_bottom)
             make.left.right.equalTo(self.view)
-            let url = self.tabManager.selectedTab?.url
-            if url == AppConstants.AboutHomeURL && self.homePanelIsInline {
+            if self.homePanelIsInline {
                 make.bottom.equalTo(self.toolbar?.snp_top ?? self.view.snp_bottom)
             } else {
                 make.bottom.equalTo(self.view.snp_bottom)
             }
         }
-
-        super.updateViewConstraints()
     }
 
     private func wrapInEffect(view: UIView, parent: UIView) -> UIView {


### PR DESCRIPTION
So I'm still trying to wrap my head around how this is 'supposed' to work. The amount of state that's changing everywhere makes it confusing as to what's going on when. 

Essentially with this patch, I removed the requirement that you need to be on about:home in order to set the bottom constraint to the top of the toolbar. What was happening was when you tapped on a top site was the navigation caused the constraints to update, and since we were navigating to not about:home, the home panel constraint got updated to be at the bottom - hiding the toolbar. When the url starts loading, the constraints get updated again but this time the web view container's constraints are set to be above the toolbar so the toolbar appears again. The overall behavior now is as follows:

1. First launch on top sites: Toolbar shown
2. Navigate to top site: Toolbar shown
3. Tap URL field: Toolbar hides
4. Enter about:home: Toolbar shown
