### PR TITLE
Bug 1187171 - Don't call storeChanges too often on restore

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -26,6 +26,7 @@ class Browser: NSObject {
     var browserDelegate: BrowserDelegate? = nil
     var bars = [SnackBar]()
     var favicons = [Favicon]()
+    var lastExecutedTime: Timestamp?
     var sessionData: SessionData?
 
     var screenshot: UIImage?
@@ -45,6 +46,14 @@ class Browser: NSObject {
                 title: browser.displayTitle,
                 history: history,
                 lastUsed: NSDate.now(),
+                icon: nil)
+        } else if let sessionData = browser.sessionData {
+            let history = sessionData.urls.reverse()
+            return RemoteTab(clientGUID: nil,
+                URL: history[0],
+                title: browser.displayTitle,
+                history: history,
+                lastUsed: sessionData.lastUsedTime,
                 icon: nil)
         }
 
@@ -164,7 +173,7 @@ class Browser: NSObject {
     }
 
     var displayURL: NSURL? {
-        if let url = webView?.URL ?? lastRequest?.URL {
+        if let url = url {
             if ReaderModeUtils.isReaderModeURL(url) {
                 return ReaderModeUtils.decodeURL(url)
             }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1372,6 +1372,7 @@ extension BrowserViewController: WKNavigationDelegate {
             if let visitType = self.getVisitTypeForTab(tab, navigation: navigation)?.rawValue {
                 info["visitType"] = visitType
             }
+            tab.lastExecutedTime = NSDate.now()
             notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
 
             // Fire the readability check. This is here and not in the pageShow event handler in ReaderMode.js anymore

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -4,22 +4,28 @@
 
 import Foundation
 
+import Shared
+
 class SessionData: NSObject, NSCoding {
     let currentPage: Int
     let urls: [NSURL]
+    let lastUsedTime: Timestamp
 
-    init(currentPage: Int, urls: [NSURL]) {
+    init(currentPage: Int, urls: [NSURL], lastUsedTime: Timestamp) {
         self.currentPage = currentPage
         self.urls = urls
+        self.lastUsedTime = lastUsedTime
     }
 
     required init(coder: NSCoder) {
         self.currentPage = coder.decodeObjectForKey("currentPage") as? Int ?? 0
         self.urls = coder.decodeObjectForKey("urls") as? [NSURL] ?? []
+        self.lastUsedTime = UInt64(coder.decodeInt64ForKey("lastUsedTime")) ?? NSDate.now()
     }
 
     func encodeWithCoder(coder: NSCoder) {
         coder.encodeObject(currentPage, forKey: "currentPage")
         coder.encodeObject(urls, forKey: "urls")
+        coder.encodeInt64(Int64(lastUsedTime), forKey: "lastUsedTime")
     }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -298,7 +298,7 @@ extension TabManager {
                     updatedUrlList.append(url.URL)
                 }
                 var currentPage = -forwardList.count
-                self.sessionData = SessionData(currentPage: currentPage, urls: updatedUrlList)
+                self.sessionData = SessionData(currentPage: currentPage, urls: updatedUrlList, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
             } else {
                 self.sessionData = browser.sessionData
             }
@@ -412,7 +412,14 @@ extension TabManager : WKNavigationDelegate {
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         hideNetworkActivitySpinner()
-        storeChanges()
+        // only store changes if this is not an error page
+        // as we current handle tab restore as error page redirects then this ensures that we don't
+        // call storeChanges unnecessarily on startup
+        if let url = webView.URL {
+            if !ErrorPageHelper.isErrorPageURL(url) {
+                storeChanges()
+            }
+        }
     }
 
     func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1187171

Don't call storeChanges if restored tab is error message

While doing this I noticed that when we save remote tabs after restore we only store a record of the one that has loaded, not any of the other tabs that have not been looked at yet. We have this information in the persisted tabs record that we use for restoring so I changed things so that if we haven't loaded a webpage but it exists in the persisted sessionData we create a RemoteTab record for it.