### PR TITLE
Bug 1158523 - Remove accessibility hint for Reload button

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -50,12 +50,10 @@ public class BrowserToolbarHelper: NSObject {
                 toolbar.stopReloadButton.setImage(ImageStop, forState: .Normal)
                 toolbar.stopReloadButton.setImage(ImageStopPressed, forState: .Highlighted)
                 toolbar.stopReloadButton.accessibilityLabel = NSLocalizedString("Stop", comment: "Accessibility Label for the browser toolbar Stop button")
-                toolbar.stopReloadButton.accessibilityHint = NSLocalizedString("Tap to stop loading the page", comment: "Accessibility hint for the browser toolbar Stop button")
             } else {
                 toolbar.stopReloadButton.setImage(ImageReload, forState: .Normal)
                 toolbar.stopReloadButton.setImage(ImageReloadPressed, forState: .Highlighted)
                 toolbar.stopReloadButton.accessibilityLabel = NSLocalizedString("Reload", comment: "Accessibility Label for the browser toolbar Reload button")
-                toolbar.stopReloadButton.accessibilityHint = NSLocalizedString("Tap to reload the page", comment: "Accessibility hint for the browser toolbar Reload button")
             }
         }
     }
@@ -83,7 +81,6 @@ public class BrowserToolbarHelper: NSObject {
         toolbar.stopReloadButton.setImage(UIImage(named: "reload"), forState: .Normal)
         toolbar.stopReloadButton.setImage(UIImage(named: "reloadPressed"), forState: .Highlighted)
         toolbar.stopReloadButton.accessibilityLabel = NSLocalizedString("Reload", comment: "Accessibility Label for the browser toolbar Reload button")
-        toolbar.stopReloadButton.accessibilityHint = NSLocalizedString("Tap to reload the page", comment: "Accessibility hint for the browser toolbar Reload button")
         toolbar.stopReloadButton.addTarget(self, action: "SELdidClickStopReload", forControlEvents: UIControlEvents.TouchUpInside)
 
         toolbar.shareButton.setImage(UIImage(named: "send"), forState: .Normal)


### PR DESCRIPTION
[Bug 1158523 - Correct accessibility hint for Reload button (non-imperative, Double-tap instead of tap)](https://bugzilla.mozilla.org/show_bug.cgi?id=1158523)

Actually in the end I decided to remove the hint as per the last remark
in the referenced bug report. It is really IMHO not needed (or at least
not more than for the other buttons like back/forward which do not have
a hint set).

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)