### PR TITLE
Bug1189985 Rotating top sites crashes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = 746B6A781B277C1800EA83E3 /* SessionRestore.html */; };
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
+		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BF5A1CA1B4160EA00EA9DD8 /* SyncCommandsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */; };
 		7BF5A1EA1B41640500EA9DD8 /* SyncQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */; };
 		7BF5A1EE1B429B3100EA9DD8 /* SyncCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */; };
@@ -1375,6 +1376,7 @@
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
 		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
+		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
 		7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncQueue.swift; sourceTree = "<group>"; };
 		7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTests.swift; sourceTree = "<group>"; };
@@ -2333,6 +2335,7 @@
 				744B0FFD1B4F172E00100422 /* ToolbarTests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
+				7BB20B6C1B71160200F1657F /* TopSitesTests.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -4039,6 +4042,7 @@
 				D38B2D541A8D96D00040E6B5 /* GCDWebServerStreamedResponse.m in Sources */,
 				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,
 				4F97573C1AFA6F37006ECC24 /* ReaderViewUITests.swift in Sources */,
+				7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */,
 				D38B2D511A8D96D00040E6B5 /* GCDWebServerFileResponse.m in Sources */,
 				D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */,
 				E42475EA1AB73B9B00B23D33 /* SWUtilityButtonView.m in Sources */,

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -328,20 +328,29 @@ private class TopSitesLayout: UICollectionViewLayout {
         return CGSize(width: width, height: topSectionHeight + bottomSectionHeight)
     }
 
+    private var layoutAttributes:[UICollectionViewLayoutAttributes]?
+
+    private override func prepareLayout() {
+        var layoutAttributes = [UICollectionViewLayoutAttributes]()
+        for section in 0..<(self.collectionView?.numberOfSections() ?? 0) {
+            for item in 0..<(self.collectionView?.numberOfItemsInSection(section) ?? 0) {
+                let indexPath = NSIndexPath(forItem: item, inSection: section)
+                layoutAttributes.append(self.layoutAttributesForItemAtIndexPath(indexPath))
+            }
+        }
+        self.layoutAttributes = layoutAttributes
+    }
+
     override func layoutAttributesForElementsInRect(rect: CGRect) -> [AnyObject]? {
-        let start = getIndexAtPosition(y: rect.origin.y)
-        let end = getIndexAtPosition(y: rect.origin.y + rect.height)
-
         var attrs = [UICollectionViewLayoutAttributes]()
-        if start == -1 || end == -1 {
-            return attrs
+        if let layoutAttributes = self.layoutAttributes {
+            for attr in layoutAttributes {
+                if CGRectIntersectsRect(rect, attr.frame) {
+                    attrs.append(attr)
+                }
+            }
         }
 
-        for i in start...end {
-            let indexPath = NSIndexPath(forItem: i, inSection: 0)
-            let attr = layoutAttributesForItemAtIndexPath(indexPath)
-            attrs.append(attr)
-        }
         return attrs
     }
 

--- a/UITests/TopSitesTests.swift
+++ b/UITests/TopSitesTests.swift
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+class TopSitesTests: KIFTestCase {
+    private var webRoot: String!
+
+    override func setUp() {
+        webRoot = SimplePageServer.start()
+    }
+
+    func createNewTab(){
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Add Tab")
+        tester().waitForViewWithAccessibilityLabel("Search or enter address")
+    }
+
+    func openURLForPageNumber(pageNo: Int) {
+        let url = "\(webRoot)/numberedPage.html?page=\(pageNo)"
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page \(pageNo)")
+    }
+
+    func rotateToLandscape() {
+        // Rotate to landscape.
+        let value = UIInterfaceOrientation.LandscapeLeft.rawValue
+        UIDevice.currentDevice().setValue(value, forKey: "orientation")
+    }
+
+    func rotateToPortrait() {
+        // Rotate to landscape.
+        let value = UIInterfaceOrientation.Portrait.rawValue
+        UIDevice.currentDevice().setValue(value, forKey: "orientation")
+    }
+
+    func testRotatingOnTopSites() {
+        // go to top sites. rotate to landscape, rotate back again. ensure it doesn't crash
+        createNewTab()
+        rotateToLandscape()
+        rotateToPortrait()
+
+        // go to top sites. rotate to landscape, switch to another tab, switch back to top sites, ensure it doesn't crash
+        rotateToLandscape()
+        tester().tapViewWithAccessibilityLabel("History")
+        tester().tapViewWithAccessibilityLabel("Top sites")
+        rotateToPortrait()
+
+        // go to web page. rotate to landscape. click URL Bar, rotate to portrait. ensure it doesn't crash.
+        openURLForPageNumber(1)
+        rotateToLandscape()
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().waitForViewWithAccessibilityLabel("Top sites")
+        rotateToPortrait()
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
+}


### PR DESCRIPTION
As this is the second issue we have had in this area relating to data and layout being out of sync I have rewritten the way we calculate our layout.

The problem was that the layout was being called before the data refresh had completed leaving things out of sync. Now we are calculating the layout up front in `prepareLayout` and then just finding the right layout cells to return in `layoutAttributesForElementsInRect` rather than working everything out on the fly and risking that the data will change underneath us as we do it.

This strategy was the one recommended in https://developer.apple.com/library/ios/documentation/WindowsViews/Conceptual/CollectionViewPGforIOS/AWorkedExample/AWorkedExample.html#//apple_ref/doc/uid/TP40012334-CH8-SW1

I've added tests for all the rotating top sites STR that we've had so far, except for the one explicitly relating to this bug as this requires a fresh start with an already populated DB which is a scenario that I couldn't get Kif to reproduce.