### PR TITLE
Bug 1175792 Don't persist URL bar value to new tab

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -190,6 +190,8 @@ class BrowserLocationView : UIView, ToolbarTextFieldDelegate {
                 } else {
                     editTextField.text = url
                 }
+            } else {
+                editTextField.text = nil
             }
 
             setNeedsUpdateConstraints()


### PR DESCRIPTION
ensure that if there is no valid URL then the URL Bar text field is emptied of text

https://bugzilla.mozilla.org/show_bug.cgi?id=1175792