### PR TITLE
Bug 1190602 - Formatting of 'Licenses' could use some clean up r=st3fan

### DIFF
--- a/Client/Assets/Licenses.html
+++ b/Client/Assets/Licenses.html
@@ -13,7 +13,6 @@ body,p,h1,h2,h3 {
 h2 {
     padding: 0;
     margin: 0;
-    text-transform: uppercase;
 }
 .link {
   margin: 0;


### PR DESCRIPTION
The upper case looks ugly as told in the bug, so I removed the upper case