### PR TITLE
Bug 1189296 - use fx_ios_v1 instead of fx_desktop_v1 as context arg for FxA

### DIFF
--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -20,7 +20,7 @@ public enum FirefoxAccountConfigurationLabel: String {
 
 /**
  * In the URLs below, service=sync ensures that we always get the keys with signin messages,
- * and context=fx_desktop_v1 opts us in to the Desktop Sync postMessage interface.
+ * and context=fx_ios_v1 opts us in to the Desktop Sync postMessage interface.
  */
 public protocol FirefoxAccountConfiguration {
     init()
@@ -56,9 +56,9 @@ public struct LatestDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
     public let oauthEndpointURL = NSURL(string: "https://oauth-latest.dev.lcip.org")!
     public let profileEndpointURL = NSURL(string: "https://latest.dev.lcip.org/profile")!
 
-    public let signInURL = NSURL(string: "https://latest.dev.lcip.org/signin?service=sync&context=fx_desktop_v1")!
-    public let settingsURL = NSURL(string: "https://latest.dev.lcip.org/settings?context=fx_desktop_v1")!
-    public let forceAuthURL = NSURL(string: "https://latest.dev.lcip.org/force_auth?service=sync&context=fx_desktop_v1")!
+    public let signInURL = NSURL(string: "https://latest.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = NSURL(string: "https://latest.dev.lcip.org/settings?context=fx_ios_v1")!
+    public let forceAuthURL = NSURL(string: "https://latest.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 }
@@ -73,9 +73,9 @@ public struct StableDevFirefoxAccountConfiguration: FirefoxAccountConfiguration 
     public let oauthEndpointURL = NSURL(string: "https://oauth-stable.dev.lcip.org")!
     public let profileEndpointURL = NSURL(string: "https://stable.dev.lcip.org/profile")!
 
-    public let signInURL = NSURL(string: "https://stable.dev.lcip.org/signin?service=sync&context=fx_desktop_v1")!
-    public let settingsURL = NSURL(string: "https://stable.dev.lcip.org/settings?context=fx_desktop_v1")!
-    public let forceAuthURL = NSURL(string: "https://stable.dev.lcip.org/force_auth?service=sync&context=fx_desktop_v1")!
+    public let signInURL = NSURL(string: "https://stable.dev.lcip.org/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = NSURL(string: "https://stable.dev.lcip.org/settings?context=fx_ios_v1")!
+    public let forceAuthURL = NSURL(string: "https://stable.dev.lcip.org/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = StageSync15Configuration()
 }
@@ -90,9 +90,9 @@ public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration
     public let oauthEndpointURL = NSURL(string: "https://oauth.accounts.firefox.com/v1")!
     public let profileEndpointURL = NSURL(string: "https://profile.accounts.firefox.com/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_desktop_v1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_desktop_v1")!
-    public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_desktop_v1")!
+    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
+    public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ProductionSync15Configuration()
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1189296