### PR TITLE
No bug - Add google-breakpad to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,11 @@ DerivedData
 
 Carthage/
 
+ThirdParty/google-breakpad
+
 # Saved Sync credentials for tests.
 signedInUser.json
 
 # Generated config file
 MozBuildID.xcconfig
+


### PR DESCRIPTION
Forgot to add folder to .gitignore so we don't accidentally check it in.