### PR TITLE
Bug 1188011 - Clear Private Data makes both toolbars disappear

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -417,7 +417,10 @@ extension TabTrayController: TabManagerDelegate {
         }, completion: { finished in
             if finished {
                 tabManager.selectTab(tabManager[index])
-                self.navigationController?.popViewControllerAnimated(true)
+                // don't pop the tab tray view controller if it is not in the foreground
+                if self.presentedViewController == nil {
+                    self.navigationController?.popViewControllerAnimated(true)
+                }
             }
         })
     }


### PR DESCRIPTION
Only pop tab tray controller on add tab if it is the presented view controller

when in accessibility mode the navigation controller is popped, but when not then even though the pop is called, nothing happens. Therefore I am preventing this from ever occurring.