### PR TITLE
Bug 1174052 - Sent tabs for remote clients

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -304,6 +304,12 @@
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = 746B6A781B277C1800EA83E3 /* SessionRestore.html */; };
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
+		6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE4ACF81B0657180092AEBE /* Accessibility.swift */; };
+		7BF5A1CA1B4160EA00EA9DD8 /* SyncCommandsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */; };
+		7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
+		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
+		7BF5A1F01B429CD200EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
+		7BF5A1F11B429CD700EA9DD8 /* SyncCommandsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */; };
 		D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* TabTrayController.swift */; };
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -1388,6 +1394,11 @@
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
+		74C295261B21152000862FE3 /* AboutHomeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutHomeHandler.swift; sourceTree = "<group>"; };
+		6BE4ACF81B0657180092AEBE /* Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
+		7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncQueue.swift; sourceTree = "<group>"; };
+		7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTests.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
@@ -2115,6 +2126,7 @@
 				2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */,
 				2FCAE23F1ABB531100877008 /* Bookmarks.swift */,
 				28C4AB711AD42D4300D9ACE3 /* Clients.swift */,
+				7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */,
 				2FCAE2411ABB531100877008 /* Cursor.swift */,
 				28302E3F1AF0747800521E2E /* DatabaseError.swift */,
 				2FCAE2421ABB531100877008 /* Favicons.swift */,
