### PR TITLE
Bug 1183174 - URL bar text isnt updated correctly when cancelling

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -293,7 +293,9 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         active = false
         if editTextField.text.isEmpty {
             editTextField.text = clearedText ?? ""
-        } else if let url = self.url {
+        }
+
+        if let url = self.url {
             highlightDomain()
         } else {
             self.url = nil


### PR DESCRIPTION
1. if editTextField.text.isEmpty is true and then I click cancel, it doesn't highlightDomain(), so I broke it out of that if clause