### PR TITLE
Bug 1185083 - Empty panel, Remote Tabs displays errant cell dividing line

### DIFF
--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -283,6 +283,15 @@ class RemoteTabsPanelErrorDataSource: NSObject, RemoteTabsPanelDataSource {
         return tableView.bounds.height
     }
 
+    func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        // Making the footer height as small as possible because it will disable button tappability if too high.
+        return 1
+    }
+
+    func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         switch error {
         case .NotLoggedIn:


### PR DESCRIPTION
1. Googled some options, turns out what they said was to either made the separators (lines) in the tableView be clear colored, or push a certain cell's separator off the screen. Would not have this problem if the object wasn't a UITableViewCell, but that's what it has to be i think. 
 source: http://stackoverflow.com/questions/8561774/hide-separator-line-on-one-uitableviewcell

