### PR TITLE
Bug 1177597 & 1183210 - Search screen does not show on iOS9

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -25,7 +25,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     private var completionActive = false
     private var canAutocomplete = true
-    private var enteredTextLength = 0
+    private var enteredText = ""
+    private var previousSuggestion = ""
     private var notifyTextChanged: (() -> ())? = nil
 
     override init(frame: CGRect) {
@@ -43,7 +44,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         super.addTarget(self, action: "SELtextDidChange:", forControlEvents: UIControlEvents.EditingChanged)
         notifyTextChanged = debounce(0.1, {
             if self.editing {
-                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.text)
+                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.enteredText)
             }
         })
     }
@@ -54,7 +55,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             attributedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(0, count(text)))
             attributedText = attributedString
 
-            enteredTextLength = 0
+            enteredText = ""
             completionActive = true
         }
 
@@ -65,7 +66,9 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private func applyCompletion() {
         if completionActive {
             self.attributedText = NSAttributedString(string: text)
+            enteredText = text
             completionActive = false
+            previousSuggestion = ""
             // This is required to notify the SearchLoader that some text has changed and previous
             // cached query will get updated.
             notifyTextChanged?()
@@ -75,10 +78,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     /// Removes the autocomplete-highlighted text from the field.
     private func removeCompletion() {
         if completionActive {
-            let enteredText = text.substringToIndex(advance(text.startIndex, enteredTextLength, text.endIndex))
-
             // Workaround for stuck highlight bug.
-            if enteredTextLength == 0 {
+            if count(enteredText) == 0 {
                 attributedText = NSAttributedString(string: " ")
             }
 
@@ -90,14 +91,25 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     // `shouldChangeCharactersInRange` is called before the text changes, and SELtextDidChange is called after.
     // Since the text has changed, remove the completion here, and SELtextDidChange will fire the callback to
     // get the new autocompletion.
-
     func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
-        removeCompletion()
-        if completionActive && string.isEmpty {
-            // Characters are being deleted, so clear the autocompletion, but don't change the text.
-            return false
+        if completionActive {
+            if string.isEmpty {
+                // Characters are being deleted, so clear the autocompletion, but don't change the text.
+                removeCompletion()
+                return false
+            }
+            removeCompletionIfRequiredForEnteredString(string)
         }
         return true
+    }
+
+    private func removeCompletionIfRequiredForEnteredString(string: String) {
+        // If user-entered text does not start with previous suggestion then remove the completion.
+        let actualEnteredString = enteredText + string
+        if !previousSuggestion.startsWith(actualEnteredString) {
+            removeCompletion()
+        }
+        enteredText = actualEnteredString
     }
 
     func setAutocompleteSuggestion(suggestion: String?) {
@@ -105,14 +117,17 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).
-            if suggestion.startsWith(text) && count(text) < count(suggestion) {
-                let endingString = suggestion.substringFromIndex(advance(suggestion.startIndex, count(self.text)))
+            if suggestion.startsWith(enteredText) && count(enteredText) < count(suggestion) {
+                let endingString = suggestion.substringFromIndex(advance(suggestion.startIndex, count(enteredText)))
                 let completedAndMarkedString = NSMutableAttributedString(string: suggestion)
-                completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(enteredTextLength, count(endingString)))
+                completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(count(enteredText), count(endingString)))
                 attributedText = completedAndMarkedString
                 completionActive = true
+                previousSuggestion = suggestion
+                return
             }
         }
+        removeCompletion()
     }
 
     func textFieldDidBeginEditing(textField: UITextField) {
@@ -142,15 +157,21 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     func SELtextDidChange(textField: UITextField) {
         canAutocomplete = true
-        enteredTextLength = count(self.text)
+        if completionActive {
+            // Immediately reuse the previous suggestion if it's still valid.
+            setAutocompleteSuggestion(previousSuggestion)
+        } else {
+            // Updates entered text while completion is not active. If it is 
+            // active, enteredText will already be updated from 
+            // removeCompletionIfRequiredForEnteredString.
+            enteredText = text
+        }
         notifyTextChanged?()
     }
 
     override func deleteBackward() {
         canAutocomplete = false
-        removeCompletion()
         super.deleteBackward()
-        enteredTextLength = count(self.text)
     }
 
     override func caretRectForPosition(position: UITextPosition!) -> CGRect {

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -113,7 +113,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     func setAutocompleteSuggestion(suggestion: String?) {
-        if let suggestion = suggestion where editing && canAutocomplete {
+        // Setting the autocomplete suggestion during multi-stage input will break the session since the text
+        // is not fully entered. If `markedTextRange` is nil, that means the multi-stage input is complete, so
+        // it's safe to append the suggestion.
+        if let suggestion = suggestion where editing && canAutocomplete && markedTextRange == nil {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).


### PR DESCRIPTION
In iOS9 due to some bug `UIKeyInput` method `insertText` is not calling.
This commit resolve the issue.