### PR TITLE
Bug 1167334 - Ignore "quick" redirects in snackbar updates

### DIFF
--- a/Utils/Functions.swift
+++ b/Utils/Functions.swift
@@ -175,3 +175,35 @@ public func jsonsToStrings(arr: [JSON]?) -> [String]? {
     }
     return nil
 }
+
+// Encapsulate a callback in a way that we can use it with NSTimer.
+private class Callback {
+    private let handler:()->()
+
+    init(handler:()->()) {
+        self.handler = handler
+    }
+
+    @objc
+    func go() {
+        handler()
+    }
+}
+
+/**
+ * Taken from http://stackoverflow.com/questions/27116684/how-can-i-debounce-a-method-call
+ * Allows creating a block that will fire after a delay. Resets the timer if called again before the delay expires.
+ **/
+public func debounce(delay:NSTimeInterval, action:()->()) -> ()->() {
+    let callback = Callback(handler: action)
+    var timer: NSTimer?
+
+    return {
+        // If calling again, invalidate the last timer.
+        if let timer = timer {
+            timer.invalidate()
+        }
+        timer = NSTimer(timeInterval: delay, target: callback, selector: "go", userInfo: nil, repeats: false)
+        NSRunLoop.currentRunLoop().addTimer(timer!, forMode: NSDefaultRunLoopMode)
+    }
+}


### PR DESCRIPTION
I wanted to just use a debounce function here, but GMail's redirects are SOOO slow that it has be set kinda high (5sec). Trying something else quick before I put this up for review.