### PR TITLE
Bug 1167970 - Bluetooth Keyboard Shortcuts For Common Actions: New tab

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
 		7BF5A1F01B429CD200EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
 		7BF5A1F11B429CD700EA9DD8 /* SyncCommandsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */; };
+		CE838FC01B5F2254005784AC /* BluetoothKeyboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE838FBF1B5F2254005784AC /* BluetoothKeyboardManager.swift */; };
 		D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D301AAED1A3A55B70078DD1D /* TabTrayController.swift */; };
 		D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D308E4EC1A530A8B00842685 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
@@ -1366,6 +1367,7 @@
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
 		7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncQueue.swift; sourceTree = "<group>"; };
 		7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTests.swift; sourceTree = "<group>"; };
+		CE838FBF1B5F2254005784AC /* BluetoothKeyboardManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothKeyboardManager.swift; sourceTree = "<group>"; };
 		D301AAED1A3A55B70078DD1D /* TabTrayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTrayController.swift; sourceTree = "<group>"; };
 		D308E4E31A5306F500842685 /* SearchEngines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngines.swift; sourceTree = "<group>"; };
 		D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
@@ -2351,6 +2353,7 @@
 				0BF0DBBF1A8598D50039F300 /* TransitionManager.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
+				CE838FBF1B5F2254005784AC /* BluetoothKeyboardManager.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -4103,6 +4106,7 @@
 				0BB5B2891AC0A2B90052877D /* Toolbar.swift in Sources */,
 				D38B2D461A8D96D00040E6B5 /* GCDWebServerURLEncodedFormRequest.m in Sources */,
 				D38B2D4C1A8D96D00040E6B5 /* GCDWebServerErrorResponse.m in Sources */,
+				CE838FC01B5F2254005784AC /* BluetoothKeyboardManager.swift in Sources */,
 				E4CD9F2D1A6DC91200318571 /* BrowserLocationView.swift in Sources */,
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -11,6 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var browserViewController: BrowserViewController!
     weak var profile: BrowserProfile?
     var tabManager: TabManager!
+    let keyboardManager = BluetoothKeyboardManager()
 
     let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
 

