### PR TITLE
Bug 1178015 - Accessibility escape not dismissing editing mode in editing-mode URL bar when keyboard is not shown

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -548,7 +548,7 @@ class BrowserViewController: UIViewController {
     }
 
     override func accessibilityPerformEscape() -> Bool {
-        if urlBar.isEditing {
+        if urlBar.canCancel {
             urlBar.SELdidClickCancel()
             return true
         } else if let selectedTab = tabManager.selectedTab where selectedTab.canGoBack {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -146,6 +146,10 @@ class URLBarView: UIView {
         return locationView.active
     }
 
+    var canCancel: Bool {
+        return !cancelButton.hidden
+    }
+
     var currentURL: NSURL? {
         get {
             return locationView.url
@@ -517,7 +521,7 @@ extension URLBarView: BrowserToolbarProtocol {
 
     override var accessibilityElements: [AnyObject]! {
         get {
-            if isEditing {
+            if canCancel {
                 return [locationView, cancelButton]
             } else {
                 if toolbarIsShowing {


### PR DESCRIPTION
Also while at it, fix "Cancel" button not being shown to VoiceOver in
the same situation - because of the same wrong logic.

[Bug 1178015 - Accessibility escape not dismissing editing mode in editing-mode URL bar when keyboard is not shown](https://bugzilla.mozilla.org/show_bug.cgi?id=1178015)

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)