### PR TITLE
Bug 1170672 - Tests for search suggestions prompt

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		D32075391B017DA400CA1CD2 /* SearchPlugins in Resources */ = {isa = PBXBuildFile; fileRef = D32075381B017DA400CA1CD2 /* SearchPlugins */; };
 		D32CACED1AE04DA1000658EB /* TestSwiftData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */; };
 		D339C2831AD354B400C087BD /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339C2821AD354B400C087BD /* Loader.swift */; };
+		D33B5B7C1AF1AFC100F4DDE6 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */; };
 		D33D6BC81ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
 		D33D6BC91ABCE8F60089DAB2 /* Thumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */; };
 		D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34510871ACF415700EC27F0 /* SearchLoader.swift */; };
@@ -993,13 +994,6 @@
 			remoteGlobalIDString = DCAE4D151ABE0B3300EFCE7A;
 			remoteInfo = sqlite3;
 		};
-		E6BA70371B2734EE00CE2662 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9CC9673B1AD4B1B600576D13;
-			remoteInfo = KIFFramework;
-		};
 		F84B21D41A090F8100AAB793 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -1265,6 +1259,7 @@
 		D32075381B017DA400CA1CD2 /* SearchPlugins */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SearchPlugins; sourceTree = "<group>"; };
 		D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSwiftData.swift; sourceTree = "<group>"; };
 		D339C2821AD354B400C087BD /* Loader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
+		D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D33D6BC71ABCE8F60089DAB2 /* Thumbnails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Thumbnails.swift; path = Storage/Thumbnails.swift; sourceTree = "<group>"; };
 		D34510871ACF415700EC27F0 /* SearchLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchLoader.swift; sourceTree = "<group>"; };
 		D34DC84D1A16C40C00D49B7B /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -2098,7 +2093,6 @@
 				D38B2D701A8D976A0040E6B5 /* Test Host.app */,
 				D38B2D721A8D976A0040E6B5 /* KIF Tests - XCTest.xctest */,
 				D38B2D741A8D976A0040E6B5 /* KIF Tests-OCUnit.octest */,
-				E6BA70381B2734EE00CE2662 /* KIF.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2127,10 +2121,11 @@
 				D39FA1801A83E84900EE869C /* Global.swift */,
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
 				D39FA1821A83E87900EE869C /* NavigationTests.swift */,
+				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 				2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */,
+				D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
-				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -3277,13 +3272,6 @@
 			remoteRef = E4D567BB1ADED44A00F1EFE7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		E6BA70381B2734EE00CE2662 /* KIF.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KIF.framework;
-			remoteRef = E6BA70371B2734EE00CE2662 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -3654,6 +3642,7 @@
 				0B5A93221B1EB4C8004F47A2 /* ReadingListTest.swift in Sources */,
 				0BB5B3601AC0D6360052877D /* BookmarkingTests.swift in Sources */,
 				D39FA1811A83E84900EE869C /* Global.swift in Sources */,
