### PR TITLE
Bug 1171145 - Don't advance past endIndex in removeCompletion.

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -55,7 +55,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     private func removeCompletion() {
         if completionActive {
-            let enteredText = text.substringToIndex(advance(text.startIndex, enteredTextLength))
+            let enteredText = text.substringToIndex(advance(text.startIndex, enteredTextLength, text.endIndex))
 
             // Workaround for stuck highlight bug.
             if enteredTextLength == 0 {


### PR DESCRIPTION
Autocomplete of bookmarks seems to work with this change, and it removes the failure. (BookmarkTests still fail, but this is no longer why!)