### PR TITLE
Bug 1191428 - Crash when restoring tab with no session data

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -47,7 +47,7 @@ class Browser: NSObject {
                 history: history,
                 lastUsed: NSDate.now(),
                 icon: nil)
-        } else if let sessionData = browser.sessionData {
+        } else if let sessionData = browser.sessionData where !sessionData.urls.isEmpty {
             let history = sessionData.urls.reverse()
             return RemoteTab(clientGUID: nil,
                 URL: history[0],

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -11,10 +11,21 @@ class SessionData: NSObject, NSCoding {
     let urls: [NSURL]
     let lastUsedTime: Timestamp
 
+    /**
+        Creates a new SessionData object representing a serialized tab.
+
+        :param: currentPage     The active page index. Must be in the range of (-N, 0],
+                                where 1-N is the first page in history, and 0 is the last.
+        :param: urls            The sequence of URLs in this tab's session history.
+        :param: lastUsedTime    The last time this tab was modified.
+    **/
     init(currentPage: Int, urls: [NSURL], lastUsedTime: Timestamp) {
         self.currentPage = currentPage
         self.urls = urls
         self.lastUsedTime = lastUsedTime
+
+        assert(urls.count > 0, "Session has at least one entry")
+        assert(currentPage > -urls.count && currentPage <= 0, "Session index is valid")
     }
 
     required init(coder: NSCoder) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -287,25 +287,27 @@ extension TabManager {
         var sessionData: SessionData?
 
         init?(browser: Browser, isSelected: Bool) {
-            let currentItem = browser.webView?.backForwardList.currentItem
+            self.screenshot = browser.screenshot
+            self.isSelected = isSelected
+            super.init()
+
+            let currentItem: WKBackForwardListItem! = browser.webView?.backForwardList.currentItem
+
+            // Freshly created web views won't have any history entries at all.
+            // If we have no history, abort.
+            if currentItem == nil {
+                return nil
+            }
+
             if browser.sessionData == nil {
                 let backList = browser.webView?.backForwardList.backList as? [WKBackForwardListItem] ?? []
                 let forwardList = browser.webView?.backForwardList.forwardList as? [WKBackForwardListItem] ?? []
-                let currentList = (currentItem != nil) ? [currentItem!] : []
-                var urlList = backList + currentList + forwardList
-                var updatedUrlList = [NSURL]()
-                for url in urlList {
-                    updatedUrlList.append(url.URL)
-                }
+                let urls = (backList + [currentItem] + forwardList).map { $0.URL }
                 var currentPage = -forwardList.count
-                self.sessionData = SessionData(currentPage: currentPage, urls: updatedUrlList, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
+                self.sessionData = SessionData(currentPage: currentPage, urls: urls, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
             } else {
                 self.sessionData = browser.sessionData
             }
-            self.screenshot = browser.screenshot
-            self.isSelected = isSelected
-
-            super.init()
         }
 
         required init(coder: NSCoder) {


### PR DESCRIPTION
Part 1 avoids crashing in the (hopefully rare) situation where we've persisted a tab with no session history. Part 2 avoids creating a `SavedTab` in the first place if there's no history in that tab.