### PR TITLE
Fixes 1177201 - Saving pictures doesn't always prompt for Photos permission

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Photos
 import UIKit
 import WebKit
 import Shared
@@ -1975,9 +1976,22 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 dialogTitle = url.absoluteString
             }
 
+            let photoAuthorizeStatus = PHPhotoLibrary.authorizationStatus()
             let saveImageTitle = NSLocalizedString("Save Image", comment: "Context menu item for saving an image")
             let saveImageAction = UIAlertAction(title: saveImageTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction!) -> Void in
-                self.getImage(url) { UIImageWriteToSavedPhotosAlbum($0, nil, nil, nil) }
+                if photoAuthorizeStatus == PHAuthorizationStatus.Authorized || photoAuthorizeStatus == PHAuthorizationStatus.NotDetermined {
+                    self.getImage(url) { UIImageWriteToSavedPhotosAlbum($0, nil, nil, nil) }
+                } else {
+                    let accessDenied = UIAlertController(title: NSLocalizedString("Firefox would like to access your Photos", comment: "See http://mzl.la/1G7uHo7"), message: NSLocalizedString("This allows you to save the image to your Camera Roll.", comment: "See http://mzl.la/1G7uHo7"), preferredStyle: UIAlertControllerStyle.Alert)
+                    let dismissAction = UIAlertAction(title: CancelString, style: UIAlertActionStyle.Default, handler: nil)
+                    accessDenied.addAction(dismissAction)
+                    let settingsAction = UIAlertAction(title: NSLocalizedString("Open Settings", comment: "See http://mzl.la/1G7uHo7"), style: UIAlertActionStyle.Default ) { (action: UIAlertAction!) -> Void in
+                        UIApplication.sharedApplication().openURL(NSURL(string: UIApplicationOpenSettingsURLString)!)
+                    }
+                    accessDenied.addAction(settingsAction)
+                    self.presentViewController(accessDenied, animated: true, completion: nil)
+
+                }
             }
             actionSheetController.addAction(saveImageAction)
 


### PR DESCRIPTION
(I took @allenngn's patch and changed the strings and made them localizable)

Original comment taken from https://github.com/mozilla/firefox-ios/pull/673

The problem with this bug is that you cannot always prompt for Photos permission. The prompt that asks for Photos permission ("\"Firefox\" Would Like To Access Your Photos - Don't Allow / OK") only comes up once - the very first time Firefox needs to access the Photo Library. Apple has iOS calling that prompt through some private framework or something and it's not something we can call explicitly, I don't think. It only ever comes up once because iOS never seems to call it again, regardless of whether the user allows or denies permission to the photo library. I think Apple did this to prevent users from being spammed by the permissions prompt should they choose not to allow access.

What this means for us is that we cannot have a prompt that directly changes the access permissions for the Firefox iOS app. My proposed changes make it so that if the user denies access, any subsequent attempt to use the "Save Image" option of the context menu will bring up a UIAlertViewController which tells them they need to enable access permissions in order to save the image. They can either dismiss it by pressing OK or press Change Access Settings to go into Settings -> Firefox -> Privacy -> Photos where they can enable the access themselves.

Apple made it so that if privacy settings are changed for an app, the app is terminated. You will see this manifest in the simulator by getting a SIGKILL when you try changing the access privileges in Settings. If you run the app in the simulator on its own (i.e. not as a result of the Xcode's play button), it works fine. Or if you run it on an actual iPhone, it works too. When you open the app after changing the privacy setting, it restarts with the changed privacy settings and can now save images.

I added the Photos.framework to the project. I also alphabetized the import statements to improve readability.
