### PR TITLE
Bug 1176709 - ensure correct number of rows are added and removed on history item delete

### DIFF
--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -27,6 +27,7 @@ public class TabsSynchronizer: BaseSingleCollectionSynchronizer, Synchronizer {
                 log.info("Fetching tabs.")
                 func doInsert(record: Record<TabsPayload>) -> Deferred<Result<(Int)>> {
                     let remotes = record.payload.remoteTabs
+                    log.debug("\(remotes)")
                     log.info("Inserting \(remotes.count) tabs for client \(record.id).")
                     return localTabs.insertOrUpdateTabsForClientGUID(record.id, tabs: remotes)
                 }

--- a/Sync/TabsPayload.swift
+++ b/Sync/TabsPayload.swift
@@ -69,6 +69,7 @@ public class TabsPayload: CleartextPayloadJSON {
     // lives in Storage, and Tab is more closely tied to TabsPayload.
 
     var remoteTabs: [RemoteTab] {
+        println(self)
         if let clientGUID = self["id"].asString {
             return optFilter(self["tabs"].asArray!.map({ Tab.remoteTabFromJSON($0, clientGUID: clientGUID) }))
         }

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -12,32 +12,85 @@ class HistoryTests: KIFTestCase {
         webRoot = SimplePageServer.start()
     }
 
+    func addHistoryItemPage(pageNo: Int) -> String {
+        // Load a page
+        tester().tapViewWithAccessibilityIdentifier("url")
+        let url = "\(webRoot)/numberedPage.html?page=\(pageNo)"
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page \(pageNo)")
+        return "Page \(pageNo), \(url)"
+    }
+
+    func addHistoryItems(noOfItemsToAdd: Int) -> [String] {
+        var urls = [String]()
+        for index in 1...noOfItemsToAdd {
+            urls.append(addHistoryItemPage(index))
+        }
+
+        return urls
+    }
+
     /**
      * Tests for listed history visits
      */
     func testHistoryUI() {
-        // Load a page
-        tester().tapViewWithAccessibilityIdentifier("url")
-        let url1 = "\(webRoot)/numberedPage.html?page=1"
-        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url1)\n")
-        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
 
-        // Load a different page
-        tester().tapViewWithAccessibilityIdentifier("url")
-        let url2 = "\(webRoot)/numberedPage.html?page=2"
-        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url2)\n")
-        tester().waitForWebViewElementWithAccessibilityLabel("Page 2")
+        let urls = addHistoryItems(2)
 
         // Check that both appear in the history home panel
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().tapViewWithAccessibilityLabel("History")
 
-        let firstHistoryRow = tester().waitForViewWithAccessibilityLabel("Page 1, \(url1)") as! UITableViewCell
+        let firstHistoryRow = tester().waitForViewWithAccessibilityLabel(urls[0]) as! UITableViewCell
         XCTAssertNotNil(firstHistoryRow.imageView?.image)
-        let secondHistoryRow = tester().waitForViewWithAccessibilityLabel("Page 2, \(url2)") as! UITableViewCell
+        let secondHistoryRow = tester().waitForViewWithAccessibilityLabel(urls[1]) as! UITableViewCell
         XCTAssertNotNil(secondHistoryRow.imageView?.image)
 
         tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    func testDeleteHistoryItemFromSmallList() {
+        // add 2 history items
+        // delete all history items
+
+        let urls = addHistoryItems(2)
+
+        // Check that both appear in the history home panel
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().tapViewWithAccessibilityLabel("History")
+
+        tester().swipeViewWithAccessibilityLabel(urls[0], inDirection: KIFSwipeDirection.Left)
+        tester().tapViewWithAccessibilityLabel("Remove")
+
+        let secondHistoryRow = tester().waitForViewWithAccessibilityLabel(urls[1]) as! UITableViewCell
+        XCTAssertNotNil(secondHistoryRow.imageView?.image)
+
+        if let keyWindow = UIApplication.sharedApplication().keyWindow {
+            XCTAssertNil(keyWindow.accessibilityElementWithLabel(urls[0]), "page 1 should have been deleted")
+        }
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    func testDeleteHistoryItemFromLargeList() {
+        for pageNo in 1...102 {
+            BrowserUtils.addHistoryEntry("Page \(pageNo)", url: NSURL(string: "\(webRoot)/numberedPage.html?page=\(pageNo)")!)
+        }
+        let urlToDelete = "Page \(102), \(webRoot)/numberedPage.html?page=\(102)"
+        let secondToLastUrl = "Page \(101), \(webRoot)/numberedPage.html?page=\(101)"
+
+        tester().tapViewWithAccessibilityLabel("History")
+
+        let firstHistoryRow = tester().waitForViewWithAccessibilityLabel(urlToDelete) as! UITableViewCell
+        tester().swipeViewWithAccessibilityLabel(urlToDelete, inDirection: KIFSwipeDirection.Left)
+        tester().tapViewWithAccessibilityLabel("Remove")
+
+        let secondHistoryRow = tester().waitForViewWithAccessibilityLabel(secondToLastUrl) as! UITableViewCell
+        XCTAssertNotNil(secondHistoryRow.imageView?.image)
+
+        if let keyWindow = UIApplication.sharedApplication().keyWindow {
+            XCTAssertNil(keyWindow.accessibilityElementWithLabel(urlToDelete), "page 102 should have been deleted")
+        }
     }
 
     override func tearDown() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1176709

Previous version did not always calculate the correct number of rows/sections to add or remove causing a crash