### PR TITLE
Bug 1177493 - When you refresh the settings page when signed in, unwanted headers appear at the top

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -656,6 +656,7 @@ private class SettingsTableSectionHeaderView: UITableViewHeaderFooterView {
         super.init(frame: frame)
         self.contentView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
         addSubview(titleLabel)
+        self.clipsToBounds = true
     }
 
 


### PR DESCRIPTION
added a line to clip header so that it doesn't show up after refresh