### PR TITLE
Bug 1170915 - Tab thumbnail code doesn't account for reader toolbar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -679,7 +679,12 @@ extension BrowserViewController: URLBarDelegate {
         tabTrayController.modalPresentationStyle = .Custom
 
         if let tab = tabManager.selectedTab {
-            tab.screenshot = screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1)
+            if let readerUnwrapped = readerModeBar {
+                tab.screenshot = self.view.screenshot(CGFloat(0), offset: CGPoint(x: 0, y: -readerUnwrapped.frame.origin.y), quality: CGFloat(0))
+            }
+            else {
+                tab.screenshot = screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1)
+            }
         }
 
         presentViewController(tabTrayController, animated: true, completion: nil)


### PR DESCRIPTION
Hi, the way I tried to fix this bug was by making it so the screenshot would include the reader mode toolbar as well. That way, when the transition from tabTrayController is dismissed and it goes back to the selected tab through the affine transform, the reader mode toolbar portion of the UIImage screenshot ends up exactly where the real reader mode bar should be. The real reader mode bar is not actually there, but to the user, it looks like it's there. The webView portion of the screenshot ends up exactly when a webView would be if there was a reader toolbar enabled. When the showReaderModeBar() and updateViewConstraints() methods eventually get called, the real reader mode bar takes the place of the screenshotted reader mode toolbar. The screenshotted reader mode toolbar disappears when BrowserViewController switches from screenshot to actual webView. Essentially, I tried to give the reader toolbar a temporary placeholder until the browser is finished setting up all of its visual elements.

To do this, I called the screenshot function in UIViewExtensions.swift on BrowserViewController and set the offset to the top of the readerModeBar so it wouldn't show the urlBar.

This process also works anytime the user switches tabs to a reader toolbar enabled tab, not just from a reader toolbar enabled tab to itself like the Bugzilla report said. From one reader enabled tab to another, from a reader disabled tab to a reader enabled tab, from the homePanel tab to a reader enabled tab. The user will never have to see the reader toolbar being rendered because as far as they're concerned, it's already there as soon as the tab is brought into view.