### PR TITLE
Fixes 1193712 - Clearing Private Data does not log user out of sites

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -287,6 +287,10 @@ class TabManager : NSObject {
             tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
         }
     }
+
+    func resetProcessPool() {
+        configuration.processPool = WKProcessPool()
+    }
 }
 
 extension TabManager {

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -74,6 +74,9 @@ class CacheClearable : Clearable {
         // First ensure we close all open tabs first.
         tabManager.removeAll()
 
+        // Reset the process pool to ensure no cached data is written back
+        tabManager.resetProcessPool()
+
         // Remove the basic cache.
         NSURLCache.sharedURLCache().removeAllCachedResponses()
 


### PR DESCRIPTION
As part of clearing private data we now also create a new `WKProcessPool`. This prevents the content processes to write back cached data to the main process. (The data that we just deleted)