--- a/Client/Frontend/Browser/BluetoothKeyboardManager.swift
+++ b/Client/Frontend/Browser/BluetoothKeyboardManager.swift
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+struct BluetoothKeyboardNotification {
+    static let TabTrayDidOpen = "TabTrayDidOpen"
+}
+
+@objc protocol BluetoothKeyboardDelegate : class {
+    optional func openNewTab()
+    optional func testFunc()
+}
+
+class WeakBluetoothKeyboardDelegate {
+    weak var value : BluetoothKeyboardDelegate?
+
+    init (value: BluetoothKeyboardDelegate) {
+        self.value = value
+    }
+
+    func get() -> BluetoothKeyboardDelegate? {
+        return value
+    }
+}
+
+class BluetoothKeyboardManager: NSObject {
+    private var delegates = [WeakBluetoothKeyboardDelegate]()
+
+    func addDelegate(delegate: BluetoothKeyboardDelegate) {
+        assert(NSThread.isMainThread())
+        delegates.append(WeakBluetoothKeyboardDelegate(value: delegate))
+    }
+
+    static var sharedManager: BluetoothKeyboardManager {
+        return (UIApplication.sharedApplication().delegate as! AppDelegate).keyboardManager
+    }
+
+    var keyCommands: [AnyObject]? {
+        get {
+            var commands = [UIKeyCommand]()
+            var commandsSrc: [(input: String, flag: UIKeyModifierFlags)] = []
+
+            commandsSrc = [("", .Command),
+                ("t", .Command),
+                ("n", .Command),
+                ("l", .Command),
+                ("w", .Command),
+                ("r", .Command),
+                (".", .Command),
+                ("+", .Command),
+                ("d", .Command)]
+
+            for cmd in commandsSrc {
+                commands.append(UIKeyCommand(input: cmd.input, modifierFlags: cmd.flag, action: "keyboardPressed:"))
+            }
+
+            return commands
+        }
+    }
+
+    func keyboardPressed(keyCommand: UIKeyCommand) {
+        let input = keyCommand.input
+        let flag = keyCommand.modifierFlags
+
+        var keyboardDelegate = getKeyboardDelegate() // The delegate that will perform the action
+
+        // CMD+key pressed
+        if flag == .Command {
+            switch input {
+            case "t", "n":
+                // New tab
+                keyboardDelegate?.openNewTab?()
+            case "+":
+                // Zoom in reader mode
+                keyboardDelegate?.testFunc?()
+            default:
+                return
+            }
+        }
+    }
+
+    /**
+    Returns the `UIResponder<BluetoothKeyboardDelegate>` that is first responder and should handle
+    the keyboard event received
+    */
+    private func getKeyboardDelegate() -> BluetoothKeyboardDelegate? {
+        for delegate in delegates {
+            if let delegate = delegate.get() as? UIResponder where delegate.isFirstResponder() {
+                if let delegate = delegate as? BluetoothKeyboardDelegate {
+                    return delegate
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -55,6 +55,7 @@ class BrowserViewController: UIViewController {
 
     private let profile: Profile
     private let tabManager: TabManager
+    unowned private let keyboardManager = BluetoothKeyboardManager.sharedManager
 
     // These views wrap the urlbar and toolbar to provide background effects on them
     private var header: UIView!
@@ -99,6 +100,7 @@ class BrowserViewController: UIViewController {
         screenshotHelper = BrowserScreenshotHelper(controller: self)
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
+        keyboardManager.addDelegate(self)
     }
 
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
@@ -109,6 +111,22 @@ class BrowserViewController: UIViewController {
             return UIStatusBarStyle.LightContent
         }
         return UIStatusBarStyle.Default
+    }
+
+    // MARK: Bluetooth Keyboard Shortcuts Setup
+
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
+    override var keyCommands: [AnyObject]? {
+        get {
+            return keyboardManager.keyCommands
+        }
+    }
+
+    func keyboardPressed(keyCommand: UIKeyCommand) {
+        keyboardManager.keyboardPressed(keyCommand)
     }
 
     func shouldShowToolbarForTraitCollection(previousTraitCollection: UITraitCollection) -> Bool {
@@ -688,6 +706,13 @@ class BrowserViewController: UIViewController {
     func openURLInNewTab(url: NSURL) {
         let tab = tabManager.addTab(request: NSURLRequest(URL: url))
         tabManager.selectTab(tab)
+    }
+}
+
+extension BrowserViewController: BluetoothKeyboardDelegate {
+    func openNewTab() {
+        urlBarDidPressTabs(self.urlBar)
+        NSNotificationCenter.defaultCenter().addObserver(self.tabTrayController, selector: "SELdidClickAddTab", name:BluetoothKeyboardNotification.TabTrayDidOpen, object: nil)
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -237,6 +237,8 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
     var addTabButton: UIButton!
     var settingsButton: UIButton!
 
+    unowned private let keyboardManager = BluetoothKeyboardManager.sharedManager
+
     var statusBarFrame: CGRect {
         return UIApplication.sharedApplication().statusBarFrame
     }
@@ -247,11 +249,16 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
         self.view.setNeedsUpdateConstraints()
     }
 
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.accessibilityLabel = NSLocalizedString("Tabs Tray", comment: "Accessibility label for the Tabs Tray view.")
         tabManager.addDelegate(self)
+        keyboardManager.addDelegate(self)
 
         navBar = UIView()
         navBar.backgroundColor = TabTrayControllerUX.BackgroundColor
@@ -437,6 +444,12 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
     }
 }
 
+extension TabTrayController: BluetoothKeyboardDelegate {
+    func openNewTab() {
+        SELdidClickAddTab()
+    }
+}
+
 extension TabTrayController: Transitionable {
     private func getTransitionCell(options: TransitionOptions, browser: Browser?) -> CustomCell {
         var transitionCell: CustomCell
@@ -540,6 +553,12 @@ extension TabTrayController: Transitionable {
     }
 
     func transitionableWillComplete(transitionable: Transitionable, options: TransitionOptions) {
+        // Transitioning to tab tray
+        if options.toView == self {
+            NSNotificationCenter.defaultCenter().postNotificationName(BluetoothKeyboardNotification.TabTrayDidOpen, object: nil)
+            NSNotificationCenter.defaultCenter().removeObserver(self, name: BluetoothKeyboardNotification.TabTrayDidOpen, object: nil)
+        }
+
         if let cell = options.moving as? CustomCell {
             cell.removeFromSuperview()
 


### PR DESCRIPTION
This is the groundwork to handle Bluetooth Keyboard shortcuts. I only implemented the `New tab` shortcut on purpose, to first validate my approach, then implement the rest of the shortcuts.

Basically, any UIResponder (views and view controllers) can implement a handler for a keyboard event. To do that, it should conform to the BluetoothKeyboardDelegate protocol, declare itself as able to become firstResponder and implement the desired delegate method(s).
For each keyboard event that we support, only the delegate method of the firstResponder BluetoothKeyboardDelegate will be called (if there's any).