### PR TITLE
Bug 1193178 - Added KVO to check contentSize of WKWebView to update us on if we want it to be scrollable or not

### DIFF
--- a/Client/Frontend/Browser/BrowserScrollController.swift
+++ b/Client/Frontend/Browser/BrowserScrollController.swift
@@ -23,10 +23,12 @@ class BrowserScrollingController: NSObject {
         willSet {
             self.scrollView?.delegate = nil
             self.scrollView?.removeGestureRecognizer(panGesture)
+            self.scrollView?.removeObserver(self, forKeyPath: "contentSize")
         }
 
         didSet {
             self.scrollView?.addGestureRecognizer(panGesture)
+            self.scrollView?.addObserver(self, forKeyPath: "contentSize", options: NSKeyValueObservingOptions.New, context: nil)
             scrollView?.delegate = self
         }
     }
@@ -102,6 +104,14 @@ class BrowserScrollingController: NSObject {
             footerOffset: footerFrame.height - snackBarsFrame.height,
             alpha: 0,
             completion: completion)
+    }
+
+    override func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject : AnyObject], context: UnsafeMutablePointer<Void>) {
+        if keyPath == "contentSize" {
+            if !checkScrollHeightIsLargeEnoughForScrolling() && !toolbarsShowing {
+                showToolbars(animated: true, completion: nil)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The caltrain website's behavior is that it loads larger than the viewport then updates it's size to match the viewport. In some cases, the user can scroll just before the size change which leaves the user in a state without toolbars. I've added a KVO observer to the webview's contentSize so anytime this change happens, we get notified, and can act accordingly. This also fixes an issue where the toolbars do not show after zooming into a page and zooming back out.