### PR TITLE
Bug 1174227 - When you clear the history (clear private data), the favicons in the bookmark list aren't fetched until you click the link

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -291,9 +291,9 @@ extension SQLiteHistory: Favicons {
         var err: NSError? = nil
 
         db.withWritableConnection(&err) { (conn, inout err: NSError?) -> Int in
-            err = conn.executeChange("DELETE FROM \(TableFaviconSites)", withArgs: nil)
+            err = conn.executeChange("DELETE FROM \(TableFaviconSites) WHERE url NOT IN (SELETE url FROM \(TableBookmarks))", withArgs: nil)
             if err == nil {
-                err = conn.executeChange("DELETE FROM \(TableFavicons)", withArgs: nil)
+                err = conn.executeChange("DELETE FROM \(TableFavicons) WHERE url NOT IN (SELETE url FROM \(TableBookmarks))", withArgs: nil)
             }
             return 1
         }


### PR DESCRIPTION
Change the SQLite Command when clear favicons.