### PR TITLE
Bug 1170682 - Tests for domain autocompletion

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D30B0F301AA7D66300C01CA3 /* ThumbnailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */; };
 		D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30B101D1AA7F9C600C01CA3 /* HomePanels.swift */; };
+		D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */; };
 		D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314E7F51A37B98700426A76 /* BrowserToolbar.swift */; };
 		D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
 		D31A0FC81A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
@@ -993,13 +994,6 @@
 			remoteGlobalIDString = DCAE4D151ABE0B3300EFCE7A;
 			remoteInfo = sqlite3;
 		};
-		E6BA70371B2734EE00CE2662 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9CC9673B1AD4B1B600576D13;
-			remoteInfo = KIFFramework;
-		};
 		F84B21D41A090F8100AAB793 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -1258,6 +1252,7 @@
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
 		D30B101D1AA7F9C600C01CA3 /* HomePanels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePanels.swift; sourceTree = "<group>"; };
+		D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTests.swift; sourceTree = "<group>"; };
 		D314E7F51A37B98700426A76 /* BrowserToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
 		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotHelper.swift; sourceTree = "<group>"; };
@@ -2098,7 +2093,6 @@
 				D38B2D701A8D976A0040E6B5 /* Test Host.app */,
 				D38B2D721A8D976A0040E6B5 /* KIF Tests - XCTest.xctest */,
 				D38B2D741A8D976A0040E6B5 /* KIF Tests-OCUnit.octest */,
