### PR TITLE
Bug 1185006 - Regression: Dismiss Reader View toolbar when navigating to a new site

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1293,6 +1293,7 @@ extension BrowserViewController: WKNavigationDelegate {
         if let url = webView.URL {
             if !ReaderModeUtils.isReaderModeURL(url) {
                 urlBar.updateReaderModeState(ReaderModeState.Unavailable)
+                hideReaderModeBar(animated: false)
             }
         }
     }


### PR DESCRIPTION
1. copy pasted the code for how didSelectedTabChange updated it's Reader Bar state into didFinishNavigation. Should I stub out as separate method?