### PR TITLE
Bug 1181425 - Settings TableViewCells that aren't buttons shouldn't show animation on tap

### DIFF
--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -62,6 +62,7 @@ class SearchSettingsTableViewController: UITableViewController {
                 toggle.addTarget(self, action: "SELdidToggleSearchSuggestions:", forControlEvents: UIControlEvents.ValueChanged)
                 toggle.on = model.shouldShowSearchSuggestions
                 cell.editingAccessoryView = toggle
+                cell.selectionStyle = .None
 
             default:
                 // Should not happen.
@@ -86,6 +87,8 @@ class SearchSettingsTableViewController: UITableViewController {
 
             cell.textLabel?.text = engine.shortName
             cell.imageView?.image = engine.image?.createScaled(IconSize)
+			
+            cell.selectionStyle = .None
         }
 
         // So that the seperator line goes all the way to the left edge.

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -104,6 +104,12 @@ private class AccountSetting: Setting, FxAContentViewControllerDelegate {
         self.settings = settings
         super.init(title: nil)
     }
+    private override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        if settings.profile.getAccount() != nil {
+            cell.selectionStyle = .None
+        }
+    }
 
     override var accessoryType: UITableViewCellAccessoryType { return .None }
 
@@ -343,7 +349,11 @@ private class VersionSetting : Setting {
         let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as! String
         return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), appVersion, buildNumber), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
     }
-
+    private override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.selectionStyle = .None
+    }
+    
     override func onClick(navigationController: UINavigationController?) {
         if AppConstants.BuildChannel != .Aurora {
             DebugSettingsClickCount += 1
@@ -410,6 +420,7 @@ class UseCompactTabLayoutSetting: Setting {
         control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
         control.on = profile.prefs.boolForKey("CompactTabLayout") ?? true
         cell.accessoryView = control
+        cell.selectionStyle = .None
     }
 
     @objc func switchValueChanged(control: UISwitch) {
@@ -490,6 +501,7 @@ private class PopupBlockingSettings: Setting {
         control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
         control.on = prefs.boolForKey(prefKey) ?? true
         cell.accessoryView = control
+        cell.selectionStyle = .None
     }
 
     @objc func switchValueChanged(toggle: UISwitch) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1181425

Cells that provide no function when being tapped no longer animate
