### PR TITLE
Bug 1187176 - TabManager.storeChanges does unnecessary work

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -393,6 +393,9 @@
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
 		D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B451B054F8600641031 /* TestAppDelegate.swift */; };
 		D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */; };
+		D3BF8CBB1B7425570007AFE6 /* DiskImageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */; };
+		D3BF8CBD1B7472FA0007AFE6 /* DiskImageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */; };
+		D3BF8CBE1B74735F0007AFE6 /* DiskImageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */; };
 		D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */; };
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CE1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
@@ -1458,6 +1461,8 @@
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D3BE7B451B054F8600641031 /* TestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuroraAppDelegate.swift; sourceTree = "<group>"; };
+		D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskImageStore.swift; sourceTree = "<group>"; };
+		D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskImageStoreTests.swift; sourceTree = "<group>"; };
 		D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreTests.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
@@ -2120,26 +2125,27 @@
 		2FCAE21B1ABB51F800877008 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
-				0B3E7DB91B27AB4C00E2E84D /* MockLogins.swift */,
 				2FCAE33D1ABB5F1800877008 /* Storage-Bridging-Header.h */,
 				2FCAE23F1ABB531100877008 /* Bookmarks.swift */,
 				28C4AB711AD42D4300D9ACE3 /* Clients.swift */,
-				7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */,
 				2FCAE2411ABB531100877008 /* Cursor.swift */,
 				28302E3F1AF0747800521E2E /* DatabaseError.swift */,
+				D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */,
 				E42CCE001A24C4E300B794D3 /* ExtensionUtils.swift */,
 				2FCAE2421ABB531100877008 /* Favicons.swift */,
 				2FCAE2431ABB531100877008 /* FileAccessor.swift */,
 				2FCAE2441ABB531100877008 /* History.swift */,
 				0BDA56B11B26B1E4008C9B96 /* Logins.swift */,
+				0B3E7DB91B27AB4C00E2E84D /* MockLogins.swift */,
 				285D3B671B4380B70035FD22 /* Queue.swift */,
 				2FCAE2471ABB531100877008 /* RemoteTabs.swift */,
 				2FCAE2481ABB531100877008 /* Site.swift */,
+				0B54BD181B698B7C004C822C /* SuggestedSites.swift */,
+				7BF5A1E91B41640500EA9DD8 /* SyncQueue.swift */,
 				2FCAE25C1ABB531100877008 /* Visit.swift */,
 				2FCAE2491ABB531100877008 /* SQL */,
 				2FCAE21C1ABB51F800877008 /* Supporting Files */,
 				2FCAE25A1ABB531100877008 /* ThirdParty */,
