### PR TITLE
Followup Fix for 1168136 - Compact tabs

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -352,8 +352,8 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
                 return TabTrayControllerUX.NumberOfColumnsWide
             }
         } else {
-            // On iPad we make no difference between portrait and landscape
-            return compactLayout ? TabTrayControllerUX.CompactNumberOfColumnsWide : TabTrayControllerUX.NumberOfColumnsWide
+            // On iPad we do not use compact tabs
+            return TabTrayControllerUX.NumberOfColumnsWide
         }
     }
 

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -448,7 +448,7 @@ private class ClearPrivateDataSetting: Setting {
 // The base settings view controller.
 class SettingsTableViewController: UITableViewController {
     private let Identifier = "CellIdentifier"
-    private var settings: [SettingSection]!
+    private var settings = [SettingSection]()
 
     var profile: Profile!
     var tabManager: TabManager!
@@ -469,7 +469,7 @@ class SettingsTableViewController: UITableViewController {
             accountDebugSettings = []
         }
 
-        settings = [
+        settings += [
             SettingSection(title: nil, children: [
                 // Without a Firefox Account:
                 ConnectSetting(settings: self),
@@ -485,13 +485,24 @@ class SettingsTableViewController: UITableViewController {
             ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
                 ShowIntroductionSetting(settings: self)
-            ]),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("Customize", comment: "Customize section title in settings")), children: [
-                UseCompactTabLayoutSetting(settings: self)
-            ]),
+            ])
+        ]
+
+        // There is nothing to show in the Customize section if we don't include the compact tab layout
+        // setting on iPad. When more options are added that work on both device types, this logic can
+        // be changed.
+        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
+            settings += [
+                SettingSection(title: NSAttributedString(string: NSLocalizedString("Customize", comment: "Customize section title in settings")), children: [
+                    UseCompactTabLayoutSetting(settings: self)
+                ])
+            ]
+        }
+
+        settings += [
             SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [
                 VersionSetting(settings: self)
-            ]),
+            ])
         ]
 
         navigationItem.title = NSLocalizedString("Settings", comment: "Settings")


### PR DESCRIPTION
This patch disabled compact tabs on iPad. It defaults to 3 columns and it does not show the Compact Tabs option in the settings.