### PR TITLE
1171633 - New toggle appears in settings when disconnecting account

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -47,6 +47,7 @@ class Setting {
         cell.detailTextLabel?.attributedText = status
         cell.textLabel?.attributedText = title
         cell.accessoryType = accessoryType
+        cell.accessoryView = nil
     }
 
     // Called when the pref is tapped.


### PR DESCRIPTION
This patch resets the cell's `accessoryView` to `nil` when it is configured with the defaults. This is not the best solution. I think what really should happen is that instead of subclassing a `Setting` class, we should simply implement `UITableViewCell` subclasses for the individual items, with unique `reuseIdentifiers`. There is no need to put an extra abstraction on top of that.