### PR TITLE
Bug 1193028 - Fixed calculation to determine when we should the toolbars away

### DIFF
--- a/Client/Frontend/Browser/BrowserScrollController.swift
+++ b/Client/Frontend/Browser/BrowserScrollController.swift
@@ -202,7 +202,7 @@ private extension BrowserScrollingController {
     }
 
     func checkScrollHeightIsLargeEnoughForScrolling() -> Bool {
-        return (scrollViewHeight + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height
+        return (UIScreen.mainScreen().bounds.size.height + 2 * UIConstants.ToolbarHeight) < scrollView?.contentSize.height
     }
 }
 


### PR DESCRIPTION
Before we were using the WKWebView's scrollView's frame which actually changes size as the toolbars move. So what was happening in the case of abc.xyz/encryped.google.com was the condition was true when the toolbars were showing (since scrollView.frame.height < acceptable height for scrolling), but as the user scrolls, this value changes, which makes the condition false part way through the animation.