### PR TITLE
Bug 1182612 - Search suggestions engine image does not have accessibility label

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -487,6 +487,8 @@ extension SearchViewController: UITableViewDataSource {
         switch SearchListSection(rawValue: indexPath.section)! {
         case .SearchSuggestions:
             suggestionCell.imageView?.image = searchEngines.defaultEngine.image
+            suggestionCell.imageView?.isAccessibilityElement = true
+            suggestionCell.imageView?.accessibilityLabel = String(format: NSLocalizedString("Search suggestions from %@", tableName: "Search", comment: "Accessibility label for image of default search engine displayed left to the actual search suggestions from the engine. The parameter substituted for \"%@\" is the name of the search engine. E.g.: Search suggestions from Google"), searchEngines.defaultEngine.shortName)
             return suggestionCell
 
         case .BookmarksAndHistory:


### PR DESCRIPTION
[Bug 1182612 - Search suggestions engine image does not have accessibility label](https://bugzilla.mozilla.org/show_bug.cgi?id=1182612)

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)