### PR TITLE
Fixes 1191866 - Add 'Send Feedback' link to Support section in Settings

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -447,6 +447,21 @@ private class ShowIntroductionSetting: Setting {
     }
 }
 
+private class SendFeedbackSetting: Setting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Send Feedback", comment: "Show an input.mozilla.org page where people can submit feedback"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var url: NSURL? {
+        let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+        return NSURL(string: "https://input.mozilla.org/feedback/fxios/\(appVersion)")
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
 // Opens the the SUMO page in a new tab
 private class OpenSupportPageSetting: Setting {
     init() {
@@ -662,6 +677,7 @@ class SettingsTableViewController: UITableViewController {
             ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
                 ShowIntroductionSetting(settings: self),
+                SendFeedbackSetting(),
                 OpenSupportPageSetting()
             ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [


### PR DESCRIPTION
This adds a Send Feedback item the Support section. It opens

> `https://input.mozilla.org/feedback/fxios/\(appVersion)`

