### PR TITLE
Bug 1182673 - Fix SnapKit errors on rotation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -112,10 +112,10 @@ class BrowserViewController: UIViewController {
                previousTraitCollection.horizontalSizeClass != .Regular
     }
 
-    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection) {
+    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator?) {
         let showToolbar = shouldShowFooterForTraitCollection(newCollection)
 
-        urlBar.setShowToolbar(!showToolbar)
+        urlBar.setShowToolbar(!showToolbar, withTransitionCoordinator: coordinator)
         toolbar?.removeFromSuperview()
         toolbar?.browserToolbarDelegate = nil
         footerBackground?.removeFromSuperview()
@@ -144,7 +144,7 @@ class BrowserViewController: UIViewController {
 
     override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
-        updateToolbarStateForTraitCollection(newCollection)
+        updateToolbarStateForTraitCollection(newCollection, withTransitionCoordinator: coordinator)
 
         // WKWebView looks like it has a bug where it doesn't invalidate it's visible area when the user
         // performs a device rotation. Since scrolling calls
@@ -237,8 +237,7 @@ class BrowserViewController: UIViewController {
         scrollController.footer = footer
         scrollController.snackBars = snackBars
 
-        self.updateToolbarStateForTraitCollection(self.traitCollection)
-
+        self.updateToolbarStateForTraitCollection(self.traitCollection, withTransitionCoordinator: nil)
     }
 
     func loadQueuedTabs() {


### PR DESCRIPTION
Ugh, this bug was a bear to fix, and I'm still not sure I'm happy with the result. I think my initial guess was correct, but I couldn't figure a clean way to do this. Basically, when transitioning from portrait -> landscape, we need to wait until the rotation has happened before updating the toolbar (since updating will *show* the toolbar, and we can't show it in portrait), but when transitioning from landscape -> portrait, we need to update it before the rotation (since updating will *hide* the toolbar, and we can't show it in portrait).

Happy to hear any ideas for improving this. The Apple-recommended way is to use multiple view controllers to avoid all these conditional layouts, though that wouldn't be very straightforward either...