### PR TITLE
Experimenting with using loadAlternateHTML for our error pages

### DIFF
--- a/Client-Bridging-Header.h
+++ b/Client-Bridging-Header.h
@@ -13,4 +13,6 @@
 #import "Carthage/Checkouts/SDWebImage/SDWebImage/UIView+WebCacheOperation.h"
 #import "Carthage/Checkouts/SWTableViewCell/SWTableViewCell/PodFiles/SWTableViewCell.h"
 
+#import "WKWebView+PrivateAPI.h"
+
 #endif

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 		E4F21AA61A13C4A300B0FAAA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4F21AA51A13C4A300B0FAAA /* Images.xcassets */; };
 		E4F480F51A954660003C0444 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2D811A8D98380040E6B5 /* SWXMLHash.framework */; };
 		E4F481041A95466A003C0444 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38B2D811A8D98380040E6B5 /* SWXMLHash.framework */; };
+		E62D42021B2B6A7C0094F3CA /* WKWebView+PrivateAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = E62D42011B2B6A7C0094F3CA /* WKWebView+PrivateAPI.m */; };
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
@@ -1431,6 +1432,8 @@
 		E4ECCD8C1AB091470005E717 /* Reader.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Reader.xcassets; sourceTree = "<group>"; };
 		E4ECCDAD1AB131770005E717 /* FiraSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Medium.ttf"; sourceTree = "<group>"; };
 		E4F21AA51A13C4A300B0FAAA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		E62D42001B2B6A7C0094F3CA /* WKWebView+PrivateAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WKWebView+PrivateAPI.h"; sourceTree = "<group>"; };
+		E62D42011B2B6A7C0094F3CA /* WKWebView+PrivateAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WKWebView+PrivateAPI.m"; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E6A99D761B20D95800006EDD /* GeometryExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryExtensions.swift; sourceTree = "<group>"; };
 		E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = scrollablePage.html; sourceTree = "<group>"; };
@@ -2170,6 +2173,8 @@
 				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				E62D42001B2B6A7C0094F3CA /* WKWebView+PrivateAPI.h */,
+				E62D42011B2B6A7C0094F3CA /* WKWebView+PrivateAPI.m */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -3790,6 +3795,7 @@
 				6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */,
 				D38B2D341A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
+				E62D42021B2B6A7C0094F3CA /* WKWebView+PrivateAPI.m in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */,

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -5,6 +5,7 @@
 import Foundation
 import WebKit
 import Shared
+import Alamofire
 
 class ErrorPageHelper {
     static let MozDomain = "mozilla"
@@ -173,8 +174,13 @@ class ErrorPageHelper {
         ErrorPageHelper.redirecting.append(url)
 
         let errorUrl = "\(WebServer.sharedInstance.base)/errors/error.html?url=\(url.absoluteString?.escape() ?? String())&code=\(error.code)&domain=\(error.domain)&description=\(error.localizedDescription.escape())"
-        let request = NSURLRequest(URL: errorUrl.asURL!)
-        webView.loadRequest(request)
+//        let request = NSURLRequest(URL: errorUrl.asURL!)
+//        webView.loadRequest(request)
+
+        Alamofire.request(.GET, errorUrl, parameters: nil, encoding: ParameterEncoding.URL)
+            .responseString(encoding: NSUTF8StringEncoding) { (request, response, data, error) in
+                        webView.loadAlternateHTMLString(data, baseURL: nil, forUnreachableURL: url)
+                   }
     }
 
     class func isErrorPageURL(url: NSURL) -> Bool {

--- a/Client/Frontend/Browser/WKWebView+PrivateAPI.h
+++ b/Client/Frontend/Browser/WKWebView+PrivateAPI.h
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <WebKit/WebKit.h>
+
+@interface WKWebView (PrivateAPI)
+
+- (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL;
+
+@end

--- a/Client/Frontend/Browser/WKWebView+PrivateAPI.m
+++ b/Client/Frontend/Browser/WKWebView+PrivateAPI.m
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import "WKWebView+PrivateAPI.h"
+
+@interface WKWebView (Internal)
+
+- (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL;
+
+@end
+
+@implementation WKWebView (PrivateAPI)
+
+- (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
+{
+    [self _loadAlternateHTMLString:string baseURL:baseURL forUnreachableURL:unreachableURL];
+}
+
+@end


### PR DESCRIPTION
Replaced the loadRequest method we're using in the ErrorPageHelper with the private _loadAlternateHTML method to see how it behaves. DO NOT MERGE THIS!