### PR TITLE
Bug 1170678 - Navigation bar falsely enables on rotation

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -19,6 +19,7 @@ protocol BrowserToolbarProtocol {
     func updateForwardStatus(canGoForward: Bool)
     func updateBookmarkStatus(isBookmarked: Bool)
     func updateReloadStatus(isLoading: Bool)
+    func updatePageStatus(#isWebPage: Bool)
 }
 
 @objc

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -68,6 +68,9 @@ class BrowserViewController: UIViewController {
     // TODO: weak references?
     var ignoredNavigation = Set<WKNavigation>()
     var typedNavigation = [WKNavigation: VisitType]()
+    var navigationToolbar: BrowserToolbarProtocol {
+        return toolbar ?? urlBar
+    }
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
@@ -128,6 +131,22 @@ class BrowserViewController: UIViewController {
         view.setNeedsUpdateConstraints()
         if let home = homePanelController {
             home.view.setNeedsUpdateConstraints()
+        }
+
+        if let tab = tabManager.selectedTab {
+            navigationToolbar.updateBackStatus(tab.canGoBack)
+            navigationToolbar.updateForwardStatus(tab.canGoForward)
+            let isPage = (tab.displayURL != nil) ? isWebPage(tab.displayURL!) : false
+            navigationToolbar.updatePageStatus(isWebPage: isPage)
+            navigationToolbar.updateReloadStatus(tab.loading ?? false)
+
+            if let url = tab.displayURL?.absoluteString {
+                profile.bookmarks.isBookmarked(url, success: { bookmarked in
+                    self.navigationToolbar.updateBookmarkStatus(bookmarked)
+                }, failure: { err in
+                    log.error("Error getting bookmark status: \(err).")
+                })
+            }
         }
     }
 
@@ -1228,20 +1247,17 @@ extension BrowserViewController: WKNavigationDelegate {
         if let tab = tabManager.selectedTab {
             if tab.webView == webView {
                 urlBar.currentURL = tab.displayURL
-                toolbar?.updateBackStatus(webView.canGoBack)
-                toolbar?.updateForwardStatus(webView.canGoForward)
+                navigationToolbar.updateBackStatus(webView.canGoBack)
+                navigationToolbar.updateForwardStatus(webView.canGoForward)
 
                 let isPage = (tab.displayURL != nil) ? isWebPage(tab.displayURL!) : false
-                toolbar?.updatePageStatus(isWebPage: isPage)
+                navigationToolbar.updatePageStatus(isWebPage: isPage)
 
-                urlBar.updateBackStatus(webView.canGoBack)
-                urlBar.updateForwardStatus(webView.canGoForward)
                 showToolbars(animated: false)
 
                 if let url = tab.displayURL?.absoluteString {
                     profile.bookmarks.isBookmarked(url, success: { bookmarked in
-                        self.toolbar?.updateBookmarkStatus(bookmarked)
-                        self.urlBar.updateBookmarkStatus(bookmarked)
+                        self.navigationToolbar.updateBookmarkStatus(bookmarked)
                     }, failure: { err in
                         log.error("Error getting bookmark status: \(err).")
                     })
@@ -1254,7 +1270,6 @@ extension BrowserViewController: WKNavigationDelegate {
                         hideReaderModeBar(animated: false)
                     }
                 }
-
                 updateInContentHomePanel(tab.url)
             }
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -501,6 +501,12 @@ extension URLBarView: BrowserToolbarProtocol {
         }
     }
 
+    func updatePageStatus(#isWebPage: Bool) {
+        bookmarkButton.enabled = isWebPage
+        stopReloadButton.enabled = isWebPage
+        shareButton.enabled = isWebPage
+    }
+
     override var accessibilityElements: [AnyObject]! {
         get {
             if isEditing {


### PR DESCRIPTION
1. added state updates for buttons per rotation
2. added highlight for bookmark state implementation in the rotation function via copy paste some code in didCommitNavigation
3. added navigationToolbar for cleaner code use of determining whether we're using urlBar and toolbar