### PR TITLE
Bug 1170581 - Removed unnecessary layoutIfNeeded calls

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1101,7 +1101,6 @@ extension BrowserViewController: TabManagerDelegate {
                 showBar(bar, animated: true)
             }
         }
-        showToolbars(animated: false)
 
         toolbar?.updateBackStatus(selected?.canGoBack ?? false)
         toolbar?.updateFowardStatus(selected?.canGoForward ?? false)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -316,10 +316,6 @@ class URLBarView: UIView {
             make.size.equalTo(AppConstants.ToolbarHeight)
         }
 
-        // Force layout pass so we have our frames calculated for the transform math
-        setNeedsLayout()
-        layoutIfNeeded()
-
         newTabsButton.frame = tabsButton.frame
 
         // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be


### PR DESCRIPTION
Added some changes to improve the startup time of the app. Removed the layoutIfNeeded call when updating the tab count as it's not needed. Also removed the showToolbars call that was happening when the user selects a tab as the toolbars will always be shown if we are selecting a new tab and not calling it avoids a layout pass.