### PR TITLE
Bug 1184678 - Ensure that all 'places' tables are initialized before creating SQLiteBookmarks.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -61,10 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        // Force a database upgrade by requesting a non-existent password
-        profile.logins.getLoginsForProtectionSpace(NSURLProtectionSpace(host: "example.com", port: 0, `protocol`: nil, realm: nil, authenticationMethod: nil))
-
-        // check to see if we started cos someone tapped on a notification
+        // check to see if we started 'cos someone tapped on a notification.
         if let localNotification = launchOptions?[UIApplicationLaunchOptionsLocalNotificationKey] as? UILocalNotification {
             viewURLInNewTab(localNotification)
         }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -254,6 +254,10 @@ public class BrowserProfile: Profile {
     }
 
     lazy var bookmarks: protocol<BookmarksModelFactory, ShareToDestination> = {
+        // Make sure the rest of our tables are initialized before we try to read them!
+        // This expression is for side-effects only.
+        let p = self.places
+
         return SQLiteBookmarks(db: self.db)
     }()
 

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -198,7 +198,7 @@ public class SQLiteLogins: BrowserLogins {
         "ORDER BY timeLastUsed DESC"
 
         let args: Args = [protectionSpace.host, protectionSpace.host]
-        log.debug("Looking for login: \(args[0])")
+        log.debug("Looking for login: \(protectionSpace.host)")
         return db.runQuery(sql, args: args, factory: SQLiteLogins.LoginDataFactory)
     }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -112,7 +112,7 @@ public class SwiftData {
 
     /**
      * Helper for opening a connection, starting a transaction, and then running a block of code inside it.
-     * The code block can return true if the transaction should be commited. False if we should rollback.
+     * The code block can return true if the transaction should be committed. False if we should roll back.
      */
     public func transaction(transactionClosure: (db: SQLiteDBConnection)->Bool) -> NSError? {
         return withConnection(SwiftData.Flags.ReadWriteCreate) { db in


### PR DESCRIPTION
On top of #869 for convenience.

This ensures that by the time any SQLiteBookmarks code runs that BrowserTable has been initialized by SQLiteHistory.

We *could* do this by initing BrowserTable in SQLiteBookmarks… but we know we're going to need history anyway, so we might as well avoid all of the duplicate queries and disk accesses.

I haven't verified that this fixes the bug, but it should do no harm.