+				D33B5B7C1AF1AFC100F4DDE6 /* SearchTests.swift in Sources */,
 				4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */,
 				E42475E71AB73B9B00B23D33 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
 				D375A9201AE71675001B30D5 /* ViewMemoryLeakTests.swift in Sources */,

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -37,6 +37,12 @@ class SearchEngines {
         self.shouldShowSearchSuggestions = prefs.boolForKey(ShowSearchSuggestions) ?? false
         self.disabledEngineNames = getDisabledEngineNames()
         self.orderedEngines = getOrderedEngines()
+
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELdidResetPrompt:", name: "SearchEnginesPromptReset", object: nil)
+    }
+
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
     }
 
     var defaultEngine: OpenSearchEngine {
@@ -52,6 +58,12 @@ class SearchEngines {
             orderedEngines.insert(defaultEngine, atIndex: 0)
             self.orderedEngines = orderedEngines
         }
+    }
+
+    @objc
+    func SELdidResetPrompt(notification: NSNotification) {
+        self.shouldShowSearchSuggestionsOptIn = true
+        self.shouldShowSearchSuggestions = false
     }
 
     func isEngineDefault(engine: OpenSearchEngine) -> Bool {

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -619,6 +619,8 @@ private class SuggestionButton: InsetButton {
         layer.borderWidth = SuggestionBorderWidth
         layer.cornerRadius = SuggestionCornerRadius
         contentEdgeInsets = SuggestionInsets
+
+        accessibilityHint = NSLocalizedString("Searches for the suggestion", comment: "Accessibility hint describing the action performed when a search suggestion is clicked")
     }
 
     required init(coder aDecoder: NSCoder) {

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -5,6 +5,8 @@
 import Foundation
 import WebKit
 
+let LabelAddressAndSearch = "Address and Search"
+
 extension XCTestCase {
     func tester(_ file: String = __FILE__, _ line: Int = __LINE__) -> KIFUITestActor {
         return KIFUITestActor(inFile: file, atLine: line, delegate: self)
@@ -16,6 +18,15 @@ extension XCTestCase {
 }
 
 extension KIFUITestActor {
+    /// Looks for a view with the given accessibility hint.
+    func tryFindingViewWithAccessibilityHint(hint: String) -> Bool {
+        let element = UIApplication.sharedApplication().accessibilityElementMatchingBlock { element in
+            return element.accessibilityHint == hint
+        }
+
+        return element != nil
+    }
+
     /**
      * Finding views by accessibility label doesn't currently work with WKWebView:
      *     https://github.com/kif-framework/KIF/issues/460

--- a/UITests/SearchTests.swift
+++ b/UITests/SearchTests.swift
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+private let LabelPrompt = "Turn on search suggestions?"
+private let HintSuggestionButton = "Searches for the suggestion"
+
+class SearchTests: KIFTestCase {
+    func testOptInPrompt() {
+        var found: Bool
+
+        // Ensure that the prompt appears.
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterText("foobar", intoViewWithAccessibilityLabel: LabelAddressAndSearch)
+        found = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
+        XCTAssertTrue(found, "Prompt is shown")
+
+        // Ensure that no suggestions are visible before answering the prompt.
+        found = tester().tryFindingViewWithAccessibilityHint(HintSuggestionButton)
+        XCTAssertFalse(found, "No suggestion shown before prompt selection")
+
+        // Ensure that suggestions are visible after selecting Yes.
+        tester().tapViewWithAccessibilityLabel("Yes")
+        found = tester().tryFindingViewWithAccessibilityHint(HintSuggestionButton)
+        XCTAssertTrue(found, "Found suggestions after choosing Yes")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+
+        // Return to the search screen, and make sure our choice was remembered.
+        found = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
+        XCTAssertFalse(found, "Prompt is not shown")
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterText("foobar", intoViewWithAccessibilityLabel: LabelAddressAndSearch)
+        found = tester().tryFindingViewWithAccessibilityHint(HintSuggestionButton)
+        XCTAssertTrue(found, "Search suggestions are still enabled")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        resetSuggestionsPrompt()
+
+        // Ensure that the prompt appears.
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterText("foobar", intoViewWithAccessibilityLabel: LabelAddressAndSearch)
+        found = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
+        XCTAssertTrue(found, "Prompt is shown")
+
+        // Ensure that no suggestions are visible before answering the prompt.
+        found = tester().tryFindingViewWithAccessibilityHint(HintSuggestionButton)
+        XCTAssertFalse(found, "No suggestion buttons are shown")
+
+        // Ensure that no suggestions are visible after selecting No.
+        tester().tapViewWithAccessibilityLabel("No")
+        found = tester().tryFindingViewWithAccessibilityHint(HintSuggestionButton)
+        XCTAssertFalse(found, "No suggestions after choosing No")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        resetSuggestionsPrompt()
+    }
+
+    private func resetSuggestionsPrompt() {
+        NSNotificationCenter.defaultCenter().postNotificationName("SearchEnginesPromptReset", object: nil)
+    }
+}

--- a/UITests/UITests-Bridging-Header.h
+++ b/UITests/UITests-Bridging-Header.h
@@ -7,6 +7,7 @@
 
 #import <KIF/KIF.h>
 #import <KIF/KIFUITestActor-IdentifierTests.h>
+#import <KIF/UIApplication-KIFAdditions.h>
 #import "GCDWebServer.h"
 #import "GCDWebServerDataResponse.h"
 


### PR DESCRIPTION
Attaches an accessibility hint to search suggestion buttons to allow KIF to find them (which we should have anyway for accessibility reasons), using a custom `tryFindingViewWithAccessibilityHint` implementation since KIF doesn't have this built in. With that, we can simply test for the presence of these buttons to determine whether suggestions are enabled. This doesn't test the suggestions themselves; we already have that covered in `SearchTests.swift` in `ClientTests`.

I really dislike having to add a `SuggestionsPromptReset` notification observer just to handle resetting the prompt, but there's no way that I know of for UI tests to access the actual `Profile` or `SearchEngines` instances. Happy to hear other ideas.