### PR TITLE
Bug 1177386 - On iOS9 every HTTPS site results in a basic auth dialog being shown

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1382,7 +1382,7 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(webView: WKWebView,
         didReceiveAuthenticationChallenge challenge: NSURLAuthenticationChallenge,
         completionHandler: (NSURLSessionAuthChallengeDisposition, NSURLCredential!) -> Void) {
-            if challenge.protectionSpace.authenticationMethod != NSURLAuthenticationMethodClientCertificate {
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest {
                 if let tab = tabManager[webView] {
                     let helper = tab.getHelper(name: LoginsHelper.name()) as! LoginsHelper
                     helper.handleAuthRequest(self, challenge: challenge).uponQueue(dispatch_get_main_queue()) { res in


### PR DESCRIPTION
This patch inverts the comparison on `protectionSpace.authenticationMethod` so that we better check for *Basic* and *Digest*.

I think this fails on iOS 9 because they now actually trigger `NSURLAuthenticationMethodServerTrust`. (Which we can then use to verify the SSL chain!)