### PR TITLE
Bug 1187686 - Autocompletion not working after pressing "GO"

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -619,6 +619,7 @@ extension URLBarView: AutocompleteTextFieldDelegate {
     }
 
     func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField) {
+        delegate?.urlBar(self, didEnterText: "")
         autocompleteTextField.highlightAll()
     }
 


### PR DESCRIPTION
Refreshed search query before editing text.