### PR TITLE
Bug 1178787 - Add a Sync Now button

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -15,6 +15,9 @@ public class MockSyncManager: SyncManager {
     public func syncClientsThenTabs() -> SyncResult { return deferResult(.Completed) }
     public func syncHistory() -> SyncResult { return deferResult(.Completed) }
     public func syncLogins() -> SyncResult { return deferResult(.Completed) }
+    public func syncEverything() -> Success {
+        return succeed()
+    }
 
     public func beginTimedSyncs() {}
     public func endTimedSyncs() {}

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -18,6 +18,7 @@ public protocol SyncManager {
     func syncClientsThenTabs() -> SyncResult
     func syncHistory() -> SyncResult
     func syncLogins() -> SyncResult
+    func syncEverything() -> Success
 
     // The simplest possible approach.
     func beginTimedSyncs()


### PR DESCRIPTION
1. edited the settings page to have button when account is signed in
2. the top row with the FFX account now links back to the login screen instead of not doing anything (in order to update if you changed a password, etc. other FFX account flow mishappenings)
3. Sync Now button syncs everything, but no timestamp for UI yet!