### PR TITLE
Bug 1161258 - Background color should be white on iPad panels

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
 import SnapKit
 import UIKit
 import Storage        // For VisitType.
@@ -54,8 +55,11 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     override func viewDidLoad() {
         view.backgroundColor = HomePanelViewControllerUX.BackgroundColor
 
-        let blur = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.Light))
-        view.addSubview(blur)
+        let blur: UIVisualEffectView? = DeviceInfo.isBlurSupported() ? UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.Light)) : nil
+
+        if let blur = blur {
+            view.addSubview(blur)
+        }
 
         buttonContainerView = UIView()
         buttonContainerView.backgroundColor = HomePanelViewControllerUX.BackgroundColor
@@ -71,7 +75,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         controllerContainerView = UIView()
         view.addSubview(controllerContainerView)
 
-        blur.snp_makeConstraints { make in
+        blur?.snp_makeConstraints { make in
             make.edges.equalTo(self.view)
         }
 

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
 
 public struct UIConstants {
     static let AboutHomeURL = NSURL(string: "\(WebServer.sharedInstance.base)/about/home/#panel=0")!
@@ -26,7 +27,7 @@ public struct UIConstants {
     static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)
     static let HighlightText = UIColor(red: 42/255, green: 121/255, blue: 213/255, alpha: 1.0)
 
-    static let PanelBackgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.6)
+    static let PanelBackgroundColor = DeviceInfo.isBlurSupported() ? UIColor.whiteColor().colorWithAlphaComponent(0.6) : UIColor.whiteColor()
     static let SeparatorColor = UIColor(rgb: 0xcccccc)
     static let HighlightBlue = UIColor(red:0.3, green:0.62, blue:1, alpha:1)
     static let DestructiveRed = UIColor(red: 255/255, green: 64/255, blue: 0/255, alpha: 1.0)

--- a/Client/Frontend/Widgets/ThumbnailCell.swift
+++ b/Client/Frontend/Widgets/ThumbnailCell.swift
@@ -110,10 +110,10 @@ class ThumbnailCell: UICollectionViewCell {
         return backgroundImage
     }()
 
-    lazy var backgroundEffect: UIVisualEffectView = {
+    lazy var backgroundEffect: UIVisualEffectView? = {
         let blur = UIBlurEffect(style: UIBlurEffectStyle.Light)
         let vib = UIVibrancyEffect(forBlurEffect: blur)
-        return UIVisualEffectView(effect: blur)
+        return DeviceInfo.isBlurSupported() ? UIVisualEffectView(effect: blur) : nil
     }()
 
     lazy var imageWrapper: UIView = {
@@ -142,10 +142,12 @@ class ThumbnailCell: UICollectionViewCell {
 
         contentView.addSubview(imageWrapper)
         imageWrapper.addSubview(backgroundImage)
-        imageWrapper.addSubview(backgroundEffect)
         imageWrapper.addSubview(imageView)
         imageWrapper.addSubview(textWrapper)
         textWrapper.addSubview(textLabel)
+        if let backgroundEffect = backgroundEffect {
+            imageWrapper.addSubview(backgroundEffect)
+        }
         contentView.addSubview(removeButton)
 
         imageWrapper.snp_remakeConstraints({ make in
@@ -156,7 +158,7 @@ class ThumbnailCell: UICollectionViewCell {
             make.top.bottom.left.right.equalTo(self.imageWrapper)
         })
 
-        backgroundEffect.snp_remakeConstraints({ make in
+        backgroundEffect?.snp_remakeConstraints({ make in
             make.top.bottom.left.right.equalTo(self.imageWrapper)
         })
 

--- a/Utils/DeviceInfo.swift
+++ b/Utils/DeviceInfo.swift
@@ -5,6 +5,27 @@
 import UIKit
 
 public class DeviceInfo {
+    // List of device names that don't support advanced visual settings
+    static let lowGraphicsQualityModels = ["iPad", "iPad1,1", "iPhone1,1", "iPhone1,2", "iPhone2,1", "iPhone3,1", "iPhone3,2", "iPhone3,3", "iPod1,1", "iPod2,1", "iPod2,2", "iPod3,1", "iPod4,1", "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4", "iPad3,1", "iPad3,2", "iPad3,3"]
+
+    public static var specificModelName: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+
+        let machine = systemInfo.machine
+        let mirror = reflect(machine)
+        var identifier = ""
+
+        // Parses the string for the model name via NSUTF8StringEncoding, refer to 
+        // http://stackoverflow.com/questions/26028918/ios-how-to-determine-iphone-model-in-swift
+        for i in 0..<mirror.count {
+            if let value = mirror[i].1.value as? Int8 where value != 0 {
+                identifier.append(UnicodeScalar(UInt8(value)))
+            }
+        }
+        return identifier
+    }
+
     public class func appName() -> String {
         let localizedDict = NSBundle.mainBundle().localizedInfoDictionary
         let infoDict = NSBundle.mainBundle().infoDictionary
@@ -34,5 +55,14 @@ public class DeviceInfo {
 
     public class func isSimulator() -> Bool {
         return UIDevice.currentDevice().model.contains("Simulator")
+    }
+
+    public class func isBlurSupported() -> Bool {
+        // We've tried multiple ways to make this change visible on simulators, but we
+        // haven't found a solution that worked:
+        // 1. http://stackoverflow.com/questions/21603475/how-can-i-detect-if-the-iphone-my-app-is-on-is-going-to-use-a-simple-transparen
+        // 2. https://gist.github.com/conradev/8655650
+        // Thus, testing has to take place on actual devices.
+        return !contains(lowGraphicsQualityModels, specificModelName)
     }
 }


### PR DESCRIPTION
1. Checks the specific hardware model name to see if the device supports blur
2. Updates the visual effects accordingly

Please update if we find a better way to detect this support such that the simulators can display the changes since the simulators are all under one "model name" (x86_64).