### PR TITLE
Bug 1186266 - testDeleteHistoryItemFromLargeList is failing

### DIFF
--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -43,6 +43,22 @@ extension KIFUITestActor {
         return UIAccessibilityElement.viewContainingAccessibilityElement(element)
     }
 
+    /// There appears to be a KIF bug where waitForViewWithAccessibilityLabel returns the parent
+    /// UITableView instead of the UITableViewCell with the given label.
+    /// As a workaround, retry until KIF gives us a cell.
+    /// Open issue: https://github.com/kif-framework/KIF/issues/336
+    func waitForCellWithAccessibilityLabel(label: String) -> UITableViewCell {
+        var cell: UITableViewCell!
+
+        runBlock { _ in
+            let view = self.waitForViewWithAccessibilityLabel(label)
+            cell = view as? UITableViewCell
+            return (cell == nil) ? KIFTestStepResult.Wait : KIFTestStepResult.Success
+        }
+
+        return cell
+    }
+
     /**
      * Finding views by accessibility label doesn't currently work with WKWebView:
      *     https://github.com/kif-framework/KIF/issues/460

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -34,16 +34,15 @@ class HistoryTests: KIFTestCase {
      * Tests for listed history visits
      */
     func testHistoryUI() {
-
         let urls = addHistoryItems(2)
 
         // Check that both appear in the history home panel
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().tapViewWithAccessibilityLabel("History")
 
-        let firstHistoryRow = tester().waitForViewWithAccessibilityLabel(urls[0]) as! UITableViewCell
+        let firstHistoryRow = tester().waitForCellWithAccessibilityLabel(urls[0])
         XCTAssertNotNil(firstHistoryRow.imageView?.image)
-        let secondHistoryRow = tester().waitForViewWithAccessibilityLabel(urls[1]) as! UITableViewCell
+        let secondHistoryRow = tester().waitForCellWithAccessibilityLabel(urls[1])
         XCTAssertNotNil(secondHistoryRow.imageView?.image)
 
         tester().tapViewWithAccessibilityLabel("Cancel")

--- a/UITests/SearchSettingsUITests.swift
+++ b/UITests/SearchSettingsUITests.swift
@@ -31,18 +31,7 @@ class SearchSettingsUITests: KIFTestCase {
 
     // Given that we're at the Search Settings sheet, return the default search engine's name.
     private func getDefaultSearchEngineName() -> String {
-        var view: UIView!
-
-        // There appears to be a KIF bug where waitForViewWithAccessibilityLabel returns the parent
-        // UITableView instead of the UITableViewCell with the given label.
-        // As a workaround, retry until KIF gives us a cell.
-        // Open issue: https://github.com/kif-framework/KIF/issues/336
-        tester().runBlock { _ in
-            view = self.tester().waitForViewWithAccessibilityLabel("Default Search Engine", traits: UIAccessibilityTraitButton)
-            let cell = view as? UITableViewCell
-            return (cell == nil) ? KIFTestStepResult.Wait : KIFTestStepResult.Success
-        }
-
+        let view = tester().waitForCellWithAccessibilityLabel("Default Search Engine")
         return view.accessibilityValue
     }
 


### PR DESCRIPTION
Uses existing workaround from `SearchSettingsUITests` as mentioned in the bug.