### PR TITLE
Bug 1145433 - Tab will always be in view and never cropped

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -491,8 +491,9 @@ extension TabTrayController: Transitionable {
     }
 
     func transitionablePreShow(transitionable: Transitionable, options: TransitionOptions) {
-        self.collectionView.layoutSubviews()
+        self.view.layoutSubviews()
         self.collectionView.scrollToItemAtIndexPath(NSIndexPath(forItem: tabManager.selectedIndex, inSection: 0), atScrollPosition: .CenteredVertically, animated: false)
+
         if let container = options.container {
             let cell = getTransitionCell(options, browser: tabManager.selectedTab)
             cell.backgroundHolder.layer.cornerRadius = TabTrayControllerUX.CornerRadius


### PR DESCRIPTION
Since we were only calling layoutSubviews on the collectionView, the frame of which we used to scroll in did not account for the height of the navigation bar which caused the last tab to be cropped at the bottom when minimizing the tab. Now, all tabs should be centered vertically if there are enough tabs above and below and the last tab will not be cropped at the bottom.