### PR TITLE
Bug 1188086 - Fixed crash when quickly deleting characters in autocomplete queries

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -24,6 +24,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     var autocompleteDelegate: AutocompleteTextFieldDelegate?
 
     private var completionActive = false
+    private var canAutocomplete = true
     private var enteredTextLength = 0
     private var notifyTextChanged: (() -> ())? = nil
 
@@ -93,7 +94,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     func setAutocompleteSuggestion(suggestion: String?) {
-        if let suggestion = suggestion where editing {
+        if let suggestion = suggestion where editing && canAutocomplete {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).
@@ -133,6 +134,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override func insertText(text: String) {
+        canAutocomplete = true
         removeCompletion()
         super.insertText(text)
         enteredTextLength = count(self.text)
@@ -141,6 +143,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     override func deleteBackward() {
+        canAutocomplete = false
+        enteredTextLength = count(self.text)
         removeCompletion()
         super.deleteBackward()
         autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.text)


### PR DESCRIPTION
When quickly typing a character and removing it, the autocomplete query is still running and the crash happens when creating the selection range because enteredTextLength contains the previous value (before removing the character). We shouldn't even autocomplete when the last user action is removing a character, which is why I introduced the `canAutoComplete` property that does the necessary check.