### PR TITLE
Bug 1164236 - Pre: provide localizable a11y strings

### DIFF
--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -35,6 +35,10 @@ struct IntroViewControllerUX {
     static let Card2Text = NSLocalizedString("Personalize your Firefox just the way you like in Settings.", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
     static let Card3Text = NSLocalizedString("Connect Firefox everywhere you use it.", tableName: "Intro", comment: "See http://mzl.la/1T8gxwo")
 
+    static let Card1ImageLabel = NSLocalizedString("The Show Tabs button is next to the Address and Search text field and displays the current number of open tabs.", tableName: "Intro", comment: "Accessibility label for an image. See http://mzl.la/1T8gxwo")
+    static let Card2ImageLabel = NSLocalizedString("The Settings button is at the beginning of the Tabs Tray.", tableName: "Intro", comment: "Accessibility label for an image. See http://mzl.la/1T8gxwo")
+    static let Card3ImageLabel = NSLocalizedString("Firefox and the cloud", tableName: "Intro", comment: "Accessibility label for an image. See http://mzl.la/1T8gxwo")
+
     static let Card3TextOffsetFromCenter = 10
     static let Card3ButtonOffsetFromCenter = 10
 
@@ -259,6 +263,10 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
 
     func SELlogin() {
 		delegate?.introViewControllerDidRequestToLogin(self)
+    }
+
+    private var accessibilityScrollStatus: String {
+        return String(format: NSLocalizedString("Introductory slide %@ of %@", tableName: "Intro", comment: "String spoken by assistive technology (like VoiceOver) stating on which page of the intro wizard we currently are. E.g. Introductory slide 1 of 3"), NSNumberFormatter.localizedStringFromNumber(pageControl.currentPage+1, numberStyle: .DecimalStyle), NSNumberFormatter.localizedStringFromNumber(IntroViewControllerUX.NumberOfCards, numberStyle: .DecimalStyle))
     }
 
     func scrollViewDidEndDecelerating(scrollView: UIScrollView) {


### PR DESCRIPTION
[Bug 1164236 - Intro View Accessibility](https://bugzilla.mozilla.org/show_bug.cgi?id=1164236)

Because of the imminent string freeze, let's have the localizable
strings that will be probably required for full solution of the bug
available before the freeze. Then, when implementing a11y fixes
themselves later (after the string freeze), we will be able to just use
the already present localizable strings.

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)