### PR TITLE
Bug 1167334 - Wait a minimum time period before dismissing login snac…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1090,16 +1090,17 @@ extension BrowserViewController: BrowserDelegate {
     }
 
     func removeBar(bar: SnackBar, animated: Bool) {
-        let index = findSnackbar(bar)!
-        UIView.animateWithDuration(animated ? 0.25 : 0, animations: { () -> Void in
-            bar.hide()
-            self.view.layoutIfNeeded()
-        }) { success in
-            // Really remove the bar
-            self.finishRemovingBar(bar)
+        if let index = findSnackbar(bar) {
+            UIView.animateWithDuration(animated ? 0.25 : 0, animations: { () -> Void in
+                bar.hide()
+                self.view.layoutIfNeeded()
+            }) { success in
+                // Really remove the bar
+                self.finishRemovingBar(bar)
 
-            // Adjust the footer size to only contain the bars
-            self.adjustFooterSize()
+                // Adjust the footer size to only contain the bars
+                self.adjustFooterSize()
+            }
         }
     }
 
@@ -1363,8 +1364,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         let tab: Browser! = tabManager[webView]
-
-        tab.expireSnackbars()
+        tabManager.expireSnackbars()
 
         if let url = webView.URL where !ErrorPageHelper.isErrorPageURL(url) && !AboutUtils.isAboutHomeURL(url) {
             let notificationCenter = NSNotificationCenter.defaultCenter()

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -124,7 +124,7 @@ class LoginsHelper: BrowserHelper {
             browser?.removeSnackbar(snackBar!)
         }
 
-        snackBar = CountdownSnackBar(attrText: promptMessage,
+        snackBar = TimerSnackBar(attrText: promptMessage,
             img: UIImage(named: "lock_verified"),
             buttons: [
                 SnackButton(title: SaveButtonTitle, callback: { (bar: SnackBar) -> Void in
@@ -159,7 +159,7 @@ class LoginsHelper: BrowserHelper {
             browser?.removeSnackbar(snackBar!)
         }
 
-        snackBar = CountdownSnackBar(attrText: promptMessage,
+        snackBar = TimerSnackBar(attrText: promptMessage,
             img: UIImage(named: "lock_verified"),
             buttons: [
                 SnackButton(title: UpdateButtonTitle, callback: { (bar: SnackBar) -> Void in

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -135,6 +135,12 @@ class TabManager : NSObject {
         }
     }
 
+    func expireSnackbars() {
+        for tab in tabs {
+            tab.expireSnackbars()
+        }
+    }
+
     // This method is duplicated to hide the flushToDisk option from consumers.
     func addTab(var request: NSURLRequest! = nil, configuration: WKWebViewConfiguration! = nil) -> Browser {
         return self.addTab(request: request, configuration: configuration, flushToDisk: true, zombie: false)

--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -203,11 +203,15 @@ class SnackBar: UIView {
             make.bottom.equalTo(self.snp_bottom)
             make.left.right.equalTo(self)
             if self.buttonsView.subviews.count > 0 {
-		make.height.equalTo(UIConstants.ToolbarHeight)
+                make.height.equalTo(UIConstants.ToolbarHeight)
             } else {
                 make.height.equalTo(0)
             }
         })
+    }
+
+    var showing: Bool {
+        return alpha != 0 && self.superview != nil
     }
 
     /**
@@ -239,7 +243,8 @@ class SnackBar: UIView {
 
 /**
  * A special version of a snackbar that persists for at least a timeout. After that
- * it will dismiss itself on the next page load.
+ * it will dismiss itself on the next page load where this tab isn't showing. As long as
+ * you stay on the current tab though, it will persist until you interact with it.
  */
 class TimerSnackBar: SnackBar {
     private var prevURL: NSURL? = nil
@@ -272,7 +277,7 @@ class TimerSnackBar: SnackBar {
     }
 
     override func shouldPersist(browser: Browser) -> Bool {
-        if browser.url != prevURL {
+        if !showing {
             return timer != nil
         }
 


### PR DESCRIPTION
…kbars.

This keeps login snackbars around for a minimum of 10seconds, and only hides them if the user interacts with them or they load something in a different tab. I think that matches the Android behavior here:

http://mxr.mozilla.org/mozilla-central/source/mobile/android/components/LoginManagerPrompter.js#173