### PR TITLE
Bug 1193500 - Moved scroll KVO to web view lifecycle in BVC

### DIFF
--- a/Client/Frontend/Browser/BrowserScrollController.swift
+++ b/Client/Frontend/Browser/BrowserScrollController.swift
@@ -23,12 +23,10 @@ class BrowserScrollingController: NSObject {
         willSet {
             self.scrollView?.delegate = nil
             self.scrollView?.removeGestureRecognizer(panGesture)
-            self.scrollView?.removeObserver(self, forKeyPath: "contentSize")
         }
 
         didSet {
             self.scrollView?.addGestureRecognizer(panGesture)
-            self.scrollView?.addObserver(self, forKeyPath: "contentSize", options: NSKeyValueObservingOptions.New, context: nil)
             scrollView?.delegate = self
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -22,6 +22,7 @@ private let KVOEstimatedProgress = "estimatedProgress"
 private let KVOURL = "URL"
 private let KVOCanGoBack = "canGoBack"
 private let KVOCanGoForward = "canGoForward"
+private let KVOContentSize = "contentSize"
 
 private let ActionSheetTitleMaxLength = 120
 
@@ -974,6 +975,7 @@ extension BrowserViewController: BrowserDelegate {
         webView.addObserver(self, forKeyPath: KVOURL, options: .New, context: nil)
         webView.addObserver(self, forKeyPath: KVOCanGoBack, options: .New, context: nil)
         webView.addObserver(self, forKeyPath: KVOCanGoForward, options: .New, context: nil)
+        webView.scrollView.addObserver(self.scrollController, forKeyPath: KVOContentSize, options: .New, context: nil)
 
         webView.UIDelegate = self
 
@@ -1006,6 +1008,7 @@ extension BrowserViewController: BrowserDelegate {
         webView.removeObserver(self, forKeyPath: KVOURL)
         webView.removeObserver(self, forKeyPath: KVOCanGoBack)
         webView.removeObserver(self, forKeyPath: KVOCanGoForward)
+        webView.scrollView.removeObserver(self.scrollController, forKeyPath: KVOContentSize)
 
         webView.UIDelegate = nil
         webView.scrollView.delegate = nil


### PR DESCRIPTION
This resolves the close tab crash as we are no longer trying to remove an observer that did not get registered. KVO for the scroll controller is now tied with the other KVO observers we set in BVC.