### PR TITLE
Bug 1177132 - Update shown url if provisional navigation fails

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1590,6 +1590,9 @@ extension BrowserViewController: WKUIDelegate {
     /// Invoked when an error occurs while starting to load data for the main frame.
     func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
         if error.code == Int(CFNetworkErrors.CFURLErrorCancelled.rawValue) {
+            if let browser = tabManager[webView] where browser === tabManager.selectedTab {
+                urlBar.currentURL = browser.displayURL
+            }
             return
         }
 


### PR DESCRIPTION
We should show the old url in some error cases here (i.e. cancels during provisional navigation). Cancels that happen further along can mean that the new page is already showing so we shouldn't do this there. Other provisional failures can result in an error page showing so we also don't want to do this there.