### PR TITLE
Bug 1182673 - Fix SnapKit errors on rotation

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -71,6 +71,9 @@ class BrowserLocationView: UIView {
         self.tapRecognizer.delegate = self
         urlTextField.addGestureRecognizer(self.tapRecognizer)
 
+        // Prevent the field from compressing the toolbar buttons on the 4S in landscape.
+        urlTextField.setContentCompressionResistancePriority(250, forAxis: UILayoutConstraintAxis.Horizontal)
+
         urlTextField.attributedPlaceholder = self.placeholder
         urlTextField.accessibilityIdentifier = "url"
         urlTextField.font = UIConstants.DefaultMediumFont

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -232,7 +232,6 @@ class BrowserViewController: UIViewController {
         scrollController.snackBars = snackBars
 
         self.updateToolbarStateForTraitCollection(self.traitCollection)
-
     }
 
     func loadQueuedTabs() {


### PR DESCRIPTION
What do you think of this alternate fix? By using `lessThanOrEqualTo`, we can set a size without strictly enforcing it when it doesn't fit. This keeps `setShowToolbar` simple without having to forward the coordinator, which I really didn't like.