### PR TITLE
Bug 1184678 - Regression: Tile defaults missing on about:home after tour

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -376,7 +376,7 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
 
     @objc func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if data.status != .Success {
-            return 0
+            return suggestedSites.count
         }
 
         // If there aren't enough data items to fill the grid, look for items in suggested sites.
@@ -476,7 +476,12 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
 
     subscript(index: Int) -> Site? {
         if data.status != .Success {
-            return nil
+            if index < suggestedSites.count {
+                return suggestedSites[index]
+            }
+            else {
+                return nil
+            }
         }
 
         if index >= data.count {


### PR DESCRIPTION
Fix the suggested site not appeared when there is no browse history. It often appear when the browser.db and all its tables have not been created such as when start the app after install. Because the next time you start app, history sql table has been created, so the bug doesn't appear. 

I have tested on these cases:
1. re-install app in simulator many times to see whether the two suggested websites appeared in TopSitePanel. It works as expected.
2. manually open 12 different websites to fill the TopSitePanel and it works as expected (the two suggested sites disappeared from TopSitePanel).