### PR TITLE
Fixes 1171189 - Custom context menu fires when closing the banner on Twitter

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -78,6 +78,12 @@ addEventListener("touchstart", function (event) {
     if (!data.link && element.localName === "a") {
       data.link = element.href;
 
+      // Don't show the context menu if this is a script link
+      if (element.getAttribute("href") === "#") {
+        data = {};
+        break;
+      }
+
       // The web view still shows the tap highlight after clicking an element,
       // so add a delay before showing the long press highlight to avoid
       // the highlight flashing twice.


### PR DESCRIPTION
The banner is a Twitter specific banner and not the built-in one that apps can ask to be shown in the `WKWebView`.

The underlying problem here is that we also try to show the context menu on script links that are handled internally by the web site. This patch has a basic fix for that where I check if the link's `href` is set to `#`. I don't know the web platform well enough if this is the best check to do.

*Note that this fix is not twitter specific. This will work on any script-backed link.*