### PR TITLE
1183205 - Incorrect keyboard height calculation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1967,6 +1967,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
         }
     }
 
+    func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+    }
+
     func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         keyboardState = nil
         // if we are showing snack bars, adjust them so they are no longer sitting above the keyboard

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -384,6 +384,9 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         animateSearchEnginesWithKeyboard(state)
     }
 
+    func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+    }
+
     func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         animateSearchEnginesWithKeyboard(state)
     }

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -306,6 +306,10 @@ extension FxAContentViewController: KeyboardHelperDelegate {
         animateInnerViewsWithKeyboard(state)
     }
 
+    func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
+        animateInnerViewsWithKeyboard(state)
+    }
+
     func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
         animateInnerViewsWithKeyboard(state)
     }

--- a/Utils/KeyboardHelper.swift
+++ b/Utils/KeyboardHelper.swift
@@ -41,6 +41,7 @@ public struct KeyboardState {
 
 public protocol KeyboardHelperDelegate: class {
     func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState)
+    func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState)
     func keyboardHelper(keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState)
 }
 
@@ -64,8 +65,8 @@ public class KeyboardHelper: NSObject {
      */
     public func startObserving() {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELkeyboardWillShow:", name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELkeyboardDidShow:", name: UIKeyboardDidShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELkeyboardWillHide:", name: UIKeyboardWillHideNotification, object: nil)
-
     }
 
     deinit {
@@ -93,6 +94,15 @@ public class KeyboardHelper: NSObject {
             currentState = KeyboardState(userInfo)
             for weakDelegate in delegates {
                 weakDelegate.delegate?.keyboardHelper(self, keyboardWillShowWithState: currentState!)
+            }
+        }
+    }
+
+    func SELkeyboardDidShow(notification: NSNotification) {
+        if let userInfo = notification.userInfo {
+            currentState = KeyboardState(userInfo)
+            for weakDelegate in delegates {
+                weakDelegate.delegate?.keyboardHelper(self, keyboardDidShowWithState: currentState!)
             }
         }
     }


### PR DESCRIPTION
Second PR for this bug. Introduced a KeyboardHelper delegate method that handles `NSKeyboardDidShow`. This only seems to be needed on iPad.

I tried to make the delegate methods optional but that fails because the protocol and keyboard state are not ObjC compatible. (Only ObjC compatible protocols can be optional). I chose the easy way here and simply added the new (empty) delegate method to the other two places where we use the KeyboardHelper.
