### PR TITLE
Bug 1182752 - Provide grouping for Switch Control

### DIFF
--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -171,6 +171,8 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
 
         addButtons(backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton)
 
+        accessibilityNavigationStyle = .Combined
+        accessibilityLabel = NSLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")
     }
 
     required init(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -60,6 +60,8 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         buttonContainerView = UIView()
         buttonContainerView.backgroundColor = HomePanelViewControllerUX.BackgroundColor
         buttonContainerView.clipsToBounds = true
+        buttonContainerView.accessibilityNavigationStyle = .Combined
+        buttonContainerView.accessibilityLabel = NSLocalizedString("Panel Chooser", comment: "Accessibility label for the Home panel's top toolbar containing list of the home panels (top sites, bookmarsk, history, remote tabs, reading list).")
         view.addSubview(buttonContainerView)
 
         self.buttonContainerBottomBorderView = UIView()
@@ -121,6 +123,8 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
 
                 let panel = self.panels[index].makeViewController(profile: profile)
                 (panel as! HomePanel).homePanelDelegate = self
+                panel.view.accessibilityNavigationStyle = .Combined
+                panel.view.accessibilityLabel = self.panels[index].accessibilityLabel
                 self.showPanel(panel)
             }
         }


### PR DESCRIPTION
[Bug 1182752 - Provide grouping for Switch Control](https://bugzilla.mozilla.org/show_bug.cgi?id=1182752)

Note that for some very strange (uknown) reason, some home panels (namely
Reading list, Top sites) do not achieve the desired behavior (and some
do, like Bookmarks and History). But let's tackle that later.

If it's too late for new strings, let me know and I will revise the PR to be without the accessibilityLabel's (which would still bring most of the improvement).

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)