### PR TITLE
Bug 1182489 - Regression: LocationView corner radius no longer consistently applied

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -192,7 +192,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
                 make.leading.equalTo(self.lockImageView.snp_trailing).offset(locationContentInset)
             }
             if readerModeButton.hidden {
-                make.trailing.equalTo(container.snp_trailing)
+                make.trailing.equalTo(container.snp_trailing).offset(-(locationContentInset / 2))
             } else {
                 make.trailing.equalTo(self.readerModeButton.snp_leading)
             }


### PR DESCRIPTION
1. updated trailing constraints to have the locationContent offset so that borders don't collide with rounded edges