### PR TITLE
Bug 1181716 - localhost pages break after multiple restores

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
 		D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B451B054F8600641031 /* TestAppDelegate.swift */; };
 		D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */; };
+		D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */; };
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CE1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
@@ -1447,6 +1448,7 @@
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D3BE7B451B054F8600641031 /* TestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuroraAppDelegate.swift; sourceTree = "<group>"; };
+		D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreTests.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
 		D3E171C11A841EAD00AB44CD /* KIFHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = KIFHelper.js; sourceTree = "<group>"; };
@@ -2334,6 +2336,7 @@
 				0B5A93211B1EB4C8004F47A2 /* ReadingListTest.swift */,
 				2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */,
 				D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */,
+				D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */,
 				744B0FFD1B4F172E00100422 /* ToolbarTests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
@@ -4051,6 +4054,7 @@
 				D38B2D481A8D96D00040E6B5 /* GCDWebServerURLEncodedFormRequest.m in Sources */,
 				D38B2D331A8D96D00040E6B5 /* GCDWebServerConnection.m in Sources */,
 				D38B2D421A8D96D00040E6B5 /* GCDWebServerFileRequest.m in Sources */,
+				D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */,
 				D38B2D3C1A8D96D00040E6B5 /* GCDWebServerResponse.m in Sources */,
 				7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */,
 				E42475E11AB73B9B00B23D33 /* SWLongPressGestureRecognizer.m in Sources */,

--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -13,6 +13,16 @@
    * error pages so that they will redirect to the correct URLs when loaded.
    */
   (function () {
+      function getRestoreURL(url) {
+          // If the URL is already an internally hosted page, we can restore it directly.
+          if (url.indexOf(document.location.origin) == 0) {
+              return url;
+          }
+
+          // Otherwise, push an error page to trigger a redirect when loaded.
+          return '/errors/error.html?url=' + escape(url);
+      }
+
       var index = document.location.href.search("history");
 
       // Pull the session out of the history query argument. 
@@ -22,11 +32,11 @@
       var currentPage = sessionRestoreComponents['currentPage'];
 
       // First, replace the session restore page (this page) with the first URL to be restored.
-      history.replaceState({}, '', '/errors/error.html?url=' + escape(urlList[0]));
+      history.replaceState({}, "", getRestoreURL(urlList[0]));
 
       // Then push the remaining pages to be restored.
       for (var i = 1; i < urlList.length; i++) {
-          history.pushState({}, '', '/errors/error.html?url=' + escape(urlList[i]));
+          history.pushState({}, '', getRestoreURL(urlList[i]));
       }
 
       // We'll end up at the last page pushed, so set the selected index to the current index in the session history.

--- a/UITests/SessionRestoreTests.swift
+++ b/UITests/SessionRestoreTests.swift
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+import Shared
+
+class SessionRestoreTests: KIFTestCase {
+    private var webRoot: String!
+
+    override func setUp() {
+        webRoot = SimplePageServer.start()
+    }
+
+    func testTabRestore() {
+        let url1 = "\(webRoot)/numberedPage.html?page=1"
+        let url2 = "\(webRoot)/numberedPage.html?page=2"
+        let url3 = "\(webRoot)/numberedPage.html?page=3"
+
+        // Build a session restore URL from the current homepage URL.
+        var jsonDict = [String: AnyObject]()
+        jsonDict["history"] = [url1, url2, url3]
+        jsonDict["currentPage"] = -1
+        let escapedJSON = JSON.stringify(jsonDict, pretty: false).stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet())!
+        let webView = tester().waitForViewWithAccessibilityLabel("Web content") as! WKWebView
+        let restoreURL = NSURL(string: "/about/sessionrestore?history=\(escapedJSON)", relativeToURL: webView.URL!)
+
+        // Enter the restore URL and verify the back/forward history.
+        // After triggering the restore, the session should look like this:
+        //   about:home, page1, *page2*, page3
+        // where page2 is active.
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(restoreURL!.absoluteString!)\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 2")
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().waitForViewWithAccessibilityLabel("Top sites")
+        let canGoBack = tester().tryFindingTappableViewWithAccessibilityLabel("Back", error: nil)
+        XCTAssertFalse(canGoBack, "Reached the beginning of browser history")
+        tester().tapViewWithAccessibilityLabel("Forward")
+        tester().tapViewWithAccessibilityLabel("Forward")
+        tester().tapViewWithAccessibilityLabel("Forward")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 3")
+        let canGoForward = tester().tryFindingTappableViewWithAccessibilityLabel("Forward", error: nil)
+        XCTAssertFalse(canGoBack, "Reached the end of browser history")
+    }
+
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
+}


### PR DESCRIPTION
All restored pages use `/errors/error.html?url=...` URLs, which redirect to the actual URL when that page is activated. We do this because of the same origin policy; `sessionrestore.html` can only use `pushState()` for URLs that match the same host (`localhost`) and port.

If a page is restored as one of these error URLs but we never activate that page by going back or forward in the history, the page will never be un-errorified. That means if we do *another* restore with these pages in our session, we'll actually end up with an error page pointing to another error page, and so on, each time a restore happens.

To fix this, we can avoid using the `/errors/error.html?url=...` redirection for any `localhost` page (including error pages, about:home pages, and reader view). These URLs are all on the same host and port as our `sessionrestore.html` launcher page, so there's no need to load them with the SOP workaround.