### PR TITLE
Bug 1148433 - Maintains state of home view in multiple tabs

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -23,7 +23,7 @@ protocol BrowserDelegate {
 
 class Browser: NSObject {
     var webView: WKWebView? = nil
-
+    var lastHomePanel = 0
     var browserDelegate: BrowserDelegate? = nil
     var bars = [SnackBar]()
     var favicons = [Favicon]()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -342,9 +342,7 @@ class BrowserViewController: UIViewController {
 
             addChildViewController(homePanelController!)
         }
-        
         homePanelController?.selectedButtonIndex = tabManager.selectedTab?.lastHomePanel
-        
         // We have to run this animation, even if the view is already showing because there may be a hide animation running
         // and we want to be sure to override its results.
         UIView.animateWithDuration(0.2, animations: { () -> Void in
@@ -898,7 +896,6 @@ extension BrowserViewController: HomePanelViewControllerDelegate {
     func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL, visitType: VisitType) {
         finishEditingAndSubmit(url, visitType: visitType)
     }
-    
     func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectPanel panel: Int) {
         tabManager.selectedTab?.lastHomePanel = panel
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -342,7 +342,9 @@ class BrowserViewController: UIViewController {
 
             addChildViewController(homePanelController!)
         }
-
+        
+        homePanelController?.selectedButtonIndex = tabManager.selectedTab?.lastHomePanel
+        
         // We have to run this animation, even if the view is already showing because there may be a hide animation running
         // and we want to be sure to override its results.
         UIView.animateWithDuration(0.2, animations: { () -> Void in
@@ -895,6 +897,10 @@ extension BrowserViewController: BrowserDelegate {
 extension BrowserViewController: HomePanelViewControllerDelegate {
     func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL, visitType: VisitType) {
         finishEditingAndSubmit(url, visitType: visitType)
+    }
+    
+    func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectPanel panel: Int) {
+        tabManager.selectedTab?.lastHomePanel = panel
     }
 }
 

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -16,6 +16,8 @@ private struct HomePanelViewControllerUX {
 
 protocol HomePanelViewControllerDelegate: class {
     func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL, visitType: VisitType)
+
+    func homePanelViewController(HomePanelViewController: HomePanelViewController, didSelectPanel panel: Int)
 }
 
 @objc
@@ -140,6 +142,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         for (index, button) in enumerate(buttons) {
             if (button == sender) {
                 selectedButtonIndex = index
+                delegate?.homePanelViewController(self, didSelectPanel: index)
                 break
             }
         }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -16,7 +16,6 @@ private struct HomePanelViewControllerUX {
 
 protocol HomePanelViewControllerDelegate: class {
     func homePanelViewController(homePanelViewController: HomePanelViewController, didSelectURL url: NSURL, visitType: VisitType)
-
     func homePanelViewController(HomePanelViewController: HomePanelViewController, didSelectPanel panel: Int)
 }
 


### PR DESCRIPTION
Originally tried working on URL changes (anchoring stuff), but it would mess up the back and forward states.
Bug 1170726 --> this is the bug where back/fwd history gets messed up when we go to a page with an anchor on it
Ended up storing a number in Browser.swift called previousHomePanel and updated using a custom function on BrowserViewController.swift when user taps on the home page. 

Filed follow-up bug: Bug 1170769 