### PR TITLE
Fixes 1154402 - Use system font instead of hardcoded Helvetica Neue

### DIFF
--- a/Client/Frontend/Browser/PasswordHelper.swift
+++ b/Client/Frontend/Browser/PasswordHelper.swift
@@ -72,11 +72,11 @@ class PasswordHelper: BrowserHelper {
         }
 
         var attributes = [NSObject: AnyObject]()
-        attributes[NSFontAttributeName] = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 13)
+        attributes[NSFontAttributeName] = UIFont.systemFontOfSize(13, weight: UIFontWeightRegular)
         attributes[NSForegroundColorAttributeName] = UIColor.darkGrayColor()
         var attr = NSMutableAttributedString(string: string, attributes: attributes)
         for (index, range) in enumerate(ranges) {
-            attr.addAttribute(NSFontAttributeName, value: UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Bold" : "HelveticaNeue-Medium", size: 13)!, range: range)
+            attr.addAttribute(NSFontAttributeName, value: UIFont.systemFontOfSize(13, weight: UIFontWeightMedium), range: range)
         }
         return attr
     }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -10,16 +10,16 @@ private let SuggestionBackgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha
 private let SuggestionBorderColor = AppConstants.HighlightBlue
 private let SuggestionBorderWidth: CGFloat = 1
 private let SuggestionCornerRadius: CGFloat = 4
-private let SuggestionFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 13)
+private let SuggestionFont = UIFont.systemFontOfSize(13, weight: UIFontWeightRegular)
 private let SuggestionInsets = UIEdgeInsetsMake(8, 8, 8, 8)
 private let SuggestionMargin: CGFloat = 8
 private let SuggestionCellVerticalPadding: CGFloat = 10
 private let SuggestionCellMaxRows = 2
 
 private let PromptColor = AppConstants.PanelBackgroundColor
-private let PromptFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 12)
-private let PromptYesFont = UIFont(name: "HelveticaNeue-Bold", size: 15)
-private let PromptNoFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 15)
+private let PromptFont = UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)
+private let PromptYesFont = UIFont.systemFontOfSize(15, weight: UIFontWeightBold)
+private let PromptNoFont = UIFont.systemFontOfSize(15, weight: UIFontWeightRegular)
 private let PromptInsets = UIEdgeInsetsMake(15, 12, 15, 12)
 private let PromptButtonColor = UIColor(rgb: 0x007aff)
 

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -17,21 +17,21 @@ private struct ReadingListTableViewCellUX {
     static let ReadIndicatorHeight: CGFloat = 14 + 16 + 14 // padding + image height + padding
     static let ReadAccessibilitySpeechPitch: Float = 0.7 // 1.0 default, 0.0 lowest, 2.0 highest
 
-    static let TitleLabelFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Bold" : "HelveticaNeue-Medium", size: 15)
+    static let TitleLabelFont = UIFont.systemFontOfSize(15, weight: UIFontWeightMedium)
     static let TitleLabelTopOffset: CGFloat = 14 - 4
     static let TitleLabelLeftOffset: CGFloat = 16 + 16 + 16
     static let TitleLabelRightOffset: CGFloat = -40
 
-    static let HostnameLabelFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue" : "HelveticaNeue-Light", size: 14)
+    static let HostnameLabelFont = UIFont.systemFontOfSize(14, weight: UIFontWeightLight)
     static let HostnameLabelBottomOffset: CGFloat = 11
 
     static let DeleteButtonBackgroundColor = UIColor(rgb: 0xef4035)
-    static let DeleteButtonTitleFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue" : "HelveticaNeue-Light", size: 15)
+    static let DeleteButtonTitleFont = UIFont.systemFontOfSize(15, weight: UIFontWeightLight)
     static let DeleteButtonTitleColor = UIColor.whiteColor()
     static let DeleteButtonTitleEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
     static let MarkAsReadButtonBackgroundColor = UIColor(rgb: 0x2193d1)
-    static let MarkAsReadButtonTitleFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue" : "HelveticaNeue-Light", size: 15)
+    static let MarkAsReadButtonTitleFont = UIFont.systemFontOfSize(15, weight: UIFontWeightLight)
     static let MarkAsReadButtonTitleColor = UIColor.whiteColor()
     static let MarkAsReadButtonTitleEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 

--- a/Client/Frontend/Widgets/SiteTableViewController.swift
+++ b/Client/Frontend/Widgets/SiteTableViewController.swift
@@ -45,7 +45,7 @@ private class SiteTableViewHeader : UITableViewHeaderFooterView {
         bottomBorder.backgroundColor = SiteTableViewControllerUX.HeaderBorderColor
         super.layoutSubviews()
 
-        textLabel.font = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Bold" : "HelveticaNeue-Medium", size: 11)
+        textLabel.font = UIFont.systemFontOfSize(11, weight: UIFontWeightMedium)
         textLabel.textColor = UIAccessibilityDarkerSystemColorsEnabled() ? UIColor.blackColor() : SiteTableViewControllerUX.HeaderTextColor
         textLabel.textAlignment = .Center
         contentView.backgroundColor = SiteTableViewControllerUX.HeaderBackgroundColor

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -145,10 +145,10 @@ private class TwoLineCellHelper {
 
         self.container.backgroundColor = UIColor.clearColor()
 
-        textLabel.font = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Bold" : "HelveticaNeue-Medium", size: 14)
+        textLabel.font = UIFont.systemFontOfSize(14, weight: UIFontWeightMedium)
         textLabel.textColor = TextColor
 
-        detailTextLabel.font = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 10)
+        detailTextLabel.font = UIFont.systemFontOfSize(10, weight: UIFontWeightRegular)
         detailTextLabel.textColor = DetailTextColor
 
         imageView.contentMode = .ScaleAspectFill

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -16,10 +16,12 @@ public struct AppConstants {
     static let DefaultRowHeight: CGFloat = 58
     static let DefaultPadding: CGFloat = 10
 
-    static let DefaultMediumFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: 13)
+    static let DefaultMediumFontSize: CGFloat = 13
+    static let DefaultMediumFont = UIFont.systemFontOfSize(DefaultMediumFontSize, weight: UIFontWeightRegular)
+
     static let DefaultSmallFontSize: CGFloat = 11
-    static let DefaultSmallFont = UIFont(name: UIAccessibilityIsBoldTextEnabled() ? "HelveticaNeue-Medium" : "HelveticaNeue", size: DefaultSmallFontSize)
-    static let DefaultSmallFontBold = UIFont(name: "HelveticaNeue-Bold", size: 11)
+    static let DefaultSmallFont = UIFont.systemFontOfSize(DefaultSmallFontSize, weight: UIFontWeightRegular)
+    static let DefaultSmallFontBold = UIFont.systemFontOfSize(DefaultSmallFontSize, weight: UIFontWeightBold)
 
     // These highlight colors are currently only used on Snackbar buttons when they're pressed
     static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)


### PR DESCRIPTION
This patch replaces calls to `UIFont(name:size:)` with `UIFont.systemFontWithSize(,weight:)`. This also replaces the usage of `UIAccessibilityIsBoldTextEnabled()` because systemFontWithName() will automatically return a bolder font when the user has enabled that feature.