### PR TITLE
Fixes 1172951 - Unable to play media (WebKit 204 Error)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1509,6 +1509,12 @@ extension BrowserViewController: WKUIDelegate {
             return
         }
 
+        // Ignore the "Plug-in handled load" error. Which is more like a notification than an error.
+        // Note that there are no constants in the SDK for the WebKit domain or error codes.
+        if error.domain == "WebKitErrorDomain" && error.code == 204 {
+            return
+        }
+
         if let url = error.userInfo?["NSErrorFailingURLKey"] as? NSURL {
             ErrorPageHelper().showPage(error, forUrl: url, inWebView: webView)
         }


### PR DESCRIPTION
This patch ignores the WebKitDomainError/204 error that happens when you open a media file that is handled by an (internal) WebKit plugin.

I don't understand why those are raised as errors via the `WKNavigationDelegate` - it is more like a notification from WebKit to tell us that it handled the page load internally.