### PR TITLE
Bug 1188168 - Bluetooth Keyboard Shortcuts: New tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -107,6 +107,29 @@ class BrowserViewController: UIViewController {
         return UIStatusBarStyle.LightContent
     }
 
+    // MARK: Bluetooth Keyboard Shortcuts
+
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
+    override var keyCommands: [AnyObject]? {
+        get {
+            return [
+                UIKeyCommand(input: "t", modifierFlags: .Command, action: "openNewTab"), // CMD+T
+                UIKeyCommand(input: "b", modifierFlags: .Command, action: "openNewTab") // CMD+N
+            ]
+        }
+    }
+
+    func openNewTab() {
+        if urlBar.textFieldIsFirstResponder(){
+            urlBar.SELdidClickCancel()
+        }
+        let tab = tabManager.addTab()
+        tabManager.selectTab(tab)
+    }
+
     func shouldShowFooterForTraitCollection(previousTraitCollection: UITraitCollection) -> Bool {
         return previousTraitCollection.verticalSizeClass != .Compact &&
                previousTraitCollection.horizontalSizeClass != .Regular

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -265,6 +265,21 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
         collectionView.reloadData()
     }
 
+    // MARK: Bluetooth Keyboard Shortcuts
+
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
+    override var keyCommands: [AnyObject]? {
+        get {
+            return [
+                UIKeyCommand(input: "t", modifierFlags: .Command, action: "SELdidClickAddTab"), // CMD+T
+                UIKeyCommand(input: "b", modifierFlags: .Command, action: "SELdidClickAddTab") // CMD+N
+            ]
+        }
+    }
+
     private func makeConstraints() {
         navBar.snp_makeConstraints { make in
             let topLayoutGuide = self.topLayoutGuide as! UIView

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -69,6 +69,10 @@ class URLBarView: UIView {
         return locationView
     }()
 
+    func textFieldIsFirstResponder() -> Bool {
+        return locationTextField.isFirstResponder()
+    }
+
     private lazy var locationTextField: ToolbarTextField = {
         let locationTextField = ToolbarTextField()
         locationTextField.setTranslatesAutoresizingMaskIntoConstraints(false)

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -624,6 +624,31 @@ class SettingsTableViewController: UITableViewController {
         }
     }
 
+    // MARK: Bluetooth Keyboard Shortcuts
+
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
+    override var keyCommands: [AnyObject]? {
+        get {
+            return [
+                UIKeyCommand(input: "t", modifierFlags: .Command, action: "openNewTab"), // CMD+T
+                UIKeyCommand(input: "b", modifierFlags: .Command, action: "openNewTab") // CMD+N
+            ]
+        }
+    }
+
+    func openNewTab() {
+        navigationController?.dismissViewControllerAnimated(true, completion: {
+            if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
+                let rootNavigationController = appDelegate.rootViewController
+                rootNavigationController.popViewControllerAnimated(true)
+                appDelegate.browserViewController.openNewTab()
+            }
+        })
+    }
+
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let section = settings[indexPath.section]
         if let setting = section[indexPath.row] {


### PR DESCRIPTION
Work in progress, todo:
- When the urlbar textfield is focused, open a new tab after leaveOverlayMode has completed.
- After opening a new tab with the keyboard, autofocus the urlbar textfield

What's done: open new tab from:
- Tab tray
- Any active tab
- Any active tab in edit mode
- Settings

Feedback is welcome.

P.S: Using cmd+b so I can test in the simulator (it's temporary)