### PR TITLE
Bug 1183353 - URL bar not updated for hostname URLs

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -247,11 +247,7 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
     var url: NSURL? {
         didSet {
             lockImageView.hidden = url?.scheme != "https"
-            if let url = url?.absoluteString {
-            	highlightDomain()
-            } else {
-                editTextField.text = nil
-            }
+            updateTextWithURL()
             setNeedsUpdateConstraints()
         }
     }
@@ -277,8 +273,9 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         }
     }
 
-    private func highlightDomain() {
+    private func updateTextWithURL() {
         if let httplessURL = url?.absoluteStringWithoutHTTPScheme(), let baseDomain = url?.baseDomain() {
+            // Highlight the base domain of the current URL.
             var attributedString = NSMutableAttributedString(string: httplessURL)
             let nsRange = NSMakeRange(0, count(httplessURL))
             attributedString.addAttribute(NSForegroundColorAttributeName, value: BrowserLocationViewUX.BaseURLFontColor, range: nsRange)
@@ -286,6 +283,9 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
             attributedString.addAttribute(UIAccessibilitySpeechAttributePitch, value: NSNumber(double: BrowserLocationViewUX.BaseURLPitch), range: nsRange)
             attributedString.pitchSubstring(baseDomain, withPitch: BrowserLocationViewUX.HostPitch)
             editTextField.attributedText = attributedString
+        } else {
+            // If we're unable to highlight the domain, just use the URL as is.
+            editTextField.text = url?.absoluteString
         }
     }
 
@@ -293,10 +293,8 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         active = false
         if editTextField.text.isEmpty {
             editTextField.text = clearedText ?? ""
-        } else if let url = self.url {
-            highlightDomain()
         } else {
-            self.url = nil
+            updateTextWithURL()
         }
     }
 

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -119,6 +119,11 @@ extension NSURL {
     */
     public func baseDomain() -> String? {
         if let host = self.host {
+            // If this is just a hostname and not a FQDN, use the entire hostname.
+            if !host.contains(".") {
+                return host
+            }
+
             return publicSuffixFromHost(host, withAdditionalParts: 1)
         } else {
             return nil


### PR DESCRIPTION
Writing some tests, I'm running into issues where URLs that use a hostname (as opposed to a FQDN), such as localhost, fail the domain highlighting. As a result, the URL bar doesn't get updated at all.

Looks like there are two bugs here:
 1. The URL bar should highlight for hostnames, and
 2. The URL bar should still update to show the URL, even if the highlight fails.