### PR TITLE
Bug 1182151 - Close the db connection when suspended

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -115,6 +115,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidEnterBackground(application: UIApplication) {
         self.profile?.syncManager.endTimedSyncs()
+
+        let taskId = application.beginBackgroundTaskWithExpirationHandler { _ in }
+        self.profile?.shutdown()
+        application.endBackgroundTask(taskId)
     }
 
     private func setUpWebServer(profile: Profile) {

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -48,7 +48,15 @@ public class MockProfile: Profile {
         return name
     }
 
+    func shutdown() {
+        if dbCreated {
+            db.close()
+        }
+    }
+
+    private var dbCreated = false
     lazy var db: BrowserDB = {
+        self.dbCreated = true
         return BrowserDB(filename: "mock.db", files: self.files)
     }()
 

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -325,6 +325,10 @@ extension BrowserDB {
         }
     }
 
+    public func close() {
+        db.close()
+    }
+
     func run(sql: String, withArgs args: Args? = nil) -> Success {
         return self.write(sql, withArgs: args) >>> succeed
     }


### PR DESCRIPTION
Assuming sqlcipher is doing something bad if we keep a connection open, this closes our shared connection when we're suspended. Seems to fix the crashes.