@@ -2145,6 +2157,7 @@
 			isa = PBXGroup;
 			children = (
 				2FCAE2791ABB533A00877008 /* MockFiles.swift */,
+				7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */,
 				2FCAE27C1ABB533A00877008 /* TestFaviconsTable.swift */,
 				0BDA56AE1B26B1D5008C9B96 /* TestLogins.swift */,
 				28D158AC1AFD90E500F9C065 /* TestSQLiteBookmarks.swift */,
@@ -2170,6 +2183,9 @@
 			isa = PBXGroup;
 			children = (
 				2FCAE24B1ABB531100877008 /* BrowserDB.swift */,
+				282915E51AF1A7920006EEB5 /* BrowserTable.swift */,
+				7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */,
+				0B5A93031B1E60B4004F47A2 /* DeferredDBOperation.swift */,
 				2FCAE24C1ABB531100877008 /* FaviconsTable.swift */,
 				2FCAE24D1ABB531100877008 /* GenericTable.swift */,
 				2FCAE2521ABB531100877008 /* RemoteTabsTable.swift */,
@@ -2179,8 +2195,6 @@
 				0BDA56B31B26B203008C9B96 /* SQLiteLogins.swift */,
 				285D3B8F1B4386520035FD22 /* SQLiteQueue.swift */,
 				2FCAE2581ABB531100877008 /* SQLiteRemoteClientsAndTabs.swift */,
-				282915E51AF1A7920006EEB5 /* BrowserTable.swift */,
-				0B5A93031B1E60B4004F47A2 /* DeferredDBOperation.swift */,
 			);
 			path = SQL;
 			sourceTree = "<group>";
@@ -3958,8 +3972,10 @@
 				285F2DC11AF80B4600211843 /* SQLiteBookmarks.swift in Sources */,
 				28C4AB721AD42D4300D9ACE3 /* Clients.swift in Sources */,
 				2FCAE26F1ABB531100877008 /* RemoteTabsTable.swift in Sources */,
+				7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */,
 				28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
+				7BF5A1CA1B4160EA00EA9DD8 /* SyncCommandsTable.swift in Sources */,
 				2FCAE25D1ABB531100877008 /* Bookmarks.swift in Sources */,
 				2FCAE2781ABB531100877008 /* Visit.swift in Sources */,
 				2FCAE2701ABB531100877008 /* SchemaTable.swift in Sources */,
@@ -3998,9 +4014,12 @@
 				2FA4352C1ABB6873008031D1 /* Visit.swift in Sources */,
 				2FA435231ABB6831008031D1 /* RemoteTabsTable.swift in Sources */,
 				28CA1BA81AFC718800220D38 /* TestTableTable.swift in Sources */,
+				7BF5A1F11B429CD700EA9DD8 /* SyncCommandsTable.swift in Sources */,
 				2FA435241ABB6831008031D1 /* SchemaTable.swift in Sources */,
 				2FCAE2841ABB533A00877008 /* MockFiles.swift in Sources */,
+				7BF5A1F01B429CD200EA9DD8 /* SyncQueue.swift in Sources */,
 				288ED6DE1B29DEAA0008E140 /* SQLiteLogins.swift in Sources */,
+				7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */,
 				287AC8661AF4776D00101515 /* TestSQLiteHistory.swift in Sources */,
 				2FA435131ABB6829008031D1 /* Cursor.swift in Sources */,
 				282915E71AF1A7920006EEB5 /* BrowserTable.swift in Sources */,
@@ -6067,6 +6086,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Sync/Sync-Bridging-Header.h";

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -108,6 +108,10 @@ public class MockProfile: Profile {
         return SQLiteRemoteClientsAndTabs(db: self.db)
     }()
 
+    private lazy var syncCommands: SyncCommands = {
+        return SQLiteRemoteClientsAndTabs(db: self.db)
+    }()
+
     lazy var logins: protocol<BrowserLogins, SyncableLogins> = {
         return MockLogins(files: self.files)
     }()
@@ -144,5 +148,8 @@ public class MockProfile: Profile {
 
     func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>> {
         return deferResult([])
+    }
+
+    func sendItems(items: [ShareItem], toClients clients: [RemoteClient]) {
     }
 }

--- a/ClientTests/ProfileTest.swift
+++ b/ClientTests/ProfileTest.swift
@@ -4,6 +4,8 @@
 
 import Foundation
 import XCTest
+import Storage
+import Shared
 
 /*
  * A base test type for tests that need a profile.

--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -47,8 +47,8 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
     func clientPickerViewController(clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
         // TODO: hook up Send Tab via Sync.
         // profile?.clients.sendItem(self.sharedItem!, toClients: clients)
-        for client in clients {
-            println("Sending tab to \(client.name)")
+        if let item = sharedItem {
+            self.profile.sendItems([item], toClients: clients)
         }
         finish()
     }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -133,6 +133,8 @@ protocol Profile {
     func getClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>>
     func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>>
 
+    func sendItems(items: [ShareItem], toClients clients: [RemoteClient])
+
     var syncManager: SyncManager { get }
 }
 
@@ -275,6 +277,14 @@ public class BrowserProfile: Profile {
 
     public func getCachedClientsAndTabs() -> Deferred<Result<[ClientAndTabs]>> {
         return self.remoteClientsAndTabs.getClientsAndTabs()
+    }
+
+
+    public func sendItems(items: [ShareItem], toClients clients: [RemoteClient]) {
+        let commands = items.map { item in
+            SyncCommand.fromShareItem(item, withAction: "displayURI")
+        }
+        self.remoteClientsAndTabs.insertCommands(commands, forClients: clients)
     }
 
     lazy var logins: protocol<BrowserLogins, SyncableLogins> = {

--- a/Storage/RemoteTabs.swift
+++ b/Storage/RemoteTabs.swift
@@ -30,7 +30,7 @@ public func ==(lhs: ClientAndTabs, rhs: ClientAndTabs) -> Bool {
            (lhs.tabs == rhs.tabs)
 }
 
-public protocol RemoteClientsAndTabs {
+public protocol RemoteClientsAndTabs: SyncCommands {
     func wipeClients() -> Deferred<Result<()>>
     func wipeTabs() -> Deferred<Result<()>>
     func getClients() -> Deferred<Result<[RemoteClient]>>

--- a/Storage/SQL/RemoteTabsTable.swift
+++ b/Storage/SQL/RemoteTabsTable.swift
@@ -4,8 +4,10 @@
 
 import Foundation
 
+let TableClients = "clients"
+
 class RemoteClientsTable<T>: GenericTable<RemoteClient> {
-    override var name: String { return "clients" }
+    override var name: String { return TableClients }
     override var version: Int { return 1 }
 
     // TODO: index on guid and last_modified.

--- a/Storage/SQL/SyncCommandsTable.swift
+++ b/Storage/SQL/SyncCommandsTable.swift
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Shared
+
+let TableSyncCommands = "commands"
+
+class SyncCommandsTable<T>: GenericTable<SyncCommand> {
+    override var name: String { return TableSyncCommands }
+    override var version: Int { return 1 }
+
+    override var rows: String { return join(",", [
+        "id INTEGER PRIMARY KEY AUTOINCREMENT",
+        "client_guid TEXT NOT NULL",
+        "value TEXT NOT NULL",
+        ])
+    }
+
+
+    override func getInsertAndArgs(inout item: SyncCommand) -> (String, [AnyObject?])? {
+        var args: [AnyObject?] = [item.clientGUID!, item.value]
+        return ("INSERT INTO \(name) (client_guid, value) VALUES (?, ?)", args)
+    }
+
+    override func getDeleteAndArgs(inout item: SyncCommand?) -> (String, [AnyObject?])? {
+        if let item = item {
+            return ("DELETE FROM \(name) WHERE client_guid = ?", [item.clientGUID!])
+        }
+        return ("DELETE FROM \(name)", [])
+    }
+
+    override var factory: ((row: SDRow) -> SyncCommand)? {
+        return { row -> SyncCommand in
+            return SyncCommand(
+                id: row["command_id"] as? Int,
+                value: row["value"] as! String,
+                clientGUID: row["client_guid"] as? GUID)
+        }
+    }
+
+    override func getQueryAndArgs(options: QueryOptions?) -> (String, [AnyObject?])? {
+        let sql = "SELECT * FROM \(name)"
+        if let opts = options,
+            let filter: AnyObject = options?.filter {
+                let args: [AnyObject?] = ["\(filter)"]
+                switch opts.filterType {
+                case .Guid :
+                    return (sql + " WHERE client_guid = ?", args)
+                case .Id:
+                    return (sql + " WHERE id = ?", args)
+                default:
+                    break
+            }
+        }
+        return (sql, [])
+    }
+}

--- a/Storage/SyncQueue.swift
+++ b/Storage/SyncQueue.swift
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Shared
+
+public struct SyncCommand: Equatable {
+    public let value: String
+    public var commandID: Int?
+    public var clientGUID: GUID?
+
+    let version: String?
+
+    public init(value: String) {
+        self.value = value
+        self.version = nil
+        self.commandID = nil
+        self.clientGUID = nil
+    }
+
+    public init(id: Int, value: String) {
+        self.value = value
+        self.version = nil
+        self.commandID = id
+        self.clientGUID = nil
+    }
+
+    public init(id: Int?, value: String, clientGUID: GUID?) {
+        self.value = value
+        self.version = nil
+        self.clientGUID = clientGUID
+        self.commandID = id
+    }
+
+
+    public static func fromShareItem(shareItem: ShareItem, withAction action: String) -> SyncCommand {
+        let jsonObj: [String: AnyObject] = [
+            "command": action,
+            "args": [shareItem.url, shareItem.title ?? ""]
+        ]
+        return SyncCommand(value: JSON.stringify(jsonObj, pretty: false))
+    }
+
+    public func withClientGUID(clientGUID: String?) -> SyncCommand {
+        return SyncCommand(id: self.commandID, value: self.value, clientGUID: clientGUID)
+    }
+}
+
+public func ==(lhs: SyncCommand, rhs: SyncCommand) -> Bool {
+    return lhs.value == rhs.value
+}
+
+public protocol SyncCommands {
+    func deleteCommands() -> Success
+    func deleteCommands(clientGUID: GUID) -> Success
+
+    func getCommands() -> Deferred<Result<[GUID: [SyncCommand]]>>
+
+    func insertCommand(command: SyncCommand, forClients clients: [RemoteClient]) -> Deferred<Result<Int>>
+    func insertCommands(commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Result<Int>>
+}

--- a/StorageTests/SyncCommandsTests.swift
+++ b/StorageTests/SyncCommandsTests.swift
@@ -1,0 +1,233 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import XCTest
+
+
+func byValue(a: SyncCommand, b: SyncCommand) -> Bool {
+    return a.value < b.value
+}
+
+func byClient(a: RemoteClient, b: RemoteClient) -> Bool{
+    return a.guid! < b.guid!
+}
+
+class SyncCommandsTests: XCTestCase {
+
+
+    var clients: [RemoteClient] = [RemoteClient]()
+    var clientsAndTabs: SQLiteRemoteClientsAndTabs!
+
+    var shareItems = [ShareItem]()
+
+    var multipleCommands: [ShareItem] = [ShareItem]()
+    var wipeCommand: SyncCommand!
+    var db: BrowserDB!
+
+    override func setUp() {
+        let files = MockFiles()
+        files.remove("browser.db")
+        db = BrowserDB(filename: "browser.db", files: files)
+        // create clients
+
+        let now = NSDate.now()
+        let client1GUID = Bytes.generateGUID()
+        let client2GUID = Bytes.generateGUID()
+        let client3GUID = Bytes.generateGUID()
+
+        self.clients.append(RemoteClient(guid: client1GUID, name: "Test client 1", modified: (now - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS"))
+        self.clients.append(RemoteClient(guid: client2GUID, name: "Test client 2", modified: (now - OneHourInMilliseconds), type: "desktop", formfactor: "laptop", os: "Darwin"))
+        self.clients.append(RemoteClient(guid: client3GUID, name: "Test local client", modified: (now - OneMinuteInMilliseconds), type: "mobile", formfactor: "largetablet", os: "iOS"))
+        clientsAndTabs = SQLiteRemoteClientsAndTabs(db: db)
+        clientsAndTabs.insertOrUpdateClients(clients)
+
+        shareItems.append(ShareItem(url: "http://mozilla.com", title: "Mozilla", favicon: nil))
+        shareItems.append(ShareItem(url: "http://slashdot.org", title: "Slashdot", favicon: nil))
+        shareItems.append(ShareItem(url: "http://news.bbc.co.uk", title: "BBC News", favicon: nil))
+        shareItems.append(ShareItem(url: "http://news.bbc.co.uk", title: nil, favicon: nil))
+
+        wipeCommand = SyncCommand(value: "{'command':'wipeAll', 'args':[]}")
+    }
+
+    override func tearDown() {
+        clientsAndTabs.deleteCommands()
+        clientsAndTabs.clear()
+    }
+
+    func testCreateSyncCommandFromShareItem(){
+        let action = "testcommand"
+        let shareItem = shareItems[0]
+        let syncCommand = SyncCommand.fromShareItem(shareItem, withAction: action)
+        XCTAssertNil(syncCommand.commandID)
+        XCTAssertNotNil(syncCommand.value)
+        let jsonObj:[String: AnyObject] = [
+            "command": action,
+            "args": [shareItem.url, shareItem.title ?? ""]
+        ]
+        XCTAssertEqual(JSON.stringify(jsonObj, pretty: false), syncCommand.value)
+    }
+
+    func testInsertWithNoURLOrTitle() {
+        // Test insert command to table for
+        let e = self.expectationWithDescription("Insert.")
+        clientsAndTabs.insertCommand(self.wipeCommand, forClients: clients).upon {
+            XCTAssertTrue($0.isSuccess)
+            XCTAssertEqual(3, $0.successValue!)
+
+            var error2: NSError? = nil
+            let commandCursor = self.db.withReadableConnection(&error2) { (connection, err) -> Cursor<Int> in
+                let select = "SELECT COUNT(*) FROM \(TableSyncCommands)"
+                return connection.executeQuery(select, factory: IntFactory, withArgs: nil)
+            }
+            XCTAssertNil(error2)
+            XCTAssertNotNil(commandCursor[0])
+            XCTAssertEqual(3, commandCursor[0]!)
+            e.fulfill()
+        }
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testInsertWithURLOnly() {
+        let action = "testcommand"
+        let shareItem = shareItems[3]
+        let syncCommand = SyncCommand.fromShareItem(shareItem, withAction: action)
+
+        let e = self.expectationWithDescription("Insert.")
+        clientsAndTabs.insertCommand(syncCommand, forClients: clients).upon {
+            XCTAssertTrue($0.isSuccess)
+            XCTAssertEqual(3, $0.successValue!)
+
+            var error: NSError? = nil
+            let commandCursor = self.db.withReadableConnection(&error) { (connection, err) -> Cursor<Int> in
+                let select = "SELECT COUNT(*) FROM \(TableSyncCommands)"
+                return connection.executeQuery(select, factory: IntFactory, withArgs: nil)
+            }
+            XCTAssertNil(error)
+            XCTAssertNotNil(commandCursor[0])
+            XCTAssertEqual(3, commandCursor[0]!)
+            e.fulfill()
+        }
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testInsertWithMultipleCommands() {
+        let action = "testcommand"
+        let e = self.expectationWithDescription("Insert.")
+        let syncCommands = shareItems.map { item in
+            return SyncCommand.fromShareItem(item, withAction: action)
+        }
+        clientsAndTabs.insertCommands(syncCommands, forClients: clients).upon {
+            XCTAssertTrue($0.isSuccess)
+            XCTAssertEqual(12, $0.successValue!)
+
+            var error: NSError? = nil
+            let commandCursor = self.db.withReadableConnection(&error) { (connection, err) -> Cursor<Int> in
+                let select = "SELECT COUNT(*) FROM \(TableSyncCommands)"
+                return connection.executeQuery(select, factory: IntFactory, withArgs: nil)
+            }
+            XCTAssertNil(error)
+            XCTAssertNotNil(commandCursor[0])
+            XCTAssertEqual(12, commandCursor[0]!)
+            e.fulfill()
+        }
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testGetForAllClients() {
+        let action = "testcommand"
+        let syncCommands = shareItems.map { item in
+            return SyncCommand.fromShareItem(item, withAction: action)
+        }.sorted(byValue)
+        clientsAndTabs.insertCommands(syncCommands, forClients: clients)
+
+        let b = self.expectationWithDescription("Get for invalid client.")
+        clientsAndTabs.getCommands().upon({ result in
+            XCTAssertTrue(result.isSuccess)
+            if let clientCommands = result.successValue {
+                XCTAssertEqual(clientCommands.count, self.clients.count)
+                for client in clientCommands.keys {
+                    XCTAssertEqual(syncCommands, clientCommands[client]!.sorted(byValue))
+                }
+            } else {
+                XCTFail("Expected no commands!")
+            }
+            b.fulfill()
+        })
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testDeleteForValidClient() {
+        let action = "testcommand"
+        let syncCommands = shareItems.map { item in
+            return SyncCommand.fromShareItem(item, withAction: action)
+        }.sorted(byValue)
+
+        var client = self.clients[0]
+        let a = self.expectationWithDescription("delete for client.")
+        let b = self.expectationWithDescription("Get for deleted client.")
+        let c = self.expectationWithDescription("Get for not deleted client.")
+        clientsAndTabs.insertCommands(syncCommands, forClients: clients).upon {
+            XCTAssertTrue($0.isSuccess)
+            XCTAssertEqual(12, $0.successValue!)
+
+            let result = self.clientsAndTabs.deleteCommands(client.guid!).value
+            XCTAssertTrue(result.isSuccess)
+            a.fulfill()
+
+            var error: NSError? = nil
+            let commandCursor = self.db.withReadableConnection(&error) { (connection, err) -> Cursor<Int> in
+                let select = "SELECT COUNT(*) FROM \(TableSyncCommands) WHERE client_guid = '\(client.guid!)'"
+                return connection.executeQuery(select, factory: IntFactory, withArgs: nil)
+            }
+            XCTAssertNil(error)
+            XCTAssertNotNil(commandCursor[0])
+            XCTAssertEqual(0, commandCursor[0]!)
+            b.fulfill()
+
+            client = self.clients[1]
+            let commandCursor2 = self.db.withReadableConnection(&error) { (connection, err) -> Cursor<Int> in
+                let select = "SELECT COUNT(*) FROM \(TableSyncCommands) WHERE client_guid = '\(client.guid!)'"
+                return connection.executeQuery(select, factory: IntFactory, withArgs: nil)
+            }
+            XCTAssertNil(error)
+            XCTAssertNotNil(commandCursor2[0])
+            XCTAssertEqual(4, commandCursor2[0]!)
+            c.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func testDeleteForAllClients() {
+        let action = "testcommand"
+        let syncCommands = shareItems.map { item in
+            return SyncCommand.fromShareItem(item, withAction: action)
+        }
+
+        let a = self.expectationWithDescription("Wipe for all clients.")
+        let b = self.expectationWithDescription("Get for clients.")
+        clientsAndTabs.insertCommands(syncCommands, forClients: clients).upon {
+            XCTAssertTrue($0.isSuccess)
+            XCTAssertEqual(12, $0.successValue!)
+
+            let result = self.clientsAndTabs.deleteCommands().value
+            XCTAssertTrue(result.isSuccess)
+            a.fulfill()
+
+            self.clientsAndTabs.getCommands().upon({ result in
+                XCTAssertTrue(result.isSuccess)
+                if let clientCommands = result.successValue {
+                    XCTAssertEqual(0, clientCommands.count)
+                } else {
+                    XCTFail("Expected no commands!")
+                }
+                b.fulfill()
+            })
+        }
+        
+        self.waitForExpectationsWithTimeout(5, handler: nil)
+    }
+}

--- a/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
+++ b/StorageTests/TestSQLiteRemoteClientsAndTabs.swift
@@ -74,6 +74,14 @@ public class MockRemoteClientsAndTabs: RemoteClientsAndTabs {
     public func getClients() -> Deferred<Result<[RemoteClient]>> {
         return Deferred(value: Result(success: self.clientsAndTabs.map { $0.client }))
     }
+
+    public func deleteCommands() -> Success { return succeed() }
+    public func deleteCommands(clientGUID: GUID) -> Success { return succeed() }
+
+    public func getCommands() -> Deferred<Result<[GUID: [SyncCommand]]>>  { return deferResult([GUID: [SyncCommand]]()) }
+
+    public func insertCommand(command: SyncCommand, forClients clients: [RemoteClient]) -> Deferred<Result<Int>>  { return deferResult(0) }
+    public func insertCommands(commands: [SyncCommand], forClients clients: [RemoteClient]) -> Deferred<Result<Int>>  { return deferResult(0) }
 }
 
 func removeLocalClient(a: ClientAndTabs) -> Bool {

--- a/Utils/DeferredUtils.swift
+++ b/Utils/DeferredUtils.swift
@@ -137,6 +137,17 @@ public func allSucceed(deferreds: Success...) -> Success {
     }
 }
 
+public func allSucceed(deferreds: [Success]) -> Success {
+    return all(deferreds).bind {
+        (results) -> Success in
+        if let failure = find(results, { $0.isFailure }) {
+            return deferResult(failure.failureValue!)
+        }
+
+        return succeed()
+    }
+}
+
 public func chainDeferred<T, U>(a: Deferred<Result<T>>, f: T -> Deferred<Result<U>>) -> Deferred<Result<U>> {
     return a.bind { res in
         if let v = res.successValue {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1104867
* accept tabs sent from extension
* save tabs to database
* on sync, retrieve commands for each client
* send commands to clients
* remove successfully sent commands

Still not entirely happy with this, but it's better than it has been so far.
I really wanted some tests around syncing the clients, but couldn't figure out a good way of doing them. Think we should come back & examine testing in this area in the future.