-				0B54BD181B698B7C004C822C /* SuggestedSites.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -2155,8 +2161,10 @@
 		2FCAE22A1ABB51F800877008 /* StorageTests */ = {
 			isa = PBXGroup;
 			children = (
+				D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */,
 				2FCAE2791ABB533A00877008 /* MockFiles.swift */,
 				7BF5A1ED1B429B3100EA9DD8 /* SyncCommandsTests.swift */,
+				0B5A93071B1E64F3004F47A2 /* TestDeferredSqlite.swift */,
 				2FCAE27C1ABB533A00877008 /* TestFaviconsTable.swift */,
 				0BDA56AE1B26B1D5008C9B96 /* TestLogins.swift */,
 				28D158AC1AFD90E500F9C065 /* TestSQLiteBookmarks.swift */,
@@ -2165,7 +2173,6 @@
 				D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */,
 				2FCAE2821ABB533A00877008 /* TestTableTable.swift */,
 				2FCAE22B1ABB51F800877008 /* Supporting Files */,
-				0B5A93071B1E64F3004F47A2 /* TestDeferredSqlite.swift */,
 			);
 			path = StorageTests;
 			sourceTree = "<group>";
@@ -4004,6 +4011,7 @@
 				2FCAE25D1ABB531100877008 /* Bookmarks.swift in Sources */,
 				2FCAE2781ABB531100877008 /* Visit.swift in Sources */,
 				2FCAE2701ABB531100877008 /* SchemaTable.swift in Sources */,
+				D3BF8CBB1B7425570007AFE6 /* DiskImageStore.swift in Sources */,
 				2FCAE2611ABB531100877008 /* FileAccessor.swift in Sources */,
 				2FCAE2691ABB531100877008 /* FaviconsTable.swift in Sources */,
 				2FCAE2661ABB531100877008 /* Site.swift in Sources */,
@@ -4056,8 +4064,10 @@
 				0BDA56B01B26B1D5008C9B96 /* TestLogins.swift in Sources */,
 				2FA435191ABB6829008031D1 /* RemoteTabs.swift in Sources */,
 				283A2AD91AF0794D003C0A26 /* DatabaseError.swift in Sources */,
+				D3BF8CBD1B7472FA0007AFE6 /* DiskImageStoreTests.swift in Sources */,
 				284AA3AD1AD4C386009041C5 /* Clients.swift in Sources */,
 				2FA435111ABB6829008031D1 /* Bookmarks.swift in Sources */,
+				D3BF8CBE1B74735F0007AFE6 /* DiskImageStore.swift in Sources */,
 				285F2DC21AF80B4600211843 /* SQLiteBookmarks.swift in Sources */,
 				2FA4351D1ABB6831008031D1 /* FaviconsTable.swift in Sources */,
 				2FA4352B1ABB6836008031D1 /* SwiftData.swift in Sources */,

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -28,10 +28,12 @@ class Browser: NSObject {
     var favicons = [Favicon]()
     var lastExecutedTime: Timestamp?
     var sessionData: SessionData?
-
-    var screenshot: UIImage?
-    private var helperManager: HelperManager? = nil
     var lastRequest: NSURLRequest? = nil
+
+    private(set) var screenshot: UIImage?
+    var screenshotUUID: NSUUID?
+
+    private var helperManager: HelperManager? = nil
     private var configuration: WKWebViewConfiguration? = nil
 
     init(configuration: WKWebViewConfiguration) {
@@ -287,6 +289,13 @@ class Browser: NSObject {
             if !bar.shouldPersist(self) {
                 removeSnackbar(bar)
             }
+        }
+    }
+
+    func setScreenshot(screenshot: UIImage?, revUUID: Bool = true) {
+        self.screenshot = screenshot
+        if revUUID {
+            self.screenshotUUID = NSUUID()
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -723,7 +723,7 @@ extension BrowserViewController: URLBarDelegate {
         tabTrayController.tabManager = tabManager
 
         if let tab = tabManager.selectedTab {
-            tab.screenshot = screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1)
+            tab.setScreenshot(screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1))
         }
 
         self.navigationController?.pushViewController(tabTrayController, animated: true)
@@ -1406,8 +1406,9 @@ extension BrowserViewController: WKNavigationDelegate {
 extension BrowserViewController: WKUIDelegate {
     func webView(webView: WKWebView, createWebViewWithConfiguration configuration: WKWebViewConfiguration, forNavigationAction navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         if let currentTab = tabManager.selectedTab {
-            currentTab.screenshot = screenshotHelper.takeScreenshot(currentTab, aspectRatio: 0, quality: 1)
+            currentTab.setScreenshot(screenshotHelper.takeScreenshot(currentTab, aspectRatio: 0, quality: 1))
         }
+
         // If the page uses window.open() or target="_blank", open the page in a new tab.
         // TODO: This doesn't work for window.open() without user action (bug 1124942).
         let tab = tabManager.addTab(request: navigationAction.request, configuration: configuration)

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import UIKit
+
+private class DiskImageStoreErrorType: ErrorType {
+    let description: String
+    init(description: String) {
+        self.description = description
+    }
+}
+
+/**
+ * Disk-backed key-value image store.
+ */
+public class DiskImageStore {
+    private let files: FileAccessor
+    private let filesDir: String
+    private let queue = dispatch_queue_create("DiskImageStore", DISPATCH_QUEUE_CONCURRENT)
+    private var keys: Set<String>
+
+    required public init(files: FileAccessor, namespace: String) {
+        self.files = files
+        self.filesDir = files.getAndEnsureDirectory(relativeDir: namespace)!
+
+        // Build an in-memory set of keys from the existing images on disk.
+        var keys = [String]()
+        let manager = NSFileManager()
+        if let fileEnumerator = NSFileManager.defaultManager().enumeratorAtPath(filesDir) {
+            for file in fileEnumerator {
+                keys.append(file as! String)
+            }
+        }
+        self.keys = Set(keys)
+    }
+
+    /// Gets an image for the given key if it is in the store.
+    public func get(key: String) -> Deferred<Result<UIImage>> {
+        if !keys.contains(key) {
+            return deferResult(DiskImageStoreErrorType(description: "Image key not found"))
+        }
+
+        return deferDispatchAsync(queue, {
+            let imagePath = self.filesDir.stringByAppendingPathComponent(key)
+            if let data = NSData(contentsOfFile: imagePath),
+               let image = UIImage(data: data)
+            {
+                return deferResult(image)
+            }
+
+            return deferResult(DiskImageStoreErrorType(description: "Invalid image data"))
+        })
+    }
+
+    /// Adds an image for the given key.
+    /// This put is asynchronous; the image is not recorded in the cache until the write completes.
+    /// Does nothing if this key already exists in the store.
+    public func put(key: String, image: UIImage) -> Success {
+        if keys.contains(key) {
+            return deferResult(DiskImageStoreErrorType(description: "Key already in store"))
+        }
+
+        return deferDispatchAsync(queue, {
+            let imagePath = self.filesDir.stringByAppendingPathComponent(key)
+            let data = UIImagePNGRepresentation(image)
+
+            if data.writeToFile(imagePath, atomically: false) {
+                self.keys.insert(key)
+                return succeed()
+            }
+
+            return deferResult(DiskImageStoreErrorType(description: "Could not write image to file"))
+        })
+    }
+
+    /// Clears all images from the cache, excluding the given set of keys.
+    public func clearExcluding(keys: Set<String>) {
+        let keysToDelete = self.keys.subtract(keys)
+
+        for key in keysToDelete {
+            let path = filesDir.stringByAppendingPathComponent(key)
+            NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
+        }
+
+        self.keys = self.keys.intersect(keys)
+    }
+}

--- a/StorageTests/DiskImageStoreTests.swift
+++ b/StorageTests/DiskImageStoreTests.swift
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import UIKit
+import XCTest
+
+class DiskImageStoreTests: XCTestCase {
+    var files: FileAccessor!
+    var store: DiskImageStore!
+
+    override func setUp() {
+        files = MockFiles()
+        store = DiskImageStore(files: files, namespace: "DiskImageStoreTests")
+
+        store.clearExcluding(Set())
+    }
+
+    func testStore() {
+        var success = false
+
+        let redImage = makeImageWithColor(UIColor.redColor())
+        XCTAssertNil(getImage("red"), "Red key is nil")
+        success = putImage("red", image: redImage)
+        XCTAssert(success, "Red image added to store")
+        ensureImagesAreEqual(getImage("red")!, otherImage: redImage)
+        success = putImage("red", image: redImage)
+        XCTAssertFalse(success, "Red image not added again")
+
+        let blueImage = makeImageWithColor(UIColor.blueColor())
+        XCTAssertNil(getImage("blue"), "Blue key is nil")
+        success = putImage("blue", image: blueImage)
+        XCTAssert(success, "Blue image added to store")
+        ensureImagesAreEqual(getImage("blue")!, otherImage: blueImage)
+        success = putImage("blue", image: blueImage)
+        XCTAssertFalse(success, "Blue image not added again")
+
+        store.clearExcluding(Set(["red"]))
+        XCTAssertNotNil(getImage("red"), "Red image still exists")
+        XCTAssertNil(getImage("blue"), "Blue image cleared")
+    }
+
+    private func makeImageWithColor(color: UIColor) -> UIImage {
+        let rect = CGRectMake(0, 0, 1, 1)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()
+        CGContextSetFillColorWithColor(context, color.CGColor)
+        CGContextFillRect(context, rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
+    }
+
+    private func getImage(key: String) -> UIImage? {
+        let expectation = expectationWithDescription("Get succeeded")
+        var image: UIImage?
+        store.get(key).upon {
+            image = $0.successValue
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(10, handler: nil)
+        return image
+    }
+
+    private func putImage(key: String, image: UIImage) -> Bool {
+        let expectation = expectationWithDescription("Put succeeded")
+        var success = false
+        store.put(key, image: image).upon {
+            success = $0.isSuccess
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(10, handler: nil)
+        return success
+    }
+
+    private func ensureImagesAreEqual(image: UIImage, otherImage: UIImage) {
+        let imageData = UIImagePNGRepresentation(image)
+        let otherImageData = UIImagePNGRepresentation(otherImage)
+        XCTAssertEqual(imageData, otherImageData, "Images are equal")
+    }
+}

--- a/Utils/DeferredUtils.swift
+++ b/Utils/DeferredUtils.swift
@@ -169,3 +169,16 @@ public func chainResult<T, U>(a: Deferred<Result<T>>, f: T -> Result<U>) -> Defe
 public func chain<T, U>(a: Deferred<Result<T>>, f: T -> U) -> Deferred<Result<U>> {
     return chainResult(a, { Result<U>(success: f($0)) })
 }
+
+/// Defer-ifies a block to an async dispatch queue.
+public func deferDispatchAsync<T>(queue: dispatch_queue_attr_t, f: () -> Deferred<Result<T>>) -> Deferred<Result<T>> {
+    let deferred = Deferred<Result<T>>()
+
+    dispatch_async(queue, {
+        f().upon { result in
+            deferred.fill(result)
+        }
+    })
+
+    return deferred
+}


### PR DESCRIPTION
Having just 5 tabs open on my iPad 2 takes a whopping 700+ms to do simple, common operations: adding a tab, removing a tab, selecting a tab, or browsing to a new URL. Ouch! Needless to say, the browser feels very sluggish on my device.

The vast majority of that work is serializing the screenshot images to be written into the `KeyedArchiver`. I improved this by doing two things: 1) only write screenshots that have actually been changed since the last write, and 2) write the images on a background thread. Things feel much smoother after the fix.