### PR TITLE
Bug 1146356 - Fix order of called scripts in export-locales.sh

### DIFF
--- a/scripts/clean-xliff.py
+++ b/scripts/clean-xliff.py
@@ -3,7 +3,7 @@
 #
 # clean-xliff.py <l10n_folder>
 #
-#  Remove targets from a locale, remove target-language attribute
+# Remove targets from a locale, remove target-language attribute
 #
 
 from glob import glob

--- a/scripts/export-locales.sh
+++ b/scripts/export-locales.sh
@@ -46,7 +46,9 @@ cp /tmp/en.xliff firefox-ios-l10n/en-US/firefox-ios.xliff || exit 1
 
 # Copy the english base back into the templates and clean it up
 cp /tmp/en.xliff firefox-ios-l10n/templates/firefox-ios.xliff || exit 1
-scripts/clean-xliff.py firefox-ios-l10n/templates || exit 1
 
-# Update all locales
+# Update all locales (including 'templates')
 scripts/update-xliff.py firefox-ios-l10n || exit 1
+
+# Clean up /templates removing target-language and translations
+scripts/clean-xliff.py firefox-ios-l10n/templates || exit 1


### PR DESCRIPTION
Completely missed this in review: the script to clean up `/templates` needs to be called *after* the update script, otherwise we’ll get a `target-language=“templates”` (see [fix](http://viewvc.svn.mozilla.org/vc?revision=143451&view=revision) just applied to the export from last Friday).