### PR TITLE
Revert "Bug 1166781 - Update autocomplete field when delete is pressed."

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -130,13 +130,6 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         autocompleteDelegate?.autocompleteTextField(self, didTextChange: self.text)
     }
 
-    override func deleteBackward() {
-        removeCompletion()
-        super.deleteBackward()
-        enteredTextLength = count(self.text)
-        autocompleteDelegate?.autocompleteTextField(self, didTextChange: self.text)
-    }
-
     override func caretRectForPosition(position: UITextPosition!) -> CGRect {
         return completionActive ? CGRectZero : super.caretRectForPosition(position)
     }


### PR DESCRIPTION
Reverts mozilla/firefox-ios#721

Backing out due to regressions.
STR:
 1. Enter "yah" that should autocomplete for "yahoo.com"
 2. Hit backspace twice

"yahoo.com" then gets suggested again. That is, it takes two deletions every time i want to go back a character: one to clear the suggestion, another to actually do the deletion. Note that we want our autocompetion logic to mirror desktop, where show autocomplete suggestions only when entering new characters -- never when deleting them.

Friendly reminder to try running tests -- this PR causes `DomainAutocompleteTests` to fail.