### PR TITLE
Fixes 1179005 - Make sure we can build on Xcode 6.4

### DIFF
--- a/Storage/modules/module.modulemap
+++ b/Storage/modules/module.modulemap
@@ -1,11 +1,11 @@
 module sqlite3 [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/usr/include/sqlite3.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.4.sdk/usr/include/sqlite3.h"
     link "sqlite3"
     export *
 }
 
 module sqlite3simulator [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.3.sdk/usr/include/sqlite3.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.4.sdk/usr/include/sqlite3.h"
     link "sqlite3"
     export *
 }


### PR DESCRIPTION
This PR branch can be used for Xcode 6.4 fixes. So far I have only fixed the absolute paths in ` Storage/modules/module.modulemap` to point to the `iPhoneOS8.4` directory. May be the only change needed.