### PR TITLE
Bug 1175639 - Reader View Button Showing When Reader View Unavailable

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -76,8 +76,6 @@ class BrowserLocationView : UIView, ToolbarTextFieldDelegate {
                 && editTextField.isFirstResponder() {
                     editTextField.resignFirstResponder()
             }
-            readerModeButton.hidden = active
-            setNeedsUpdateConstraints()
         }
     }
 
@@ -206,13 +204,13 @@ class BrowserLocationView : UIView, ToolbarTextFieldDelegate {
             if newReaderModeState != self.readerModeButton.readerModeState {
                 self.readerModeButton.readerModeState = newReaderModeState
                 readerModeButton.hidden = (newReaderModeState == ReaderModeState.Unavailable)
-                setNeedsUpdateConstraints()
                 UIView.animateWithDuration(0.1, animations: { () -> Void in
                     if newReaderModeState == ReaderModeState.Unavailable {
                         self.readerModeButton.alpha = 0.0
                     } else {
                         self.readerModeButton.alpha = 1.0
                     }
+                    self.setNeedsUpdateConstraints()
                     self.layoutIfNeeded()
                 })
             }


### PR DESCRIPTION
Don't need to show/hide reader mode when text field is active as we are now using constraints and not text field insets and everything is a whole lot easier.

https://bugzilla.mozilla.org/show_bug.cgi?id=1175639