### PR TITLE
Bug 1172524 - Added one minute buffer between network syncing for remote client/tabs on RemoteTabsPanel

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -114,4 +114,8 @@ public class MockProfile: Profile {
     func getClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>> {
         return deferResult([])
     }
+
+    func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>> {
+        return deferResult([])
+    }
 }

--- a/Providers/NSUserDefaultsPrefs.swift
+++ b/Providers/NSUserDefaultsPrefs.swift
@@ -39,6 +39,10 @@ public class NSUserDefaultsPrefs: Prefs {
         setObject(NSNumber(int: value), forKey: defaultName)
     }
 
+    public func setTimestamp(value: Timestamp, forKey defaultName: String) {
+        setLong(value, forKey: defaultName)
+    }
+
     public func setLong(value: UInt64, forKey defaultName: String) {
         setObject(NSNumber(unsignedLongLong: value), forKey: defaultName)
     }
@@ -78,6 +82,10 @@ public class NSUserDefaultsPrefs: Prefs {
 
     public func unsignedLongForKey(defaultName: String) -> UInt64? {
         return nsNumberForKey(defaultName)?.unsignedLongLongValue
+    }
+
+    public func timestampForKey(defaultName: String) -> Timestamp? {
+        return unsignedLongForKey(defaultName)
     }
 
     public func longForKey(defaultName: String) -> Int64? {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -161,6 +161,7 @@ protocol Profile {
 
     func getClients() -> Deferred<Result<[RemoteClient]>>
     func getClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>>
+    func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>>
 
     var syncManager: SyncManager { get }
 }
@@ -286,6 +287,10 @@ public class BrowserProfile: Profile {
            >>> { self.remoteClientsAndTabs.getClientsAndTabs() }
     }
 
+    public func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>> {
+        return self.remoteClientsAndTabs.getClientsAndTabs()
+    }
+
     lazy var logins: protocol<BrowserLogins, SyncableLogins> = {
         return SQLiteLogins(db: self.loginsDB)
     }()
@@ -330,6 +335,7 @@ public class BrowserProfile: Profile {
     func removeAccount() {
         let old = self.account
 
+        prefs.removeObjectForKey(PrefsKeys.KeyLastRemoteTabSyncTime)
         KeychainWrapper.removeObjectForKey(name + ".account")
         self.account = nil
 

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -4,8 +4,13 @@
 
 import Foundation
 
+public struct PrefsKeys {
+    public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
+}
+
 public protocol Prefs {
     func branch(branch: String) -> Prefs
+    func setTimestamp(value: Timestamp, forKey defaultName: String)
     func setLong(value: UInt64, forKey defaultName: String)
     func setLong(value: Int64, forKey defaultName: String)
     func setInt(value: Int32, forKey defaultName: String)
@@ -15,6 +20,7 @@ public protocol Prefs {
     func stringForKey(defaultName: String) -> String?
     func boolForKey(defaultName: String) -> Bool?
     func intForKey(defaultName: String) -> Int32?
+    func timestampForKey(defaultName: String) -> Timestamp?
     func longForKey(defaultName: String) -> Int64?
     func unsignedLongForKey(defaultName: String) -> UInt64?
     func stringArrayForKey(defaultName: String) -> [String]?
@@ -47,6 +53,10 @@ public class MockProfilePrefs : Prefs {
         return self.prefix + name
     }
 
+    public func setTimestamp(value: Timestamp, forKey defaultName: String) {
+        self.setLong(value, forKey: defaultName)
+    }
+
     public func setLong(value: UInt64, forKey defaultName: String) {
         setObject(NSNumber(unsignedLongLong: value), forKey: defaultName)
     }
@@ -77,6 +87,10 @@ public class MockProfilePrefs : Prefs {
 
     public func boolForKey(defaultName: String) -> Bool? {
         return things[name(defaultName)] as? Bool
+    }
+
+    public func timestampForKey(defaultName: String) -> Timestamp? {
+        return unsignedLongForKey(defaultName)
     }
 
     public func unsignedLongForKey(defaultName: String) -> UInt64? {


### PR DESCRIPTION
This patch adds some throttling behind refreshing of the client/tabs on the RemoteTabsPanel so we're not hitting the network every time. Instead, a one minute delay is used since the last sync time. 