### PR TITLE
Bug 1193782 - Tab count no longer displays zero when restoring tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -417,8 +417,11 @@ extension TabManager {
                             tabToSelect = tabs.first
                         }
 
-                        for delegate in delegates {
-                            delegate.get()?.tabManagerDidRestoreTabs(self)
+                        // Only tell our delegates that we restored tabs if we actually restored a tab(s)
+                        if savedTabs.count > 0 {
+                            for delegate in delegates {
+                                delegate.get()?.tabManagerDidRestoreTabs(self)
+                            }
                         }
 
                         if let tab = tabToSelect {


### PR DESCRIPTION
The reason we were seeing the transition from 1->0 sporadically is as follows:

1. Inside viewWillAppear for BrowserViewController, we make the following checks:

```
        if tabManager.count == 0 && !AppConstants.IsRunningTest {
            tabManager.restoreTabs()
        }

        if tabManager.count == 0 {
            let tab = tabManager.addTab()
            tabManager.selectTab(tab)
        }
```

Here, we restore tabs if we have no tabs. If we restore 0 tabs, then we add a new tab and select it.

2. restoreTabs internally always calls tabManagerDidRestoreTabs - even if no tabs were restored. This delegate inside BrowserViewController tells the URLBarView to update it's count which is an async animation call.

3. As mentioned above, if we did not restore any tabs, we call addTab. This calls tabManagerDidAddTab which also in turn calls URLBarView's updateTabCount method.

4. Since these two calls occur and they are async, a race condition occurs where sometimes the 1 is shown and other times the 0 is shown.

The Fix:

We simply should not tell TabManagerDelegates that we restored tabs if we didn't restore tabs. This prevents both animations from running when only one is neccessary (the addTab one).