### PR TITLE
Bug 1191925 - Moved collection record parsing off onto background thread

### DIFF
--- a/Sync/RequestExtensions.swift
+++ b/Sync/RequestExtensions.swift
@@ -13,6 +13,12 @@ extension Request {
         })
     }
 
+    public func responseParsedJSON(#queue: dispatch_queue_t, completionHandler: ResponseHandler) -> Self {
+        return response(queue: queue, serializer: Request.ParsedJSONResponseSerializer(), completionHandler: { (request, response, JSON, error) in
+            completionHandler(request, response, JSON, error)
+        })
+    }
+
     public class func ParsedJSONResponseSerializer() -> Serializer {
         return { (request, response, data) in
             if data == nil || data?.length == 0 {


### PR DESCRIPTION
Ran the profiler, saw that parsing the JSON was happening on the main thread because Alamofire by default runs it's completion blocks on the main thread. Just needed to pass in a background queue.