### PR TITLE
Bug 1178012 - Reliably handle long press gesture on ToolbarTextField

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -710,7 +710,8 @@ extension BrowserViewController: URLBarDelegate {
         })
         longPressAlertController.addAction(copyAddressAction)
 
-        let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert view"), style: .Cancel, handler: nil)
+        let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert view"), style: .Cancel, handler: { (alert: UIAlertAction!) -> Void in
+        })
         longPressAlertController.addAction(cancelAction)
 
         if let popoverPresentationController = longPressAlertController.popoverPresentationController {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -160,6 +160,6 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             // Set the current position to the end of the text.
             selectedTextRange = textRangeFromPosition(endOfDocument, toPosition: endOfDocument)
         }
-        active = true
+        active = self.isFirstResponder()
     }
 }

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -11,7 +11,7 @@ class DomainAutocompleteTests: KIFTestCase {
         BrowserUtils.addHistoryEntry("Yahoo", url: NSURL(string: "http://www.yahoo.com/")!)
         BrowserUtils.addHistoryEntry("Foo bar baz", url: NSURL(string: "https://foo.bar.baz.org/dingbat")!)
 
-        tester().tapViewWithAccessibilityLabel("Search or enter address")
+        tester().tapViewWithAccessibilityIdentifier("url")
         let textField = tester().waitForViewWithAccessibilityLabel("Address and Search") as! UITextField
 
         // Basic autocompletion cases.

--- a/UITests/SearchSettingsUITests.swift
+++ b/UITests/SearchSettingsUITests.swift
@@ -10,8 +10,8 @@ class SearchSettingsUITests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Tabs Tray")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().waitForViewWithAccessibilityLabel("Settings")
-        tester().tapViewWithAccessibilityLabel("Search")
-        tester().waitForViewWithAccessibilityLabel("Search")
+        tester().tapViewWithAccessibilityLabel("Search, Yahoo")
+        tester().waitForViewWithAccessibilityIdentifier("Search")
     }
 
     private func navigateFromSearchSettings() {

--- a/UITests/SearchTests.swift
+++ b/UITests/SearchTests.swift
@@ -14,7 +14,7 @@ class SearchTests: KIFTestCase {
 
         // Ensure that the prompt appears.
         tester().tapViewWithAccessibilityIdentifier("url")
-        tester().clearTextFromAndThenEnterText("foobar", intoViewWithAccessibilityLabel: LabelAddressAndSearch)
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("foobar")
         found = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
         XCTAssertTrue(found, "Prompt is shown")
 

--- a/UITests/ViewMemoryLeakTests.swift
+++ b/UITests/ViewMemoryLeakTests.swift
@@ -38,8 +38,7 @@ class ViewMemoryLeakTests: KIFTestCase, UITextFieldDelegate {
     func testSearchViewControllerDisposed() {
         // Type the URL to make the search controller appear.
         tester().tapViewWithAccessibilityIdentifier("url")
-        let url = "\(webRoot)/numberedPage.html?page=1"
-        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("foobar")
         let browserViewController = UIApplication.sharedApplication().keyWindow!.rootViewController!
         weak var searchViewController = getChildViewController(browserViewController, childClass: "SearchViewController")
         XCTAssertNotNil(searchViewController, "Got search controller reference")


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1178012

Move gesture recognizer code outside of text field and into BrowserLocationView
Make note of handling long press much earlier (when we decide we want to handle it rather than when it's fire). This is because the order in which textFieldShouldBeginEditing and the gesture handler are called is variable
Ensure that the firing of touchesEnded in base AutocompleteTextField class does not override our active state
Add a callback to long press delegates up the chain so that we can tell when we've finished handling the long press, otherwise the gesture might have ended before textFieldShouldBeginEditing has been called causing both field editing and quick paste functionality to appear simulatneously