### PR TITLE
Bug 1172958 - Add the error page helper to browsers.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -799,6 +799,9 @@ extension BrowserViewController: BrowserDelegate {
         let hashchangeHelper = HashchangeHelper(browser: browser)
         hashchangeHelper.delegate = self
         browser.addHelper(hashchangeHelper, name: HashchangeHelper.name())
+
+        let errorHelper = ErrorPageHelper()
+        browser.addHelper(errorHelper, name: ErrorPageHelper.name())
     }
 
     func browser(browser: Browser, willDeleteWebView webView: WKWebView) {


### PR DESCRIPTION
This was just dropped in the landing of the old patch. Will carry the r+.