### PR TITLE
Bug 1182184 - Entering text and canceling on about:home doesn't clear URL text

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -293,9 +293,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         active = false
         if editTextField.text.isEmpty {
             editTextField.text = clearedText ?? ""
-        }
-
-        if let url = self.url {
+        } else if let url = self.url {
             highlightDomain()
         } else {
             self.url = nil

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -294,6 +294,12 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         if editTextField.text.isEmpty {
             editTextField.text = clearedText ?? ""
         }
+
+        if let url = self.url {
+            highlightDomain()
+        } else {
+            self.url = nil
+        }
     }
 
     func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
@@ -320,7 +326,6 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
     }
 
     func textFieldDidEndEditing(textField: UITextField) {
-        highlightDomain()
         active = false
         UIView.animateWithDuration(0.1, animations: { () -> Void in
             self.borderLayer.layer.borderColor = self.borderColor


### PR DESCRIPTION
1. added delegate functions to detect if we're on the home page or not
2. if on the home page and we cancel, clear the editTextField