-				E6BA70381B2734EE00CE2662 /* KIF.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2117,20 +2111,21 @@
 		D39FA1601A83E0EC00EE869C /* UITests */ = {
 			isa = PBXGroup;
 			children = (
-				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
-				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
-				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
-				0B5A93411B1EB572004F47A2 /* readablePage.html */,
 				D39FA16F1A83E62600EE869C /* UITests-Bridging-Header.h */,
+				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
+				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
+				0B5A93411B1EB572004F47A2 /* readablePage.html */,
+				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
 				D3E171C11A841EAD00AB44CD /* KIFHelper.js */,
 				0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */,
+				D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */,
 				D39FA1801A83E84900EE869C /* Global.swift */,
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
 				D39FA1821A83E87900EE869C /* NavigationTests.swift */,
+				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 				2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
-				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -2396,10 +2391,11 @@
 			isa = PBXGroup;
 			children = (
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
-				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
+				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
+				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 				2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */,
 				D3FA777A1A43B2990010CD32 /* SearchTests.swift */,
 				2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */,
@@ -2411,7 +2407,6 @@
 				D3D247311ABCEA1700771C7E /* ThumbnailTests.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
-				03CCC9171AF05E7300DBF30D /* RelativeDatesTests.swift */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -3277,13 +3272,6 @@
 			remoteRef = E4D567BB1ADED44A00F1EFE7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		E6BA70381B2734EE00CE2662 /* KIF.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KIF.framework;
-			remoteRef = E6BA70371B2734EE00CE2662 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -3662,6 +3650,7 @@
 				D38B2D3F1A8D96D00040E6B5 /* GCDWebServerDataRequest.m in Sources */,
 				E42475DE1AB73B9B00B23D33 /* SWCellScrollView.m in Sources */,
 				D38B2D541A8D96D00040E6B5 /* GCDWebServerStreamedResponse.m in Sources */,
+				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,
 				D38B2D511A8D96D00040E6B5 /* GCDWebServerFileResponse.m in Sources */,
 				D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */,
 				E42475EA1AB73B9B00B23D33 /* SWUtilityButtonView.m in Sources */,

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+
+class DomainAutocompleteTests: KIFTestCase {
+    func testAutocomplete() {
+        BrowserUtils.addHistoryEntry("Mozilla", url: NSURL(string: "http://mozilla.org/")!)
+        BrowserUtils.addHistoryEntry("Yahoo", url: NSURL(string: "http://www.yahoo.com/")!)
+        BrowserUtils.addHistoryEntry("Foo bar baz", url: NSURL(string: "https://foo.bar.baz.org/dingbat")!)
+
+        tester().tapViewWithAccessibilityLabel("Search or enter address")
+        let textField = tester().waitForViewWithAccessibilityLabel("Address and Search") as! UITextField
+
+        // Basic autocompletion cases.
+        tester().enterTextIntoCurrentFirstResponder("w")
+        ensureAutocompletionResult(textField, prefix: "w", completion: "ww.yahoo.com/")
+        tester().enterTextIntoCurrentFirstResponder("ww.yahoo.com/")
+        ensureAutocompletionResult(textField, prefix: "www.yahoo.com/", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        // Ensure that the scheme is included in the autocompletion.
+        tester().enterTextIntoCurrentFirstResponder("https")
+        ensureAutocompletionResult(textField, prefix: "https", completion: "://foo.bar.baz.org/")
+        tester().clearTextFromFirstResponder()
+
+        // Multiple subdomains.
+        tester().enterTextIntoCurrentFirstResponder("f")
+        ensureAutocompletionResult(textField, prefix: "f", completion: "oo.bar.baz.org/")
+        tester().clearTextFromFirstResponder()
+        tester().enterTextIntoCurrentFirstResponder("b")
+        ensureAutocompletionResult(textField, prefix: "b", completion: "ar.baz.org/")
+        tester().enterTextIntoCurrentFirstResponder("a")
+        ensureAutocompletionResult(textField, prefix: "ba", completion: "r.baz.org/")
+        tester().enterTextIntoCurrentFirstResponder("z")
+        ensureAutocompletionResult(textField, prefix: "baz", completion: ".org/")
+
+        // Non-matches.
+        tester().enterTextIntoCurrentFirstResponder("!")
+        ensureAutocompletionResult(textField, prefix: "baz!", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        // Ensure we don't match against TLDs.
+        tester().enterTextIntoCurrentFirstResponder("o")
+        ensureAutocompletionResult(textField, prefix: "o", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        // Ensure we don't match other characters.
+        tester().enterTextIntoCurrentFirstResponder(".")
+        ensureAutocompletionResult(textField, prefix: ".", completion: "")
+        tester().clearTextFromFirstResponder()
+        tester().enterTextIntoCurrentFirstResponder(":")
+        ensureAutocompletionResult(textField, prefix: ":", completion: "")
+        tester().clearTextFromFirstResponder()
+        tester().enterTextIntoCurrentFirstResponder("/")
+        ensureAutocompletionResult(textField, prefix: "/", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        // Ensure we don't match letters that don't start a word.
+        tester().enterTextIntoCurrentFirstResponder("a")
+        ensureAutocompletionResult(textField, prefix: "a", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        // Ensure we don't match words outside of the domain.
+        tester().enterTextIntoCurrentFirstResponder("ding")
+        ensureAutocompletionResult(textField, prefix: "ding", completion: "")
+        tester().clearTextFromFirstResponder()
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    private func ensureAutocompletionResult(textField: UITextField, prefix: String, completion: String) {
+        var range = NSRange()
+        var attribute: AnyObject?
+        let textLength = count(textField.text)
+
+        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, atIndex: 0, effectiveRange: &range)
+
+        if attribute != nil {
+            // If the background attribute exists for the first character, the entire string is highlighted.
+            XCTAssertEqual(prefix, "")
+            XCTAssertEqual(completion, textField.text)
+            return
+        }
+
+        let prefixLength = range.length
+
+        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, atIndex: textLength - 1, effectiveRange: &range)
+
+        if attribute == nil {
+            // If the background attribute exists for the last character, the entire string is not highlighted.
+            XCTAssertEqual(prefix, textField.text)
+            XCTAssertEqual(completion, "")
+            return
+        }
+
+        let completionStartIndex = advance(textField.text.startIndex, prefixLength)
+        let actualPrefix = textField.text.substringToIndex(completionStartIndex)
+        let actualCompletion = textField.text.substringFromIndex(completionStartIndex)
+
+        XCTAssertEqual(prefix, actualPrefix, "Expected prefix matches actual prefix")
+        XCTAssertEqual(completion, actualCompletion, "Expected completion matches actual completion")
+    }
+}

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Storage
 import WebKit
 
 extension XCTestCase {
@@ -84,6 +85,16 @@ class BrowserUtils {
         let cell = tabsView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 0))!
         tester.swipeViewWithAccessibilityLabel(cell.accessibilityLabel, inDirection: KIFSwipeDirection.Left)
         tester.waitForTappableViewWithAccessibilityLabel("Show Tabs")
+    }
+
+    /// Injects a URL and title into the browser's history database.
+    class func addHistoryEntry(title: String, url: NSURL) {
+        let notificationCenter = NSNotificationCenter.defaultCenter()
+        var info = [NSObject: AnyObject]()
+        info["url"] = url
+        info["title"] = title
+        info["visitType"] = VisitType.Link.rawValue
+        notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
     }
 }
 


### PR DESCRIPTION
Adds various tests for domain autocompletion. I wanted to test deletion behavior (e.g., how deleting the first time clears the highlighted text, or how deleting never results in an autocompletion), but I wasn't able to figure out any way to simulate the delete key. 