### PR TITLE
Fixes 1145088 -  Add a link to SUMO in a Settings sub-menu

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -374,6 +374,25 @@ private class ShowIntroductionSetting: Setting {
     }
 }
 
+// Opens the the SUMO page in a new tab
+private class OpenSupportPageSetting: Setting {
+    init() {
+        super.init(title: NSAttributedString(string: NSLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        navigationController?.dismissViewControllerAnimated(true, completion: {
+            if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
+                appDelegate.browserViewController.dismissTabTrayController(animated: true) {
+                    if let url = NSURL(string: "https://support.mozilla.org/products/ios") {
+                        appDelegate.browserViewController.openURLInNewTab(url)
+                    }
+                }
+            }
+        })
+    }
+}
+
 class UseCompactTabLayoutSetting: Setting {
     let profile: Profile
 
@@ -513,9 +532,6 @@ class SettingsTableViewController: UITableViewController {
             ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("Search Settings", comment: "Search settings section title")), children: [
                 SearchSetting(settings: self)
-            ]),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
-                ShowIntroductionSetting(settings: self)
             ])
         ]
 
@@ -531,6 +547,10 @@ class SettingsTableViewController: UITableViewController {
         }
 
         settings += [
+            SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
+                ShowIntroductionSetting(settings: self),
+                OpenSupportPageSetting()
+            ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [
                 VersionSetting(settings: self)
             ])


### PR DESCRIPTION
This patch adds a link to SUMO in the Support section of the Settings screen. It opens https://support.mozilla.org/products/ios in a new tab when selected.