### PR TITLE
Bug 1189548 - Pasting text highlights all of URL bar text

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -204,7 +204,7 @@ class BrowserViewController: UIViewController {
         pasteAction = AccessibleAction(name: NSLocalizedString("Paste", comment: "Paste the URL into the location bar"), handler: { () -> Bool in
             if let pasteboardContents = UIPasteboard.generalPasteboard().string {
                 // Enter overlay mode and fire the text entered callback to make the search controller appear.
-                self.urlBar.enterOverlayMode(pasteboardContents)
+                self.urlBar.enterOverlayMode(pasteboardContents, pasted: true)
                 self.urlBar(self.urlBar, didEnterText: pasteboardContents)
                 return true
             }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -392,10 +392,18 @@ class URLBarView: UIView {
         locationTextField.setAutocompleteSuggestion(suggestion)
     }
 
-    func enterOverlayMode(locationText: String?) {
-        // Copy the current URL to the editable text field, then activate it.
-        locationTextField.text = locationText
-        locationTextField.becomeFirstResponder()
+    func enterOverlayMode(locationText: String?, pasted: Bool) {
+        if pasted {
+            // Clear any existing text, focus the field, then set the actual pasted text.
+            // This avoids highlighting all of the text.
+            locationTextField.text = ""
+            locationTextField.becomeFirstResponder()
+            locationTextField.text = locationText
+        } else {
+            // Copy the current URL to the editable text field, then activate it.
+            locationTextField.text = locationText
+            locationTextField.becomeFirstResponder()
+        }
 
         // Show the overlay mode UI, which includes hiding the locationView and replacing it
         // with the editable locationTextField.
@@ -585,7 +593,7 @@ extension URLBarView: BrowserLocationViewDelegate {
     }
 
     func browserLocationViewDidTapLocation(browserLocationView: BrowserLocationView) {
-        enterOverlayMode(locationView.url?.absoluteString)
+        enterOverlayMode(locationView.url?.absoluteString, pasted: false)
     }
 
     func browserLocationViewDidLongPressLocation(browserLocationView: BrowserLocationView) {
@@ -620,7 +628,6 @@ extension URLBarView: AutocompleteTextFieldDelegate {
     }
 
     func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField) {
-        delegate?.urlBar(self, didEnterText: "")
         autocompleteTextField.highlightAll()
     }
 

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -29,6 +29,13 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private var previousSuggestion = ""
     private var notifyTextChanged: (() -> ())? = nil
 
+    override var text: String! {
+        didSet {
+            // SELtextDidChange is not called when directly setting the text property, so fire it manually.
+            SELtextDidChange(self)
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -16,20 +16,20 @@ class DomainAutocompleteTests: KIFTestCase {
 
         // Basic autocompletion cases.
         tester().enterTextIntoCurrentFirstResponder("w")
-        ensureAutocompletionResult(textField, prefix: "w", completion: "ww.yahoo.com/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "w", completion: "ww.yahoo.com/")
         tester().enterTextIntoCurrentFirstResponder("ww.yahoo.com/")
-        ensureAutocompletionResult(textField, prefix: "www.yahoo.com/", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "www.yahoo.com/", completion: "")
         tester().clearTextFromFirstResponder()
 
         // Test that deleting characters works correctly with autocomplete
         tester().enterTextIntoCurrentFirstResponder("www.yah")
-        ensureAutocompletionResult(textField, prefix: "www.yah", completion: "oo.com/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "www.yah", completion: "oo.com/")
         tester().deleteCharacterFromFirstResponser()
-        ensureAutocompletionResult(textField, prefix: "www.yah", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "www.yah", completion: "")
         tester().deleteCharacterFromFirstResponser()
-        ensureAutocompletionResult(textField, prefix: "www.ya", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "www.ya", completion: "")
         tester().enterTextIntoCurrentFirstResponder("h")
-        ensureAutocompletionResult(textField, prefix: "www.yah", completion: "oo.com/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "www.yah", completion: "oo.com/")
 
         // Delete the entire string, verify the home panels are shown again.
         tester().deleteCharacterFromFirstResponser()
@@ -44,90 +44,52 @@ class DomainAutocompleteTests: KIFTestCase {
 
         // Ensure that the scheme is included in the autocompletion.
         tester().enterTextIntoCurrentFirstResponder("https")
-        ensureAutocompletionResult(textField, prefix: "https", completion: "://foo.bar.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "https", completion: "://foo.bar.baz.org/")
         tester().clearTextFromFirstResponder()
 
         // Multiple subdomains.
         tester().enterTextIntoCurrentFirstResponder("f")
-        ensureAutocompletionResult(textField, prefix: "f", completion: "oo.bar.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "f", completion: "oo.bar.baz.org/")
         tester().clearTextFromFirstResponder()
         tester().enterTextIntoCurrentFirstResponder("b")
-        ensureAutocompletionResult(textField, prefix: "b", completion: "ar.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "b", completion: "ar.baz.org/")
         tester().enterTextIntoCurrentFirstResponder("a")
-        ensureAutocompletionResult(textField, prefix: "ba", completion: "r.baz.org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "ba", completion: "r.baz.org/")
         tester().enterTextIntoCurrentFirstResponder("z")
-        ensureAutocompletionResult(textField, prefix: "baz", completion: ".org/")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "baz", completion: ".org/")
 
         // Non-matches.
         tester().enterTextIntoCurrentFirstResponder("!")
-        ensureAutocompletionResult(textField, prefix: "baz!", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "baz!", completion: "")
         tester().clearTextFromFirstResponder()
 
         // Ensure we don't match against TLDs.
         tester().enterTextIntoCurrentFirstResponder("o")
-        ensureAutocompletionResult(textField, prefix: "o", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "o", completion: "")
         tester().clearTextFromFirstResponder()
 
         // Ensure we don't match other characters.
         tester().enterTextIntoCurrentFirstResponder(".")
-        ensureAutocompletionResult(textField, prefix: ".", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: ".", completion: "")
         tester().clearTextFromFirstResponder()
         tester().enterTextIntoCurrentFirstResponder(":")
-        ensureAutocompletionResult(textField, prefix: ":", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: ":", completion: "")
         tester().clearTextFromFirstResponder()
         tester().enterTextIntoCurrentFirstResponder("/")
-        ensureAutocompletionResult(textField, prefix: "/", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "/", completion: "")
         tester().clearTextFromFirstResponder()
 
         // Ensure we don't match letters that don't start a word.
         tester().enterTextIntoCurrentFirstResponder("a")
-        ensureAutocompletionResult(textField, prefix: "a", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "a", completion: "")
         tester().clearTextFromFirstResponder()
 
         // Ensure we don't match words outside of the domain.
         tester().enterTextIntoCurrentFirstResponder("ding")
-        ensureAutocompletionResult(textField, prefix: "ding", completion: "")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "ding", completion: "")
         tester().clearTextFromFirstResponder()
 
         tester().tapViewWithAccessibilityLabel("Cancel")
-    }
-
-    private func ensureAutocompletionResult(textField: UITextField, prefix: String, completion: String) {
-        // searches are async (and debounced), so we have to wait for the results to appear.
-        tester().runBlock({ (err) -> KIFTestStepResult in
-            (textField.text == prefix + completion) ? KIFTestStepResult.Success : KIFTestStepResult.Wait
-        })
-
-        var range = NSRange()
-        var attribute: AnyObject?
-        let textLength = count(textField.text)
-
-        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, atIndex: 0, effectiveRange: &range)
-
-        if attribute != nil {
-            // If the background attribute exists for the first character, the entire string is highlighted.
-            XCTAssertEqual(prefix, "")
-            XCTAssertEqual(completion, textField.text)
-            return
-        }
-
-        let prefixLength = range.length
-
-        attribute = textField.attributedText!.attribute(NSBackgroundColorAttributeName, atIndex: textLength - 1, effectiveRange: &range)
-
-        if attribute == nil {
-            // If the background attribute exists for the last character, the entire string is not highlighted.
-            XCTAssertEqual(prefix, textField.text)
-            XCTAssertEqual(completion, "")
-            return
-        }
-
-        let completionStartIndex = advance(textField.text.startIndex, prefixLength)
-        let actualPrefix = textField.text.substringToIndex(completionStartIndex)
-        let actualCompletion = textField.text.substringFromIndex(completionStartIndex)
-
-        XCTAssertEqual(prefix, actualPrefix, "Expected prefix matches actual prefix")
-        XCTAssertEqual(completion, actualCompletion, "Expected completion matches actual completion")
     }
 
     override func tearDown() {

--- a/UITests/SearchTests.swift
+++ b/UITests/SearchTests.swift
@@ -71,11 +71,18 @@ class SearchTests: KIFTestCase {
         // Verify that Paste shows the search controller with prompt.
         var promptFound = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
         XCTAssertFalse(promptFound, "Search prompt is not shown")
-        UIPasteboard.generalPasteboard().string = "foobar"
+        UIPasteboard.generalPasteboard().string = "http"
         tester().longPressViewWithAccessibilityIdentifier("url", duration: 1)
         tester().tapViewWithAccessibilityLabel("Paste")
         promptFound = tester().waitForViewWithAccessibilityLabel(LabelPrompt) != nil
         XCTAssertTrue(promptFound, "Search prompt is shown")
+
+        // Verify that Paste triggers an autocompletion, with the correct highlighted portion.
+        let textField = tester().waitForViewWithAccessibilityLabel(LabelAddressAndSearch) as! UITextField
+        let expectedString = "\(webRoot)/"
+        let endingString = expectedString.substringFromIndex(advance(expectedString.startIndex, count("http")))
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "http", completion: endingString)
+
         tester().tapViewWithAccessibilityLabel("Cancel", traits: UIAccessibilityTraitButton)
 
         // Verify that Copy Address copies the text to the clipboard.
@@ -87,9 +94,10 @@ class SearchTests: KIFTestCase {
         // Verify that in-editing Paste shows the search controller with prompt.
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().clearTextFromFirstResponder()
-        tester().tapViewWithAccessibilityLabel(LabelAddressAndSearch)
+        tester().waitForAbsenceOfViewWithAccessibilityLabel(LabelPrompt)
         promptFound = tester().tryFindingViewWithAccessibilityLabel(LabelPrompt, error: nil)
         XCTAssertFalse(promptFound, "Search prompt is not shown")
+        tester().tapViewWithAccessibilityLabel(LabelAddressAndSearch)
         tester().tapViewWithAccessibilityLabel("Paste")
         promptFound = tester().waitForViewWithAccessibilityLabel(LabelPrompt) != nil
         XCTAssertTrue(promptFound, "Search prompt is shown")

--- a/UITests/SearchTests.swift
+++ b/UITests/SearchTests.swift
@@ -76,14 +76,13 @@ class SearchTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Paste")
         promptFound = tester().waitForViewWithAccessibilityLabel(LabelPrompt) != nil
         XCTAssertTrue(promptFound, "Search prompt is shown")
-        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityLabel("Cancel", traits: UIAccessibilityTraitButton)
 
         // Verify that Copy Address copies the text to the clipboard.
         XCTAssertNotEqual(UIPasteboard.generalPasteboard().string!, testURL, "URL is not in clipboard")
         tester().longPressViewWithAccessibilityIdentifier("url", duration: 1)
         tester().tapViewWithAccessibilityLabel("Copy Address")
         XCTAssertEqual(UIPasteboard.generalPasteboard().string!, testURL, "URL is in clipboard")
-        tester().tapViewWithAccessibilityLabel("Cancel")
 
         // Verify that in-editing Paste shows the search controller with prompt.
         tester().tapViewWithAccessibilityIdentifier("url")


### PR DESCRIPTION
I split this up into 4 parts. The first part actually fixes the bug; the next three fix/add tests:

* Part 2 simply extracts `ensureAutocompletionResult` to `BrowserUtils` so we can use it elsewhere.
* Part 3 fixed weird behavior I saw when writing these tests, which is that long-pressing the URL bar causes both the context menu to appear *and* enters editing mode (the latter shouldn't happen). I fixed this by returning `false` for the field's `canBecomeFirstResponder`, then triggering editing mode via a `UITapGestureRecognizer` instead of `textFieldShouldBeginEditing`.
* Part 4 builds on the previous two fixes to create a simple test that verifies that highlighted text after pasting.