### PR TITLE
Fixes 1145388 - Reading list items not marked as read after viewing

### DIFF
--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -439,6 +439,8 @@ class ReadingListPanel: UITableViewController, HomePanel, SWTableViewCellDelegat
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
         if let record = records?[indexPath.row], encodedURL = ReaderModeUtils.encodeURL(NSURL(string: record.url)!) {
+            // Mark the item as read
+            profile.readingList?.updateRecord(record, unread: false)
             // Reading list items are closest in concept to bookmarks.
             let visitType = VisitType.Bookmark
             homePanelDelegate?.homePanel(self, didSelectURL: encodedURL, visitType: visitType)

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -43,6 +43,26 @@ extension KIFUITestActor {
         return UIAccessibilityElement.viewContainingAccessibilityElement(element)
     }
 
+    /// Wait for and returns a view with the given accessibility label as an
+    /// attributed string. See the comment in ReadingListPanel.swift about
+    /// using attributed strings as labels. (It lets us set the pitch)
+    func waitForViewWithAttributedAccessibilityLabel(label: NSAttributedString) -> UIView {
+        var element: UIAccessibilityElement!
+
+        runBlock { _ in
+            element = UIApplication.sharedApplication().accessibilityElementMatchingBlock { element in
+                if let elementLabel = element.valueForKey("accessibilityLabel") as? NSAttributedString {
+                    return elementLabel.isEqualToAttributedString(label)
+                }
+                return false
+            }
+            
+            return (element == nil) ? KIFTestStepResult.Wait : KIFTestStepResult.Success
+        }
+
+        return UIAccessibilityElement.viewContainingAccessibilityElement(element)
+    }
+
     /// There appears to be a KIF bug where waitForViewWithAccessibilityLabel returns the parent
     /// UITableView instead of the UITableViewCell with the given label.
     /// As a workaround, retry until KIF gives us a cell.

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -52,6 +52,36 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 
+    func testReadingListAutoMarkAsRead() {
+        // Load a page
+        tester().tapViewWithAccessibilityIdentifier("url")
+        let url1 = "\(webRoot)/readablePage.html"
+        tester().clearTextFromAndThenEnterText("\(url1)\n", intoViewWithAccessibilityLabel: "Address and Search")
+        tester().waitForWebViewElementWithAccessibilityLabel("Readable Page")
+
+        // Add it to the reading list
+        tester().tapViewWithAccessibilityLabel("Reader View")
+        tester().tapViewWithAccessibilityLabel("Add to Reading List")
+
+        // Check that it appears in the reading list home panel and make sure it marked as unread
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().tapViewWithAccessibilityLabel("Reading list")
+        tester().waitForViewWithAccessibilityLabel("Readable page, unread, localhost")
+
+        // Tap to open it
+        tester().tapViewWithAccessibilityLabel("Readable page, unread, localhost")
+        tester().waitForWebViewElementWithAccessibilityLabel("Readable page")
+
+        // Go back to the reading list panel
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().tapViewWithAccessibilityLabel("Reading list")
+
+        // Make sure the article is marked as read
+        let labelString = NSMutableAttributedString(string: "Readable page, read, localhost")
+        labelString.addAttribute(UIAccessibilitySpeechAttributePitch, value: NSNumber(float: 0.7), range: NSMakeRange(0, labelString.length))
+        tester().waitForViewWithAttributedAccessibilityLabel(labelString)
+    }
+
     override func tearDown() {
         BrowserUtils.resetToAboutHome(tester())
     }


### PR DESCRIPTION
This patch marks reading list items as read when you open them. This is a very basic start. Let me know via *UI Review* if this is good enough via v1.