### PR TITLE
Bug 1184239 - Refactor URL bar to use separate viewable and editable text fields

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -19,228 +19,13 @@ protocol BrowserLocationViewDelegate {
 private struct BrowserLocationViewUX {
     static let HostFontColor = UIColor.blackColor()
     static let BaseURLFontColor = UIColor.lightGrayColor()
-    static let DefaultURLColor = UIColor.blackColor()
     static let BaseURLPitch = 0.75
     static let HostPitch = 1.0
+    static let LocationContentInset = 8
 }
 
-enum InputMode {
-    case URL
-    case Search
-}
-
-class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDelegate {
+class BrowserLocationView: UIView {
     var delegate: BrowserLocationViewDelegate?
-    var inputMode: InputMode = .URL
-    private var borderLayer: UIView!
-    private var lockImageView: UIImageView!
-    private var readerModeButton: ReaderModeButton!
-    var editTextField: ToolbarTextField!
-
-    private var editTextFieldListenerView: UIView!
-
-    var cornerRadius: CGFloat {
-        get {
-            return self.layer.cornerRadius
-        }
-        set(newCornerRadius) {
-            self.layer.cornerRadius = newCornerRadius
-            // need to add borderWidth to the borderLayer radius so the corners nest properly, because it is offset outside this view
-            borderLayer.layer.cornerRadius = newCornerRadius + self.borderWidth
-        }
-    }
-
-    var editingBorderColor: CGColorRef!
-    var borderColor: CGColorRef! {
-        didSet {
-            if !editTextField.isFirstResponder(){
-                borderLayer.layer.borderColor = borderColor
-            }
-        }
-    }
-
-    var borderWidth: CGFloat {
-        get {
-            return borderLayer.layer.borderWidth
-        }
-
-        set (newBorderWidth) {
-            borderLayer.layer.borderWidth = newBorderWidth
-        }
-    }
-
-    var locationContentInset: CGFloat = 0
-
-    var text: String {
-        get {
-            return editTextField.text
-        }
-        set(newText) {
-            editTextField.text = newText
-            editTextField.becomeFirstResponder()
-        }
-    }
-
-    var autocompleteDelegate: AutocompleteTextFieldDelegate? {
-        get {
-            return editTextField.autocompleteDelegate
-        }
-        set (delegate) {
-            editTextField.autocompleteDelegate = delegate
-        }
-    }
-
-    var readerModeButtonWidthConstraint: NSLayoutConstraint?
-
-    var active = false {
-        didSet{
-            if !active
-                && editTextField.isFirstResponder() {
-                    editTextField.resignFirstResponder()
-            }
-        }
-    }
-
-    static var PlaceholderText: NSAttributedString {
-        let placeholderText = NSLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home")
-        return NSAttributedString(string: placeholderText, attributes: [NSForegroundColorAttributeName: UIColor.grayColor()])
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        self.backgroundColor = UIColor.whiteColor()
-        borderColor = UIColor.clearColor().CGColor
-        editingBorderColor = UIColor.clearColor().CGColor
-
-        borderLayer = UIView()
-        addSubview(borderLayer)
-
-        editTextField = ToolbarTextField()
-        editTextField.keyboardType = UIKeyboardType.WebSearch
-        editTextField.autocorrectionType = UITextAutocorrectionType.No
-        editTextField.autocapitalizationType = UITextAutocapitalizationType.None
-        editTextField.returnKeyType = UIReturnKeyType.Go
-        editTextField.clearButtonMode = UITextFieldViewMode.WhileEditing
-        editTextField.layer.backgroundColor = UIColor.whiteColor().CGColor
-        editTextField.font = UIConstants.DefaultMediumFont
-        editTextField.isAccessibilityElement = true
-        editTextField.accessibilityActionsSource = self
-        editTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")
-        editTextField.attributedPlaceholder = BrowserLocationView.PlaceholderText
-        editTextField.toolbarTextFieldDelegate = self
-        addSubview(editTextField)
-
-        editTextFieldListenerView = UIView()
-        editTextFieldListenerView.userInteractionEnabled = true
-        editTextFieldListenerView.accessibilityIdentifier = "url"
-        editTextFieldListenerView.accessibilityLabel = NSLocalizedString("URL bar", comment: "Accessibility label for the URL bar")
-        editTextFieldListenerView.backgroundColor = UIColor.clearColor()
-        editTextFieldListenerView.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: "SELlongPressLocation:"))
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: "SELtapLocation:")
-        tapRecognizer.numberOfTapsRequired = 1
-        editTextFieldListenerView.addGestureRecognizer(tapRecognizer)
-        addSubview(editTextFieldListenerView)
-
-        lockImageView = UIImageView(image: UIImage(named: "lock_verified.png"))
-        lockImageView.hidden = true
-        lockImageView.isAccessibilityElement = true
-        lockImageView.accessibilityLabel = NSLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure")
-        addSubview(lockImageView)
-
-        readerModeButton = ReaderModeButton(frame: CGRectZero)
-        readerModeButton.hidden = true
-        readerModeButton.addTarget(self, action: "SELtapReaderModeButton", forControlEvents: .TouchUpInside)
-        readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: "SELlongPressReaderModeButton:"))
-        addSubview(readerModeButton)
-        readerModeButton.isAccessibilityElement = true
-        readerModeButton.accessibilityLabel = NSLocalizedString("Reader View", comment: "Accessibility label for the Reader View button")
-        readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: NSLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list."), target: self, selector: "SELreaderModeCustomAction")]
-
-        accessibilityElements = [editTextFieldListenerView, lockImageView, editTextField, readerModeButton]
-    }
-
-    override func updateConstraints() {
-        super.updateConstraints()
-
-        let container = self
-
-        lockImageView.snp_remakeConstraints { make in
-            make.centerY.equalTo(container)
-            make.leading.equalTo(container).offset(locationContentInset)
-            make.width.equalTo(self.lockImageView.intrinsicContentSize().width)
-        }
-
-        readerModeButton.snp_remakeConstraints { make in
-            make.centerY.equalTo(container)
-            make.trailing.equalTo(self.snp_trailing).offset(-(locationContentInset / 2))
-
-            // We fix the width of the button (to the height of the view) to prevent content
-            // compression when the locationLabel has more text contents than will fit. It
-            // would be nice to do this with a content compression priority but that does
-            // not seem to work.
-            make.width.equalTo(container.snp_height)
-        }
-
-        editTextField.snp_remakeConstraints { make in
-            make.centerY.equalTo(container)
-            make.height.equalTo(container)
-            if lockImageView.hidden {
-                make.leading.equalTo(container).offset(locationContentInset)
-            } else {
-                make.leading.equalTo(self.lockImageView.snp_trailing).offset(locationContentInset)
-            }
-            if readerModeButton.hidden {
-                make.trailing.equalTo(container.snp_trailing).offset(-(locationContentInset / 2))
-            } else {
-                make.trailing.equalTo(self.readerModeButton.snp_leading)
-            }
-        }
-        
-        editTextFieldListenerView.snp_remakeConstraints { make in
-            make.width.equalTo(editTextField.snp_width)
-            make.height.equalTo(editTextField.snp_height)
-            make.center.equalTo(editTextField.snp_center)
-        }
-
-        borderLayer.snp_makeConstraints { make in
-            make.edges.equalTo(container).insets(EdgeInsetsMake(-borderWidth, -borderWidth, -borderWidth, -borderWidth))
-        }
-    }
-
-    required init(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func intrinsicContentSize() -> CGSize {
-        return CGSize(width: 200, height: 28)
-    }
-
-    func SELtapReaderModeButton() {
-        delegate?.browserLocationViewDidTapReaderMode(self)
-    }
-
-    func SELlongPressReaderModeButton(recognizer: UILongPressGestureRecognizer) {
-        if recognizer.state == UIGestureRecognizerState.Began {
-            delegate?.browserLocationViewDidLongPressReaderMode(self)
-        }
-    }
-
-    func SELlongPressLocation(recognizer: UILongPressGestureRecognizer) {
-        if recognizer.state == UIGestureRecognizerState.Began {
-            delegate?.browserLocationViewDidLongPressLocation(self)
-        }
-    }
-
-    func SELtapLocation(recognizer: UITapGestureRecognizer) {
-        if recognizer.state == UIGestureRecognizerState.Ended {
-            editTextFieldListenerView.hidden = true
-            editTextField.becomeFirstResponder()
-        }
-    }
-
-    func SELreaderModeCustomAction() -> Bool {
-        return delegate?.browserLocationViewDidLongPressReaderMode(self) ?? false
-    }
 
     var url: NSURL? {
         didSet {
@@ -271,6 +56,110 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
         }
     }
 
+    lazy var placeholder: NSAttributedString = {
+        let placeholderText = NSLocalizedString("Search or enter address", comment: "The text shown in the URL bar on about:home")
+        return NSAttributedString(string: placeholderText, attributes: [NSForegroundColorAttributeName: UIColor.grayColor()])
+    }()
+
+    lazy var urlTextField: UITextField = {
+        let urlTextField = UITextField()
+        urlTextField.userInteractionEnabled = true
+        let gestureRecognizer = UILongPressGestureRecognizer(target: self, action: "SELlongPressLocation:")
+        gestureRecognizer.delegate = self
+        urlTextField.addGestureRecognizer(gestureRecognizer)
+        urlTextField.delegate = self
+        urlTextField.attributedPlaceholder = self.placeholder
+        urlTextField.accessibilityIdentifier = "url"
+        urlTextField.font = UIConstants.DefaultMediumFont
+        return urlTextField
+    }()
+
+    private lazy var lockImageView: UIImageView = {
+        let lockImageView = UIImageView(image: UIImage(named: "lock_verified.png"))
+        lockImageView.hidden = true
+        lockImageView.isAccessibilityElement = true
+        lockImageView.contentMode = UIViewContentMode.Center
+        lockImageView.accessibilityLabel = NSLocalizedString("Secure connection", comment: "Accessibility label for the lock icon, which is only present if the connection is secure")
+        return lockImageView
+    }()
+
+    private lazy var readerModeButton: ReaderModeButton = {
+        let readerModeButton = ReaderModeButton(frame: CGRectZero)
+        readerModeButton.hidden = true
+        readerModeButton.addTarget(self, action: "SELtapReaderModeButton", forControlEvents: .TouchUpInside)
+        readerModeButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: "SELlongPressReaderModeButton:"))
+        readerModeButton.isAccessibilityElement = true
+        readerModeButton.accessibilityLabel = NSLocalizedString("Reader View", comment: "Accessibility label for the Reader View button")
+        readerModeButton.accessibilityCustomActions = [UIAccessibilityCustomAction(name: NSLocalizedString("Add to Reading List", comment: "Accessibility label for action adding current page to reading list."), target: self, selector: "SELreaderModeCustomAction")]
+        return readerModeButton
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.backgroundColor = UIColor.whiteColor()
+
+        addSubview(urlTextField)
+        addSubview(lockImageView)
+        addSubview(readerModeButton)
+
+        lockImageView.snp_makeConstraints { make in
+            make.leading.centerY.equalTo(self)
+            make.width.equalTo(self.lockImageView.intrinsicContentSize().width + CGFloat(BrowserLocationViewUX.LocationContentInset * 2))
+        }
+
+        readerModeButton.snp_makeConstraints { make in
+            make.trailing.centerY.equalTo(self)
+            make.width.equalTo(self.readerModeButton.intrinsicContentSize().width + CGFloat(BrowserLocationViewUX.LocationContentInset * 2))
+        }
+
+        accessibilityElements = [lockImageView, urlTextField, readerModeButton]
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateConstraints() {
+        urlTextField.snp_remakeConstraints { make in
+            make.top.bottom.equalTo(self)
+
+            if lockImageView.hidden {
+                make.leading.equalTo(self).offset(BrowserLocationViewUX.LocationContentInset)
+            } else {
+                make.leading.equalTo(self.lockImageView.snp_trailing)
+            }
+
+            if readerModeButton.hidden {
+                make.trailing.equalTo(self).offset(-BrowserLocationViewUX.LocationContentInset)
+            } else {
+                make.trailing.equalTo(self.readerModeButton.snp_leading)
+            }
+        }
+
+        super.updateConstraints()
+    }
+
+    func SELtapReaderModeButton() {
+        delegate?.browserLocationViewDidTapReaderMode(self)
+    }
+
+    func SELlongPressReaderModeButton(recognizer: UILongPressGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.Began {
+            delegate?.browserLocationViewDidLongPressReaderMode(self)
+        }
+    }
+
+    func SELlongPressLocation(recognizer: UITapGestureRecognizer) {
+        if recognizer.state == UIGestureRecognizerState.Began {
+            delegate?.browserLocationViewDidLongPressLocation(self)
+        }
+    }
+
+    func SELreaderModeCustomAction() -> Bool {
+        return delegate?.browserLocationViewDidLongPressReaderMode(self) ?? false
+    }
+
     private func updateTextWithURL() {
         if let httplessURL = url?.absoluteStringWithoutHTTPScheme(), let baseDomain = url?.baseDomain() {
             // Highlight the base domain of the current URL.
@@ -280,62 +169,36 @@ class BrowserLocationView : UIView, UIGestureRecognizerDelegate, UITextFieldDele
             attributedString.colorSubstring(baseDomain, withColor: BrowserLocationViewUX.HostFontColor)
             attributedString.addAttribute(UIAccessibilitySpeechAttributePitch, value: NSNumber(double: BrowserLocationViewUX.BaseURLPitch), range: nsRange)
             attributedString.pitchSubstring(baseDomain, withPitch: BrowserLocationViewUX.HostPitch)
-            editTextField.attributedText = attributedString
+            urlTextField.attributedText = attributedString
         } else {
             // If we're unable to highlight the domain, just use the URL as is.
-            editTextField.text = url?.absoluteString
+            urlTextField.text = url?.absoluteString
         }
     }
