### PR TITLE
Bug 1135885 - Animate transition to editing mode

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -466,7 +466,6 @@ class URLBarView: UIView {
         prepareEditingAnimation(editing)
 
         if animated {
-            self.layoutIfNeeded()
             UIView.animateWithDuration(0.3, delay: 0.0, usingSpringWithDamping: 0.85, initialSpringVelocity: 0.0, options: nil, animations: { _ in
                 self.transitionToEditing(editing)
                 self.layoutIfNeeded()


### PR DESCRIPTION
1. call self.layoutIfNeeded() in the animation instead of outside // it seems to be forcing the subviews to their already transitioned position when starting the transition by editing the url bar.