### PR TITLE
Fixes 1183205 - Incorrect keyboard height calculation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1009,7 +1009,7 @@ extension BrowserViewController: BrowserDelegate {
             let bars = self.snackBars.subviews
             // if the keyboard is showing then ensure that the snackbars are positioned above it, otherwise position them above the toolbar/view bottom
             if let state = keyboardState {
-                make.bottom.equalTo(-(state.height + 20))
+                make.bottom.equalTo(-(state.intersectionHeightForView(self.view) + 20)) // TODO Why is this 20 here? I don't think that should be here, it leaves a gap between the keyboard and the snackbar
             } else {
                 make.bottom.equalTo(self.toolbar?.snp_top ?? self.view.snp_bottom)
             }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -139,8 +139,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     private func layoutSearchEngineScrollView() {
-        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.height ?? 0
-
+        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
         searchEngineScrollView.snp_remakeConstraints { make in
             make.left.right.equalTo(self.view)
             make.bottom.equalTo(self.view).offset(-keyboardHeight)

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -287,7 +287,7 @@ class FxAContentViewController: UIViewController, WKScriptMessageHandler, WKNavi
 
 extension FxAContentViewController: KeyboardHelperDelegate {
     private func layoutInnerViews() {
-        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.height ?? 0
+        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.webView) ?? 0
 
         self.webView.snp_remakeConstraints { make in
             make.left.right.top.equalTo(self.view)


### PR DESCRIPTION
This patch changes the `KeyboardHelper` to have a `intersectionHeightForView()` method instead of a `height` property.

> Return the height of the keyboard that overlaps with the specified view. This is more accurate than simply using the height of UIKeyboardFrameBeginUserInfoKey since for example on iPad the overlap may be partial or if an external keyboard is attached, the intersection height will be zero. (Even if the height of the *invisible* keyboard will look normal!)

This fixes the case where the FxA login has a abnormal bottom inset on iPad and it also fixes the case where all our views that deal with the keyboard (Search, Snackbar, FxA) have a large bottom inset when a virtual or external keyboard is used.
