### PR TITLE
Bug1157303 sent tabs notifications

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -461,7 +461,7 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    private func addBookmark(url: String, title: String?) {
+    func addBookmark(url: String, title: String?) {
         let shareItem = ShareItem(url: url, title: title, favicon: nil)
         profile.bookmarks.shareItem(shareItem)
 
@@ -549,6 +549,11 @@ class BrowserViewController: UIViewController {
                 log.error("Error getting bookmark status: \(err).")
             })
         }
+    }
+
+    func openURLInNewTab(url: NSURL) {
+        let tab = tabManager.addTab(request: NSURLRequest(URL: url))
+        tabManager.selectTab(tab)
     }
 }
 


### PR DESCRIPTION
Send localized notifications for sent tabs. Add default action of open URL in new tab in FF on tap. Add custom actions "View", "Bookmark" and "Add to reading list" to notifications

https://bugzilla.mozilla.org/show_bug.cgi?id=1157303