### PR TITLE
1171626 - Tapping item in Reading List takes causes crash

### DIFF
--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -38,6 +38,7 @@ class ReadabilityOperation: NSOperation, WKNavigationDelegate, ReadabilityBrowse
         dispatch_async(dispatch_get_main_queue(), { () -> Void in
             let configuration = WKWebViewConfiguration()
             self.browser = Browser(configuration: configuration)
+            self.browser.createWebview()
             self.browser.navigationDelegate = self
 
             if let readabilityBrowserHelper = ReadabilityBrowserHelper(browser: self.browser) {


### PR DESCRIPTION
This patch fixes a regression that was introduced after the lazy loading of the `WKWebView` was implemented. The `ReadabiltyOperation` requires the `Browser.webView` to be present so this patch simply calls `createWebview()` to ensure that.