### PR TITLE
No Bug - Fix broken archive step from Breakpad bug

### DIFF
--- a/breakpad_ios_fix.patch
+++ b/breakpad_ios_fix.patch
@@ -1,6 +1,6 @@
 Index: src/client/ios/Breakpad.h
 ===================================================================
---- src/client/ios/Breakpad.h	(revision 1474)
+--- src/client/ios/Breakpad.h	(revision 1477)
 +++ src/client/ios/Breakpad.h	(working copy)
 @@ -45,7 +45,7 @@
  
@@ -13,7 +13,7 @@ Index: src/client/ios/Breakpad.h
  #define BREAKPAD_OUTPUT_DUMP_FILE   "BreakpadDumpFile"
 Index: src/client/ios/Breakpad.xcodeproj/project.pbxproj
 ===================================================================
---- src/client/ios/Breakpad.xcodeproj/project.pbxproj	(revision 1474)
+--- src/client/ios/Breakpad.xcodeproj/project.pbxproj	(revision 1477)
 +++ src/client/ios/Breakpad.xcodeproj/project.pbxproj	(working copy)
 @@ -11,8 +11,8 @@
  		14569323182CE2C10029C465 /* mach_vm_compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 14569322182CE2C10029C465 /* mach_vm_compat.h */; };
@@ -26,7 +26,7 @@ Index: src/client/ios/Breakpad.xcodeproj/project.pbxproj
  		16C7CCCD147D4A4300776EAD /* Breakpad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16C7C96B147D4A4200776EAD /* Breakpad.mm */; };
  		16C7CDE8147D4A4300776EAD /* ConfigFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 16C7CB9E147D4A4300776EAD /* ConfigFile.h */; };
  		16C7CDE9147D4A4300776EAD /* ConfigFile.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16C7CB9F147D4A4300776EAD /* ConfigFile.mm */; };
-@@ -51,7 +51,7 @@
+@@ -51,14 +51,32 @@
  		16C7CE94147D4A4300776EAD /* md5.h in Headers */ = {isa = PBXBuildFile; fileRef = 16C7CCA5147D4A4300776EAD /* md5.h */; };
  		16C7CEA7147D4A4300776EAD /* string_conversion.cc in Sources */ = {isa = PBXBuildFile; fileRef = 16C7CCB9147D4A4300776EAD /* string_conversion.cc */; };
  		16C7CEA8147D4A4300776EAD /* string_conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 16C7CCBA147D4A4300776EAD /* string_conversion.h */; };
@@ -35,7 +35,32 @@ Index: src/client/ios/Breakpad.xcodeproj/project.pbxproj
  		16C92FAE150DF8330053D7BA /* BreakpadController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16C92FAC150DF8330053D7BA /* BreakpadController.mm */; };
  		1EEEB60F1720821900F7E689 /* simple_string_dictionary.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1EEEB60C1720821900F7E689 /* simple_string_dictionary.cc */; };
  		1EEEB6101720821900F7E689 /* simple_string_dictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EEEB60D1720821900F7E689 /* simple_string_dictionary.h */; };
