### PR TITLE
Bug 1183326 - UI tests for URL entry

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1020,6 +1020,13 @@
 			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
 			remoteInfo = Client;
 		};
+		D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0B6544B01A96C59E000DD202 /* SDWebImage.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4A2CADFF1AB4BB5300B6BC39;
+			remoteInfo = WebImage;
+		};
 		E444F8281B4C1E8D00FEB19B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
@@ -1779,6 +1786,7 @@
 				0B6544C21A96C59E000DD202 /* libSDWebImage.a */,
 				0B6544C41A96C59E000DD202 /* libSDWebImage+WebP.a */,
 				0B6544C61A96C59E000DD202 /* libSDWebImage+MKAnnotation.a */,
+				D3B5A0EA1B5459F600C15BCF /* WebImage.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2294,12 +2302,11 @@
 		D39FA1601A83E0EC00EE869C /* UITests */ = {
 			isa = PBXGroup;
 			children = (
-				4F9757391AFA6F37006ECC24 /* readerContent.html */,
-				4F97573A1AFA6F37006ECC24 /* ReaderViewUITests.swift */,
 				D39FA16F1A83E62600EE869C /* UITests-Bridging-Header.h */,
 				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
 				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
 				0B5A93411B1EB572004F47A2 /* readablePage.html */,
+				4F9757391AFA6F37006ECC24 /* readerContent.html */,
 				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
 				D3E171C11A841EAD00AB44CD /* KIFHelper.js */,
 				0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */,
@@ -2307,12 +2314,13 @@
 				D39FA1801A83E84900EE869C /* Global.swift */,
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
 				D39FA1821A83E87900EE869C /* NavigationTests.swift */,
+				4F97573A1AFA6F37006ECC24 /* ReaderViewUITests.swift */,
 				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 				2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */,
 				D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */,
+				744B0FFD1B4F172E00100422 /* ToolbarTests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
-				744B0FFD1B4F172E00100422 /* ToolbarTests.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -3548,6 +3556,13 @@
 			fileType = wrapper.cfbundle;
 			path = SWXMLHashTests.xctest;
 			remoteRef = D38B2D821A8D98380040E6B5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		D3B5A0EA1B5459F600C15BCF /* WebImage.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = WebImage.framework;
+			remoteRef = D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		E4D567B41ADED44A00F1EFE7 /* SQLite.framework */ = {

--- a/UITests/ToolbarTests.swift
+++ b/UITests/ToolbarTests.swift
@@ -82,7 +82,34 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
         // Rotates back to previous orientation
         UIDevice.currentDevice().setValue(previousOrientation, forKey: "orientation")
     }
-    
+
+    func testURLEntry() {
+        let textField = tester().waitForViewWithAccessibilityLabel("Address and Search") as! UITextField
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().enterTextIntoCurrentFirstResponder("foobar")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        XCTAssertEqual(textField.text, "", "Verify that the URL bar text clears on about:home")
+
+        let url = "\(webRoot)/numberedPage.html?page=1"
+
+        // URL without "http://".
+        let displayURL = "\(webRoot)/numberedPage.html?page=1".substringFromIndex(advance(url.startIndex, count("http://")))
+
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().enterTextIntoCurrentFirstResponder("\(url)\n")
+        XCTAssertEqual(textField.text, displayURL, "URL matches page URL")
+
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().enterTextIntoCurrentFirstResponder("foobar")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        XCTAssertEqual(textField.text, displayURL, "Verify that text reverts to page URL after entering text")
+
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromFirstResponder()
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        XCTAssertEqual(textField.text, displayURL, "Verify that text reverts to page URL after clearing text")
+    }
+
     override func tearDown() {
         BrowserUtils.resetToAboutHome(tester())
     }


### PR DESCRIPTION
Created some simple URL entry tests since there seem to be a number of regressions recently. Note that these tests require both [bug 1183353](https://bugzilla.mozilla.org/show_bug.cgi?id=1183353) and [bug 1183174](https://bugzilla.mozilla.org/show_bug.cgi?id=1183174) to pass.