### PR TITLE
Bug 1183738 - Keyboard State not properly updated

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1166,6 +1166,7 @@ extension BrowserViewController: TabManagerDelegate {
         // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
         // and having multiple views with the same label confuses tests.
         if let wv = previous?.webView {
+            wv.endEditing(true)
             wv.accessibilityLabel = nil
             wv.accessibilityElementsHidden = true
             wv.accessibilityIdentifier = nil


### PR DESCRIPTION
1. The keyboard state persists even when we click the tabs button which is what we don't want; we want to end that activity before navigation out of that tab. To my understanding, that's the only way we navigated out of the tab without updating the webView activity, i.e. keyboard state