-@@ -314,9 +314,10 @@
+ 		AA747D9F0F9514B9006C5449 /* Breakpad_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AA747D9E0F9514B9006C5449 /* Breakpad_Prefix.pch */; };
+ 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
++		E677C7CD1B6BEF37003FA9FC /* BreakpadDefines.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16C7C968147D4A4200776EAD /* BreakpadDefines.h */; };
++		E677C7CE1B6BEF37003FA9FC /* BreakpadController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16C92FAB150DF8330053D7BA /* BreakpadController.h */; };
++		E677C7CF1B6BEF37003FA9FC /* Breakpad.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16C7C96A147D4A4200776EAD /* Breakpad.h */; };
+ /* End PBXBuildFile section */
+ 
++/* Begin PBXCopyFilesBuildPhase section */
++		E677C7CC1B6BEF24003FA9FC /* CopyFiles */ = {
++			isa = PBXCopyFilesBuildPhase;
++			buildActionMask = 2147483647;
++			dstPath = "include/$(PRODUCT_NAME)";
++			dstSubfolderSpec = 16;
++			files = (
++				E677C7CD1B6BEF37003FA9FC /* BreakpadDefines.h in CopyFiles */,
++				E677C7CE1B6BEF37003FA9FC /* BreakpadController.h in CopyFiles */,
++				E677C7CF1B6BEF37003FA9FC /* Breakpad.h in CopyFiles */,
++			);
++			runOnlyForDeploymentPostprocessing = 0;
++		};
++/* End PBXCopyFilesBuildPhase section */
++
+ /* Begin PBXFileReference section */
+ 		14569320182CE29F0029C465 /* ucontext_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ucontext_compat.h; sourceTree = "<group>"; };
+ 		14569322182CE2C10029C465 /* mach_vm_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mach_vm_compat.h; sourceTree = "<group>"; };
+@@ -314,9 +332,10 @@
  			isa = PBXHeadersBuildPhase;
  			buildActionMask = 2147483647;
  			files = (
@@ -48,7 +73,7 @@ Index: src/client/ios/Breakpad.xcodeproj/project.pbxproj
  				16C7CDE8147D4A4300776EAD /* ConfigFile.h in Headers */,
  				14569321182CE29F0029C465 /* ucontext_compat.h in Headers */,
  				16C7CDF6147D4A4300776EAD /* breakpad_nlist_64.h in Headers */,
-@@ -338,7 +339,6 @@
+@@ -338,7 +357,6 @@
  				16C7CE94147D4A4300776EAD /* md5.h in Headers */,
  				16C7CEA8147D4A4300776EAD /* string_conversion.h in Headers */,
  				16BFA67014E195E9009704F8 /* ios_exception_minidump_generator.h in Headers */,
@@ -56,25 +81,35 @@ Index: src/client/ios/Breakpad.xcodeproj/project.pbxproj
  				1EEEB6101720821900F7E689 /* simple_string_dictionary.h in Headers */,
  				14569323182CE2C10029C465 /* mach_vm_compat.h in Headers */,
  			);
-@@ -464,6 +464,7 @@
+@@ -354,6 +372,7 @@
+ 				D2AAC07A0554694100DB518D /* Headers */,
+ 				D2AAC07B0554694100DB518D /* Sources */,
+ 				D2AAC07C0554694100DB518D /* Frameworks */,
++				E677C7CC1B6BEF24003FA9FC /* CopyFiles */,
+ 			);
+ 			buildRules = (
+ 			);
+@@ -464,6 +483,8 @@
  					"\"$(SRCROOT)/../mac/gcov\"",
  				);
  				PRODUCT_NAME = Breakpad;
 +				PUBLIC_HEADERS_FOLDER_PATH = Breakpad;
++				SKIP_INSTALL = YES;
  			};
  			name = Debug;
  		};
-@@ -492,6 +493,7 @@
+@@ -492,6 +513,8 @@
  					"\"$(SRCROOT)/../mac/gcov\"",
  				);
  				PRODUCT_NAME = Breakpad;
 +				PUBLIC_HEADERS_FOLDER_PATH = Breakpad;
++				SKIP_INSTALL = YES;
  			};
  			name = Release;
  		};
 Index: src/client/ios/BreakpadController.h
 ===================================================================
---- src/client/ios/BreakpadController.h	(revision 1474)
+--- src/client/ios/BreakpadController.h	(revision 1477)
 +++ src/client/ios/BreakpadController.h	(working copy)
 @@ -32,7 +32,7 @@
  


### PR DESCRIPTION
Archiving builds broke after adding Breakpad because of the way headers are exposed for archive builds vs debug. This patch fixes that by copying the headers into the correct directory for lookup.