### PR TITLE
Bug 1172954 - Don't suspend the webserver in the background

### DIFF
--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -18,7 +18,7 @@ class WebServer {
     }
 
     func start() -> Bool {
-        return server.running || server.startWithOptions([GCDWebServerOption_Port: 0, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true], error: nil)
+        return server.running || server.startWithOptions([GCDWebServerOption_Port: 0, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: false], error: nil)
     }
 
     /// Convenience method to register a dynamic handler. Will be mounted at $base/$module/$resource


### PR DESCRIPTION
From the docs:
> - If the app is still in the background when the last HTTP connection is closed, GCDWebServer will suspend itself and stop accepting new connections as if you had called ```-stop``` (this behavior can be disabled with the ```GCDWebServerOption_AutomaticallySuspendInBackground``` option).
> - If the app goes in the background while no HTTP connections are opened, GCDWebServer will immediately suspend itself and stop accepting new connections as if you had called ```-stop``` (this behavior can be disabled with the ```GCDWebServerOption_AutomaticallySuspendInBackground``` option).

So it sounds like we don't want the `GCDWebServerOption_AutomaticallySuspendInBackground` to be enabled.