### PR TITLE
Bug 1183486 - Tapping URL bar causes app to crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -435,9 +435,10 @@ class BrowserViewController: UIViewController {
             homePanelController!.delegate = self
             homePanelController!.url = tabManager.selectedTab?.displayURL
             homePanelController!.view.alpha = 0
-            view.addSubview(homePanelController!.view)
 
             addChildViewController(homePanelController!)
+            view.addSubview(homePanelController!.view)
+            homePanelController!.didMoveToParentViewController(self)
         }
 
         var panelNumber = tabManager.selectedTab?.url?.fragment
@@ -465,6 +466,7 @@ class BrowserViewController: UIViewController {
                 controller.view.alpha = 0
             }, completion: { finished in
                 if finished {
+                    controller.willMoveToParentViewController(nil)
                     controller.view.removeFromSuperview()
                     controller.removeFromParentViewController()
                     self.homePanelController = nil
@@ -506,6 +508,7 @@ class BrowserViewController: UIViewController {
 
         searchLoader.addListener(searchController!)
 
+        addChildViewController(searchController!)
         view.addSubview(searchController!.view)
         searchController!.view.snp_makeConstraints { make in
             make.top.equalTo(self.urlBar.snp_bottom)
@@ -515,11 +518,12 @@ class BrowserViewController: UIViewController {
 
         homePanelController?.view?.hidden = true
 
-        addChildViewController(searchController!)
+        searchController!.didMoveToParentViewController(self)
     }
 
     private func hideSearchController() {
         if let searchController = searchController {
+            searchController.willMoveToParentViewController(nil)
             searchController.view.removeFromSuperview()
             searchController.removeFromParentViewController()
             self.searchController = nil

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -136,19 +136,20 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
 
     private func hideCurrentPanel() {
         if let panel = childViewControllers.first as? UIViewController {
+            panel.willMoveToParentViewController(nil)
             panel.view.removeFromSuperview()
             panel.removeFromParentViewController()
         }
     }
 
     private func showPanel(panel: UIViewController) {
+        addChildViewController(panel)
         controllerContainerView.addSubview(panel.view)
         panel.view.snp_makeConstraints { make in
             make.top.equalTo(self.buttonContainerView.snp_bottom)
             make.left.right.bottom.equalTo(self.view)
         }
-
-        addChildViewController(panel)
+        panel.didMoveToParentViewController(self)
     }
 
     func SELtappedButton(sender: UIButton!) {

--- a/Extensions/ShareTo/InitialViewController.swift
+++ b/Extensions/ShareTo/InitialViewController.swift
@@ -89,7 +89,8 @@ class InitialViewController: UIViewController, ShareControllerDelegate {
         self.addChildViewController(shareDialogController)
         shareDialogController.view.setTranslatesAutoresizingMaskIntoConstraints(false)
         self.view.addSubview(shareDialogController.view)
-        
+        shareDialogController.didMoveToParentViewController(self)
+
         // Setup constraints for the dialog. We keep the dialog centered with 16 points of padding on both
         // sides. The dialog grows to max 380 points wide so that it does not look too big on landscape or
         // iPad devices.


### PR DESCRIPTION
I had a hard time reproducing this one but I feel confident that the issue is with the incorrect way we're adding/removing the child view controller. The crash points to L135 in HomePanelViewController where we are supposedly explicitly unwrapping the view controler's view property which is defined as UIView!. From the surface, this doesn't make and sense and leads me to think that the issue lies inside UIViewController's lifecycle and the way it manages it's view property. If we are incorrectly handling the lifecycle on our end there's a good chance that the internals are not correct which causes this strange bug. I followed the Apple docs recommendation on how they do add/remove child view controller callbacks: https://developer.apple.com/library/ios/featuredarticles/ViewControllerPGforiPhoneOS/CreatingCustomContainerViewControllers/CreatingCustomContainerViewControllers.html#//apple_ref/doc/uid/TP40007457-CH18-SW12.