### PR TITLE
Bug 1165586 - Browser scrolling no longer causes speed increase and parallax effect

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -557,6 +557,7 @@
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E6E079851B41E54A001645A6 /* FXCrashDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = E6E079841B41E54A001645A6 /* FXCrashDetector.m */; };
+		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
 		E6EAC5961B29CB3A00E1DE1E /* scrollablePage.html in Resources */ = {isa = PBXBuildFile; fileRef = E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */; };
 		E6F965121B2F1CF20034B023 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288A2D861AB8B3260023ABC3 /* Shared.framework */; };
 		E6F9653C1B2F1D5D0034B023 /* NSURLExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */; };
@@ -1553,6 +1554,7 @@
 		E4ECCDAD1AB131770005E717 /* FiraSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Medium.ttf"; sourceTree = "<group>"; };
 		E4F21AA51A13C4A300B0FAAA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
+		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
 		E6A99D761B20D95800006EDD /* GeometryExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryExtensions.swift; sourceTree = "<group>"; };
 		E6E079831B41E54A001645A6 /* FXCrashDetector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FXCrashDetector.h; sourceTree = "<group>"; };
 		E6E079841B41E54A001645A6 /* FXCrashDetector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FXCrashDetector.m; sourceTree = "<group>"; };
@@ -1757,13 +1759,6 @@
 			);
 			name = UIImageViewAligned;
 			path = ThirdParty/UIImageViewAligned/UIImageViewAligned;
-			sourceTree = "<group>";
-		};
-		0B59D3361B27A5460037A0A5 /* Browser */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Browser;
 			sourceTree = "<group>";
 		};
 		0B6544B11A96C59E000DD202 /* Products */ = {
@@ -2346,6 +2341,7 @@
 				746D4E361B1E699C008F789F /* HashchangeHelper.swift */,
 				74C295261B21152000862FE3 /* AboutHomeHandler.swift */,
 				74C027441B2A348C001B1E88 /* SessionData.swift */,
+				E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -2370,6 +2366,7 @@
 		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				287DA9D51AE06D220055AC35 /* Extensions */,
 				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
@@ -2384,8 +2381,6 @@
 				282731A11ABC9D2600AA1954 /* Prefs.swift */,
 				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
 				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
-				0B59D3361B27A5460037A0A5 /* Browser */,
-				287DA9D51AE06D220055AC35 /* Extensions */,
 				E4252A0D1AF01AE40028C684 /* Swizzling.m */,
 				E4C358531AF1440B00299F7E /* Swizzling.h */,
 				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
@@ -4127,6 +4122,7 @@
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
 				6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */,
 				D38B2D341A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
+				E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -70,7 +70,6 @@ class Browser: NSObject {
             webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
             webView.allowsBackForwardNavigationGestures = true
             webView.backgroundColor = UIColor.lightGrayColor()
-            webView.scrollView.layer.masksToBounds = false
 
             // Turning off masking allows the web content to flow outside of the scrollView's frame
             // which allows the content appear beneath the toolbars in the BrowserViewController

--- a/Client/Frontend/Browser/BrowserScrollController.swift
+++ b/Client/Frontend/Browser/BrowserScrollController.swift
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import SnapKit
+
+private let ToolbarBaseAnimationDuration: CGFloat = 0.3
+
+class BrowserScrollingController: NSObject {
+    weak var browser: Browser? {
+        willSet {
+            self.scrollView?.delegate = nil
+            self.scrollView?.removeGestureRecognizer(panGesture)
+        }
+
+        didSet {
+            self.scrollView?.addGestureRecognizer(panGesture)
+            scrollView?.delegate = self
+        }
+    }
+
+    weak var header: UIView?
+    weak var footer: UIView?
+    weak var urlBar: URLBarView?
+
+    var footerBottomConstraint: Constraint?
+    var headerTopConstraint: Constraint?
+    var toolbarsShowing: Bool { return headerTopOffset == 0 }
+
+    private var headerTopOffset: CGFloat = 0 {
+        didSet {
+            headerTopConstraint?.updateOffset(headerTopOffset)
+            header?.superview?.setNeedsLayout()
+        }
+    }
+
+    private var footerBottomOffset: CGFloat = 0 {
+        didSet {
+            footerBottomConstraint?.updateOffset(footerBottomOffset)
+            footer?.superview?.setNeedsLayout()
+        }
+    }
+
+    private lazy var panGesture: UIPanGestureRecognizer = {
+        let panGesture = UIPanGestureRecognizer(target: self, action: "handlePan:")
+        panGesture.maximumNumberOfTouches = 1
+        panGesture.delegate = self
+        return panGesture
+    }()
+
+    private var scrollView: UIScrollView? { return browser?.webView?.scrollView }
+    private var contentOffset: CGPoint { return scrollView?.contentOffset ?? CGPointZero }
+    private var contentSize: CGSize { return scrollView?.contentSize ?? CGSizeZero }
+    private var scrollViewHeight: CGFloat { return scrollView?.frame.height ?? 0 }
+    private var headerFrame: CGRect { return header?.frame ?? CGRectZero }
+    private var footerFrame: CGRect { return footer?.frame ?? CGRectZero }
+
+    private var lastContentOffset: CGFloat = 0
+
+    override init() {
+        super.init()
+    }
+
+    func showToolbars(#animated: Bool, completion: ((finished: Bool) -> Void)? = nil) {
+        let durationRatio = abs(headerTopOffset / headerFrame.height)
+        let actualDuration = NSTimeInterval(ToolbarBaseAnimationDuration * durationRatio)
+        self.animateToolbarsWithOffsets(
+            animated: animated,
+            duration: actualDuration,
+            headerOffset: 0,
+            footerOffset: 0,
+            alpha: 1,
+            completion: completion)
+    }
+
+    func hideToolbars(#animated: Bool, completion: ((finished: Bool) -> Void)? = nil) {
+        let animationDistance = headerFrame.height - abs(headerTopOffset)
+        let durationRatio = abs(headerTopOffset / headerFrame.height)
+        let actualDuration = NSTimeInterval(ToolbarBaseAnimationDuration * durationRatio)
+        self.animateToolbarsWithOffsets(
+            animated: animated,
+            duration: actualDuration,
+            headerOffset: -headerFrame.height,
+            footerOffset: footerFrame.height,
+            alpha: 0,
+            completion: completion)
+    }
+}
+
+private extension BrowserScrollingController {
+    @objc func handlePan(gesture: UIPanGestureRecognizer) {
+        if let loading = browser?.loading where loading { return }
+
+        if let containerView = scrollView?.superview {
+            let translation = gesture.translationInView(containerView)
+            let delta = lastContentOffset - translation.y
+            lastContentOffset = translation.y
+            if checkRubberbandingForDelta(delta) {
+                scrollWithDelta(delta)
+            }
+
+            if gesture.state == .Ended || gesture.state == .Cancelled {
+                lastContentOffset = 0
+            }
+        }
+    }
+
+    func checkRubberbandingForDelta(delta: CGFloat) -> Bool {
+        return !((delta < 0 && contentOffset.y + scrollViewHeight > contentSize.height &&
+                scrollViewHeight < contentSize.height) ||
+                contentOffset.y < delta)
+    }
+
+    func scrollWithDelta(delta: CGFloat) {
+        if scrollViewHeight >= contentSize.height {
+            return
+        }
+
+        var updatedOffset = headerTopOffset - delta
+        headerTopOffset = clamp(updatedOffset, min: -headerFrame.height, max: 0)
+        if isHeaderDisplayedForGivenOffset(updatedOffset) {
+            scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
+        }
+
+        updatedOffset = footerBottomOffset + delta
+        footerBottomOffset = clamp(updatedOffset, min: 0, max: footerFrame.height)
+
+        let alpha = 1 - abs(headerTopOffset / headerFrame.height)
+        urlBar?.updateAlphaForSubviews(alpha)
+    }
+
+    func isHeaderDisplayedForGivenOffset(offset: CGFloat) -> Bool {
+        return offset > -headerFrame.height && offset < 0
+    }
+
+    func clamp(y: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
+        if y >= max {
+            return max
+        } else if y <= min {
+            return min
+        }
+        return y
+    }
+
+    func animateToolbarsWithOffsets(#animated: Bool, duration: NSTimeInterval, headerOffset: CGFloat,
+        footerOffset: CGFloat, alpha: CGFloat, completion: ((finished: Bool) -> Void)?) {
+
+        let animation: () -> Void = {
+            self.headerTopOffset = headerOffset
+            self.footerBottomOffset = footerOffset
+            self.urlBar?.updateAlphaForSubviews(alpha)
+            self.header?.superview?.layoutIfNeeded()
+        }
+
+        if animated {
+            UIView.animateWithDuration(duration, animations: animation, completion: completion)
+        } else {
+            animation()
+            completion?(finished: true)
+        }
+    }
+}
+
+extension BrowserScrollingController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}
+
+extension BrowserScrollingController: UIScrollViewDelegate {
+    func scrollViewWillEndDragging(scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        // Check to see if the target offset after the scroll gesture will be enough to hide the toolbars or not
+        let finalOffset = -abs(contentOffset.y - targetContentOffset.memory.y) + headerTopOffset
+        if headerTopOffset > -headerFrame.height && headerTopOffset < 0 {
+            if finalOffset > (-headerFrame.height / 2) {
+                showToolbars(animated: true)
+            } else {
+                hideToolbars(animated: true)
+            }
+        }
+    }
+
+    func scrollViewShouldScrollToTop(scrollView: UIScrollView) -> Bool {
+        showToolbars(animated: true)
+        return true
+    }
+}


### PR DESCRIPTION
When the user used to scroll, the header would move along with the page content which caused a weird parallax effect and the scroll speed to increase because the web view is being enlarged while also scrolling. For better control over the scrolling, I add our own pan gesture handler on top of the web view's and have them run simultaneously so I can force the scrollView's contentOffset to adjust for the delta change in the frame height. I also moved all of the scrolling behavior code into it's own controller object to clean up the BVC.