### PR TITLE
Bug 1191831 ios9 toolbar layout errors

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -252,7 +252,7 @@ class URLBarView: UIView {
 
         backButton.snp_makeConstraints { make in
             make.left.centerY.equalTo(self)
-            make.size.lessThanOrEqualTo(UIConstants.ToolbarHeight)
+            make.size.equalTo(UIConstants.ToolbarHeight)
         }
 
         forwardButton.snp_makeConstraints { make in
@@ -281,6 +281,7 @@ class URLBarView: UIView {
     }
 
     override func updateConstraints() {
+        super.updateConstraints()
         if inOverlayMode {
             // In overlay mode, we always show the location view full width
             self.locationContainer.snp_remakeConstraints { make in
@@ -306,7 +307,6 @@ class URLBarView: UIView {
             }
         }
 
-        super.updateConstraints()
     }
 
     // Ideally we'd split this implementation in two, one URLBarView with a toolbar and one without
@@ -315,7 +315,11 @@ class URLBarView: UIView {
     func setShowToolbar(shouldShow: Bool) {
         toolbarIsShowing = shouldShow
         setNeedsUpdateConstraints()
-        updateConstraintsIfNeeded()
+        // when we transition from portrait to landscape, calling this here causes
+        // the constraints to be calculated too early and there are constraint errors
+        if !toolbarIsShowing {
+            updateConstraintsIfNeeded()
+        }
         updateViewsForOverlayModeAndToolbarChanges()
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1191831
This bug was no fun at all.
Fixing the issue was super easy - lessThanOrEqualTo always went for the smallest option rather than the highest so returning the size of the toolbar buttons to the toolbar height sorted all layout problems - however this also reverted all the SnapKit Layout errors that Brian fixed in https://github.com/mozilla/firefox-ios/commit/6a80ffc2aeeca398e85ef7033f2c6a2d72924d92.

Anyway, some investigation lead me to conclude the problem lay in forcing the update calculation to occur at the wrong time, so I've ensured that `updateConstraintsIfNeeded()` isn't called when transitioning to landscape.

I am not utterly convinced that this is the right solution, but I have been unable to replicate either the layout issue OR the snapkit errors since so.....