### PR TITLE
Bug 1183257 - Allow storing logins from iframes

### DIFF
--- a/Client/Assets/LoginsHelper.js
+++ b/Client/Assets/LoginsHelper.js
@@ -321,11 +321,12 @@ var LoginManagerContent = {
 
     // Somewhat gross hack - we don't want to show the "remember password"
     // notification on about:accounts for Firefox.
-    var topWin = win.top;
-    if (/^about:accounts($|\?)/i.test(topWin.document.documentURI)) {
-      log("(form submission ignored -- about:accounts)");
-      return;
-    }
+    // XXX: window.top.document throws on iOS, so this isn't worth even trying
+    // var topWin = win.top;
+    // if (/^about:accounts($|\?)/i.test(topWin.document.documentURI)) {
+      // log("(form submission ignored -- about:accounts)");
+      // return;
+    // }
 
     var formSubmitURL = LoginUtils._getActionOrigin(form);
 


### PR DESCRIPTION
This allows storing logins from iframes. We still won't be able to autofill them though, which makes this a bit silly. If you submit invalid data on twitch, they do redirect to the login page, so we should theoretically them fill in there, which is nice. And showing the prompt is nicer than nothing.

Trying to do any routing through the main document to insert logins into the child would mean exposing your credentials to the parent document. I don't think we can safely do that. Maybe with some same-domain checks?