### PR TITLE
Bug 1146596 - Reading View Content Security Policy

### DIFF
--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -10,11 +10,10 @@
   <style type="text/css">
     %READER-CSS%
   </style>
-  <script type="text/javascript">var _firefox_ReaderPage = { style: %READER-STYLE% };</script>
   <title>%READER-TITLE%</title>
 </head>
 
-<body>
+<body data-readerStyle='%READER-STYLE%'>
   <div id="reader-header" class="header">
     <h1 id="reader-title">%READER-TITLE%</h1>
     <div id="reader-credits" class="credits">%READER-CREDITS%</div>

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -44,10 +44,4 @@
 
 </body>
 
-<script type="text/javascript">
-window.addEventListener('pageshow', function(event) {
-    webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderPageEvent", Value: "PageShow"});
-});
-</script>
-
 </html>

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -7,9 +7,7 @@
 <head>
   <meta content="text/html; charset=UTF-8" http-equiv="content-type">
   <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=.25, maximum-scale=1.6, initial-scale=1.0">
-  <style type="text/css">
-    %READER-CSS%
-  </style>
+  <link rel="stylesheet" type="text/css" href="/reader-mode/styles/Reader.css">
   <title>%READER-TITLE%</title>
 </head>
 

--- a/Client/Frontend/Reader/Reader.html
+++ b/Client/Frontend/Reader/Reader.html
@@ -10,7 +10,7 @@
   <style type="text/css">
     %READER-CSS%
   </style>
-  <script type="text/javascript">var _firefox_ReaderPage = { style: %READER-STYLE%, webServerBase: "%WEBSERVER-BASE%" };</script>
+  <script type="text/javascript">var _firefox_ReaderPage = { style: %READER-STYLE% };</script>
   <title>%READER-TITLE%</title>
 </head>
 

--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -158,3 +158,11 @@ window.addEventListener('load', function(event) {
         _firefox_ReaderMode.configureReader();
     }
 });
+
+
+window.addEventListener('pageshow', function(event) {
+    // If this is an about:reader page that we are showing, fire an event to the native code
+    if (document.location.href.match(/^http:\/\/localhost:\d+\/reader-mode\/page/)) {
+        webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderPageEvent", Value: "PageShow"});
+    }
+});

--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -141,7 +141,8 @@ var _firefox_ReaderMode = {
     
     configureReader: function() {
         // Configure the reader with the initial style that was injected in the page.
-        _firefox_ReaderMode.setStyle(_firefox_ReaderPage.style);
+        var style = JSON.parse(document.body.getAttribute("data-readerStyle"));
+        _firefox_ReaderMode.setStyle(style);
 
         // The order here is important. Because updateImageMargins depends on contentElement.offsetWidth which
         // will not be set until contentElement is visible. If this leads to annoying content reflowing then we

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -40,7 +40,10 @@ struct ReaderModeHandlers {
                             }
                         }
                         if let html = ReaderModeUtils.generateReaderContent(readabilityResult, initialStyle: readerModeStyle) {
-                            return GCDWebServerDataResponse(HTML: html)
+                            let response = GCDWebServerDataResponse(HTML: html)
+                            // Apply a Content Security Policy that disallows everything except images from anywhere and fonts and css from our internal server
+                            response.setValue("default-src 'none'; img-src *; style-src http://localhost:*; font-src http://localhost:*", forAdditionalHeader: "Content-Security-Policy")
+                            return response
                         }
                     } else {
                         // This page has not been converted to reader mode yet. This happens when you for example add an

--- a/Client/Frontend/Reader/ReaderModeHandlers.swift
+++ b/Client/Frontend/Reader/ReaderModeHandlers.swift
@@ -6,8 +6,9 @@ import Foundation
 
 struct ReaderModeHandlers {
     static func register(webServer: WebServer, profile: Profile) {
-        // Register our fonts, which we want to expose to web content that we present in the WebView
+        // Register our fonts and css, which we want to expose to web content that we present in the WebView
         webServer.registerMainBundleResourcesOfType("ttf", module: "reader-mode/fonts")
+        webServer.registerMainBundleResource("Reader.css", module: "reader-mode/styles")
 
         // Register a handler that simply lets us know if a document is in the cache or not. This is called from the
         // reader view interstitial page to find out when it can stop showing the 'Loading...' page and instead load

--- a/Client/Frontend/Reader/ReaderModeUtils.swift
+++ b/Client/Frontend/Reader/ReaderModeUtils.swift
@@ -43,9 +43,6 @@ struct ReaderModeUtils {
                         tmpl.replaceOccurrencesOfString("%READER-CONTENT%", withString: readabilityResult.content,
                             options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
 
-                        tmpl.replaceOccurrencesOfString("%WEBSERVER-BASE%", withString: WebServer.sharedInstance.base,
-                            options: NSStringCompareOptions.allZeros, range: NSMakeRange(0, tmpl.length))
-
                         return tmpl as String
                     }
                 }


### PR DESCRIPTION
This patch sets a *Content Security Policy* on pages served for Reading View. I've broken the patch down in small changes.

The policy that we set is as follows:

> `default-src 'none'; img-src *; style-src http://localhost:*; font-src http://localhost:*`

This allows nothing by default. (No script, no inline, no objects, no iframes). And then makes an exception for styles and fonts to be loaded from localhost.