### PR TITLE
Bug 1187416 - Animate Bookmark star is hidden / progress bar not shown

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -404,7 +404,7 @@ class BrowserViewController: UIViewController {
 
     private func wrapInEffect(view: UIView, parent: UIView, backgroundColor: UIColor?) -> UIView {
         let effect = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.ExtraLight))
-        effect.clipsToBounds = true
+        effect.clipsToBounds = false
         effect.setTranslatesAutoresizingMaskIntoConstraints(false)
         if let background = backgroundColor {
             view.backgroundColor = backgroundColor


### PR DESCRIPTION
Turned clipsToBounds back to off to allow the progress bar/bookmark star to show past the URL bar's bounds