### PR TITLE
Bug 1141240 - Persist tab history for session restore

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -281,6 +281,10 @@
 		59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */; };
 		6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */; };
 		6BB2FD991B017DAB001A189B /* AuralProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */; };
+		74203E251B276B3D007D481D /* SessionRestoreHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74203E241B276B3D007D481D /* SessionRestoreHandler.swift */; };
+		746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = 746B6A781B277C1800EA83E3 /* SessionRestore.html */; };
+		746D4E571B1E7132008F789F /* HashchangeHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 746D4E561B1E7132008F789F /* HashchangeHelper.js */; };
+		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* TabTrayController.swift */; };
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -1253,6 +1257,12 @@
 		59A68B1F857A8638598A63A0 /* TwoLineCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLineCell.swift; sourceTree = "<group>"; };
 		59A68CCB63E2A565CB03F832 /* SearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuralProgressBar.swift; sourceTree = "<group>"; };
+		74203E241B276B3D007D481D /* SessionRestoreHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHandler.swift; sourceTree = "<group>"; };
+		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
+		746D4E361B1E699C008F789F /* HashchangeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HashchangeHelper.swift; sourceTree = "<group>"; };
+		746D4E561B1E7132008F789F /* HashchangeHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = HashchangeHelper.js; sourceTree = "<group>"; };
+		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
+		74C295261B21152000862FE3 /* AboutHomeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutHomeHandler.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
@@ -2151,7 +2161,6 @@
 			isa = PBXGroup;
 			children = (
 				0B3E7D931B27A7CE00E2E84D /* AboutHomeHandler.swift */,
-				0B3E7D941B27A7CE00E2E84D /* HashchangeHelper.swift */,
 				0AE491A51A41C88C0046C724 /* BackForwardListViewController.swift */,
 				D3A994961A3686BD008AD1AC /* Browser.swift */,
 				E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */,
@@ -2160,6 +2169,7 @@
 				D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */,
 				0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */,
 				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
+				0B3E7D941B27A7CE00E2E84D /* HashchangeHelper.swift */,
 				0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
 				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
@@ -2168,12 +2178,16 @@
 				D34510871ACF415700EC27F0 /* SearchLoader.swift */,
 				D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */,
 				59A68CCB63E2A565CB03F832 /* SearchViewController.swift */,
+				74203E241B276B3D007D481D /* SessionRestoreHandler.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				746D4E361B1E699C008F789F /* HashchangeHelper.swift */,
+				74C295261B21152000862FE3 /* AboutHomeHandler.swift */,
+				74C027441B2A348C001B1E88 /* SessionData.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -2454,6 +2468,8 @@
 				F84B22391A0914A300AAB793 /* Fonts */,
 				0BA1E00D1B03FB0B007675AF /* NetError.html */,
 				0BA1E02F1B051A07007675AF /* NetError.css */,
+				746D4E561B1E7132008F789F /* HashchangeHelper.js */,
+				746B6A781B277C1800EA83E3 /* SessionRestore.html */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -3382,6 +3398,8 @@
 				E4A961361AC052DE0069AD6F /* ReadabilityBrowserHelper.js in Resources */,
 				D32075391B017DA400CA1CD2 /* SearchPlugins in Resources */,
 				E4B7B7861A793CF20022C5E0 /* FiraSans-UltraLight.ttf in Resources */,
+				746D4E571B1E7132008F789F /* HashchangeHelper.js in Resources */,
+				746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */,
 				2F44FB2C1A9D5D8500FD20CC /* Home.xcassets in Resources */,
 				E4ECCD8D1AB091470005E717 /* Reader.xcassets in Resources */,
 				E4B7B77D1A793CF20022C5E0 /* FiraSans-Regular.ttf in Resources */,
@@ -3768,6 +3786,7 @@
 				D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */,
 				E4CD9E911A6897FB00318571 /* ReaderMode.swift in Sources */,
 				D38B2D371A8D96D00040E6B5 /* GCDWebServerRequest.m in Sources */,
+				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */,
 				0BB5B2891AC0A2B90052877D /* Toolbar.swift in Sources */,
 				D38B2D461A8D96D00040E6B5 /* GCDWebServerURLEncodedFormRequest.m in Sources */,
@@ -3783,6 +3802,7 @@
 				0B1C05D71A798B1F004C78B0 /* UIImageViewAligned.m in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				0BD19A651A2530840084FBA7 /* Locking.swift in Sources */,
