### PR TITLE
Fixes 1175897 - Send Tab not localized

### DIFF
--- a/scripts/xliff-cleanup.py
+++ b/scripts/xliff-cleanup.py
@@ -46,9 +46,10 @@ if __name__ == "__main__":
             for file_node in root.xpath("//x:file", namespaces=NS):
                 original = file_node.get('original')
                 if original and original.endswith('Info.plist'):
-                    for trans_unit_node in file_node.xpath("//x:trans-unit", namespaces=NS):
+                    for trans_unit_node in file_node.xpath("./x:body/x:trans-unit", namespaces=NS):
                         id = trans_unit_node.get('id')
-                        if id and id in STRINGS_TO_REMOVE:
+                        # TODO we should probably do the exception for SendTo in a nicer way with some kind of whitelist
+                        if id and id in STRINGS_TO_REMOVE and not (original == "Extensions/SendTo/Info.plist" and id == "CFBundleDisplayName"):
                             trans_unit_node.getparent().remove(trans_unit_node)
             # 3. Remove empty file sections
             for file_node in root.xpath("//x:file", namespaces=NS):

--- a/scripts/xliff-to-strings.py
+++ b/scripts/xliff-to-strings.py
@@ -17,6 +17,8 @@
 #  SendTo/en-US.lproj/SendTo.strings
 #  SendTo/fr.lproj/SendTo.strings
 #
+# For any Info.plist file in the xliff, we generate a InfoPlist.strings.
+#
 
 import glob
 import os
@@ -31,6 +33,7 @@ FILES = [
     "Client/Info.plist",
     "Client/Localizable.strings",
     "Client/search.strings",
+    "Extensions/SendTo/Info.plist",
     "Extensions/SendTo/SendTo.strings",
     "Extensions/ShareTo/ShareTo.strings",
     "Shared/Localizable.strings",
@@ -68,6 +71,8 @@ def export_xliff_file(file_node, export_path, target_language):
 
 def original_path(root, target, original):
     dir,file = os.path.split(original)
+    if file == "Info.plist":
+        file = "InfoPlist.strings"
     lproj = "%s.lproj" % target_language
     path = dir + "/" + lproj + "/" + file
     return path


### PR DESCRIPTION
TL;DR The Send Tab action title is now correctly localized when presented in the system-provided Share sheet.

This patch fixes a couple of things:

* We never correctly converted Info.plist sections in the XLIFF to a `.strings` file. They would end up in the project as `XX.lproj/Info.plist`, which is wrong. They are now written to `XX.lproj/InfoPlist.strings` so that the strings are correctly picked up by iOS.
* The `xliff-cleanup.py` script was broken and I think it never correctly processed `Info.plist` sections anyway.
* The l10n scripts normally ignore the `CFBundleDisplayName` but we now make an exception if that key is found in `Extensions/SendTo/Info.plist`

This patch also makes sure the `NSLocationWhenInUseUsageDescription` key is output to `Client/XX.lproj/InfoPlist.strings`. I don't think it correctly worked before.