+}
 
-    func cancel() {
-        active = false
-        updateTextWithURL()
-    }
-
-    func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
+extension BrowserLocationView: UIGestureRecognizerDelegate {
+    // Override the default UILongPressGestureRecognizer to suppress the text zoom magnifier.
+    func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }
 
-    func textFieldDidBeginEditing(textField: UITextField) {
-        active = true
-        textField.textColor = BrowserLocationViewUX.DefaultURLColor
+    // Override the default UILongPressGestureRecognizer to suppress the text zoom magnifier.
+    func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailByGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}
 
-        setNeedsUpdateConstraints()
+extension BrowserLocationView: UITextFieldDelegate {
+    func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
         delegate?.browserLocationViewDidTapLocation(self)
-
-        if inputMode == .URL {
-            textField.text = url?.absoluteString
-        }
-
-        UIView.animateWithDuration(0.1, animations: { () -> Void in
-            self.borderLayer.layer.borderColor = self.editingBorderColor
-            self.readerModeButton.hidden = true
-            self.lockImageView.hidden = true
-            self.setNeedsUpdateConstraints()
-        })
-    }
-
-    func textFieldDidEndEditing(textField: UITextField) {
-        active = false
-        UIView.animateWithDuration(0.1, animations: { () -> Void in
-            self.borderLayer.layer.borderColor = self.borderColor
-            self.readerModeButton.hidden = (self.readerModeButton.readerModeState == ReaderModeState.Unavailable)
-            self.lockImageView.hidden = self.url?.scheme != "https"
-            self.setNeedsUpdateConstraints()
-        })
-        editTextFieldListenerView.hidden = false
-    }
-
-    func longPress(gestureRecognizer: UIGestureRecognizer) {
-        if gestureRecognizer.state == .Began {
-            delegate?.browserLocationViewDidLongPressLocation(self)
-        }
+        return false
     }
 }
 
 extension BrowserLocationView: AccessibilityActionsSource {
     func accessibilityCustomActionsForView(view: UIView) -> [UIAccessibilityCustomAction]? {
-        if view === editTextField {
+        if view === urlTextField {
             return delegate?.browserLocationViewLocationAccessibilityActions(self)
         }
         return nil
@@ -373,53 +236,5 @@ private class ReaderModeButton: UIButton {
                 self.selected = true
             }
         }
-    }
-}
-
-class ToolbarTextField: AutocompleteTextField, UITextFieldDelegate {
-
-    var toolbarTextFieldDelegate: UITextFieldDelegate?
-
-    weak var accessibilityActionsSource: AccessibilityActionsSource?
-    override var accessibilityCustomActions: [AnyObject]! {
-        get {
-            if !editing {
-                return accessibilityActionsSource?.accessibilityCustomActionsForView(self)
-            }
-            return super.accessibilityCustomActions
-        }
-        set {
-            super.accessibilityCustomActions = newValue
-        }
-    }
-
-    override init(frame: CGRect) {
-
-        super.init(frame: frame)
-    }
-
-    required init(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func textFieldDidBeginEditing(textField: UITextField) {
-        super.textFieldDidBeginEditing(textField)
-        toolbarTextFieldDelegate?.textFieldDidBeginEditing?(textField)
-        textField.selectedTextRange = textField.textRangeFromPosition(textField.beginningOfDocument, toPosition: textField.endOfDocument)
-    }
-
-    override func textFieldShouldBeginEditing(textField: UITextField) -> Bool {
-        active = toolbarTextFieldDelegate?.textFieldShouldBeginEditing?(textField) ?? super.textFieldShouldBeginEditing(textField)
-        return active
-    }
-
-    override func textFieldShouldClear(textField: UITextField) -> Bool {
-        let shouldClear = super.textFieldShouldClear(textField)
-        return toolbarTextFieldDelegate?.textFieldShouldClear?(textField) ?? shouldClear
-    }
-
-    override func textFieldDidEndEditing(textField: UITextField) {
-        super.textFieldDidEndEditing(textField)
-        toolbarTextFieldDelegate?.textFieldDidEndEditing?(textField)
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -51,7 +51,6 @@ private struct SearchViewControllerUX {
 protocol SearchViewControllerDelegate: class {
     func searchViewController(searchViewController: SearchViewController, didSelectURL url: NSURL)
     func presentSearchSettingsController()
-    func searchViewControllerWillAppear(searchViewController: SearchViewController)
 }
 
 class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, LoaderListener {
@@ -133,7 +132,6 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        self.searchDelegate?.searchViewControllerWillAppear(self)
         reloadSearchEngines()
         reloadData()
     }

--- a/UITests/ToolbarTests.swift
+++ b/UITests/ToolbarTests.swift
@@ -84,7 +84,7 @@ class ToolbarTests: KIFTestCase, UITextFieldDelegate {
     }
 
     func testURLEntry() {
-        let textField = tester().waitForViewWithAccessibilityLabel("Address and Search") as! UITextField
+        let textField = tester().waitForViewWithAccessibilityIdentifier("url") as! UITextField
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().enterTextIntoCurrentFirstResponder("foobar")
         tester().tapViewWithAccessibilityLabel("Cancel")


### PR DESCRIPTION
Given all of the URL bar regressions, I think we should go back to how we did this before: use separate views for displaying and editing the page URL. Here's a mega-patch that does the following:
* Moves the `AutocompleteTextField` back into `URLBarView`.
* Creates an `inOverlayMode` variable to track whether we're in the panel overlay state. This is different from the `editing` state on a `UITextField` (we don't want to leave the mode just because the field loses focus). I decided to call it "overlay mode" instead of "editing mode" to avoid that confusion.
* Removed lots of unneeded code, and lots of mini-refactorings.

Overall, I'm pretty happy with the changes, but sorry I didn't split this up more. I can try breaking this down into smaller commits if needed.

**257 insertions(+), 398 deletions(-)** -- woohoo!