+				74203E251B276B3D007D481D /* SessionRestoreHandler.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				282DA4731A68C1E700A406E2 /* OpenSearch.swift in Sources */,
 				0BEFED8C1AC21C1E002E0A0C /* SDWebThumbnails.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -96,6 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ReaderModeHandlers.register(server, profile: profile)
         ErrorPageHelper.register(server)
         AboutHomeHandler.register(server)
+        SessionRestoreHandler.register(server)
         server.start()
     }
 

--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -1,0 +1,44 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+  /**
+   * This file is responsible for restoring session history.
+   * It uses the DOM history API to push pages onto the back/forward stack. Since that API
+   * is bound by same origin restrictions, we're only able to push pages with the current origin
+   * (which is a page hosted on localhost). As a workaround, push all to-be-restored URLs as
+   * error pages so that they will redirect to the correct URLs when loaded.
+   */
+  (function () {
+      var index = document.location.href.search("history");
+
+      // Pull the session out of the history query argument. 
+      // The session is a JSON-stringified array of all URLs to restore for this tab, plus the last active index.
+      var sessionRestoreComponents = JSON.parse(unescape(document.location.href.substring(index + "history=".length)));
+      var urlList = sessionRestoreComponents['history'];
+      var currentPage = sessionRestoreComponents['currentPage'];
+
+      // First, replace the session restore page (this page) with the first URL to be restored.
+      history.replaceState({}, '', '/errors/error.html?url=' + escape(urlList[0]));
+
+      // Then push the remaining pages to be restored.
+      for (var i = 1; i < urlList.length; i++) {
+          history.pushState({}, '', '/errors/error.html?url=' + escape(urlList[i]));
+      }
+
+      // We'll end up at the last page pushed, so set the selected index to the current index in the session history.
+      history.go(currentPage);
+   
+      // Finally, reload the page to trigger the error redirection, which will load the actual URL. 
+      // For some reason (maybe a WebKit bug?), document.location still points to SessionRestore.html at this point, 
+      // so wait until the next tick when the location points to the correct index and URL.
+      setTimeout(function () {
+          document.location.reload();
+      }, 0);
+  }) ();
+</script>
+</body>
+</html>

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -136,19 +136,10 @@ class BrowserViewController: UIViewController {
         }
 
         if let tab = tabManager.selectedTab {
-            navigationToolbar.updateBackStatus(tab.canGoBack)
-            navigationToolbar.updateForwardStatus(tab.canGoForward)
+            updateNavigationToolbarStates(tab, webView: tab.webView!)
             let isPage = (tab.displayURL != nil) ? isWebPage(tab.displayURL!) : false
             navigationToolbar.updatePageStatus(isWebPage: isPage)
             navigationToolbar.updateReloadStatus(tab.loading ?? false)
-
-            if let url = tab.displayURL?.absoluteString {
-                profile.bookmarks.isBookmarked(url, success: { bookmarked in
-                    self.navigationToolbar.updateBookmarkStatus(bookmarked)
-                }, failure: { err in
-                    log.error("Error getting bookmark status: \(err).")
-                })
-            }
         }
     }
 

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+class SessionData: NSObject, NSCoding {
+    let currentPage: Int
+    let urls: [NSURL]
+
+    init(currentPage: Int, urls: [NSURL]) {
+        self.currentPage = currentPage
+        self.urls = urls
+    }
+
+    required init(coder: NSCoder) {
+        self.currentPage = coder.decodeObjectForKey("currentPage") as? Int ?? 0
+        self.urls = coder.decodeObjectForKey("urls") as? [NSURL] ?? []
+    }
+
+    func encodeWithCoder(coder: NSCoder) {
+        coder.encodeObject(currentPage, forKey: "currentPage")
+        coder.encodeObject(urls, forKey: "urls")
+    }
+}

--- a/Client/Frontend/Browser/SessionRestoreHandler.swift
+++ b/Client/Frontend/Browser/SessionRestoreHandler.swift
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+/**
+ * Handles the page request to about/sessionrestore to restore a crashed session. The page then handles the restoration of the
+ * state of the tabs via javascript embedded in the html file and via redirecting the links using the error page custom redirect.
+ */
+struct SessionRestoreHandler {
+    static func register(webServer: WebServer) {
+        // Register the handler that accepts /about/sessionrestore?history=...&currentpage=... requests.
+        webServer.registerHandlerForMethod("GET", module: "about", resource: "sessionrestore") { (request: GCDWebServerRequest!) -> GCDWebServerResponse! in
+            println(request)
+            if let sessionRestorePath = NSBundle.mainBundle().pathForResource("SessionRestore", ofType: "html") {
+                if let sessionRestoreString = NSMutableString(contentsOfFile: sessionRestorePath, encoding: NSUTF8StringEncoding, error: nil) {
+                    return GCDWebServerDataResponse(HTML: sessionRestoreString as String)
+                }
+            }
+            return GCDWebServerResponse(statusCode: 404)
+        }
+    }
+}


### PR DESCRIPTION
1. edited Browser and TabManager class to hold a list of accessed URLs and current page in each tab (index of the list of URLs) so that whenever the app crashes, the TabManager's SavedTab can access these properties on the Browser so that it can do the session restore
2. Created a SessionRestoreHandler to handle the about/sessionrestore webpage and SessionRestore.html to trigger the JS that will update the tab histories and URLs (URL restoration is handled by tacking the error page URL header to treat them as error pages, redirecting them to the actual URLs or error pages
3. The Browser class is the one that instantiates the about/sessionrestore URL so that we can update the URLs in the URL list with new port numbers, etc. before triggering the restore web page