### PR TITLE
Fixes 1182200 - Canceled authentication doesn't send result to page

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1359,7 +1359,7 @@ extension BrowserViewController: WKNavigationDelegate {
                         if let credentials = res.successValue {
                             completionHandler(.UseCredential, credentials.credentials)
                         } else {
-                            completionHandler(NSURLSessionAuthChallengeDisposition.CancelAuthenticationChallenge, nil)
+                            completionHandler(NSURLSessionAuthChallengeDisposition.RejectProtectionSpace, nil)
                         }
                     }
                 }


### PR DESCRIPTION
This changes the result of the authentication completion handler to `RejectProtectionSpace` which results in the page showing a Auth Required warning as happens on Desktop.