### PR TITLE
Bug 1173201 - Tests are failing when looking for about:home tabs

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -407,8 +407,14 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
 
         if let tab = tabManager[indexPath.item] {
             cell.titleText.text = tab.displayTitle
-            cell.accessibilityLabel = tab.displayTitle
+            if !tab.displayTitle.isEmpty {
+                cell.accessibilityLabel = tab.displayTitle
+            } else {
+                cell.accessibilityLabel = AboutUtils.getAboutComponent(tab.url)
+            }
+
             cell.isAccessibilityElement = true
+
             if let favIcon = tab.displayFavicon {
                 cell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
             } else {

--- a/UITests/SearchSettingsUITests.swift
+++ b/UITests/SearchSettingsUITests.swift
@@ -17,7 +17,7 @@ class SearchSettingsUITests: KIFTestCase {
     private func navigateFromSearchSettings() {
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Done")
-        tester().tapViewWithAccessibilityLabel("about:home")
+        tester().tapViewWithAccessibilityLabel("home")
     }
 
     // Given that we're at the Search Settings sheet, select the named search engine as the default.

--- a/UITests/ViewMemoryLeakTests.swift
+++ b/UITests/ViewMemoryLeakTests.swift
@@ -60,12 +60,12 @@ class ViewMemoryLeakTests: KIFTestCase, UITextFieldDelegate {
         tester().tapViewWithAccessibilityLabel("Show Tabs")
         tester().waitForViewWithAccessibilityLabel("Tabs Tray")
         weak var tabTrayController = browserViewController.presentedViewController
-        weak var tabCell = tester().waitForTappableViewWithAccessibilityLabel("about:home")
+        weak var tabCell = tester().waitForTappableViewWithAccessibilityLabel("home")
         XCTAssertNotNil(tabTrayController, "Got tab tray reference")
         XCTAssertNotNil(tabCell, "Got tab cell reference")
 
         // Leave the tab tray.
-        tester().tapViewWithAccessibilityLabel("about:home")
+        tester().tapViewWithAccessibilityLabel("home")
 
         tester().runBlock { _ in
             return (tabTrayController == nil) ? KIFTestStepResult.Success : KIFTestStepResult.Wait

--- a/Utils/AboutUtils.swift
+++ b/Utils/AboutUtils.swift
@@ -5,10 +5,20 @@
 import Foundation
 
 struct AboutUtils {
+    private static let AboutPath = "/about/"
+
     static func isAboutHomeURL(url: NSURL?) -> Bool {
+        return getAboutComponent(url) == "home"
+    }
+
+    /// If the URI is an about: URI, return the path after "about/" in the URI.
+    /// For example, return "home" for "http://localhost:1234/about/home/#panel=0".
+    static func getAboutComponent(url: NSURL?) -> String? {
         if let scheme = url?.scheme, host = url?.host, path = url?.path {
-            return scheme == "http" && host == "localhost" && path == "/about/home"
+            if scheme == "http" && host == "localhost" && path.startsWith(AboutPath) {
+                return path.substringFromIndex(AboutPath.endIndex)
+            }
         }
-        return false
+        return nil
     }
 }


### PR DESCRIPTION
[Bug 1171254](https://bugzilla.mozilla.org/show_bug.cgi?id=1171254) flipped `about:home` URLs to `http://localhost:1234/about/home/#panel=X`-style URLs, so this extracts the component after `about/`. That means `about:home` tabs will have `home` as their accessibility labels.