### PR TITLE
Bug 1192480 testURLBarContextMenu test failure

### DIFF
--- a/UITests/BookmarkingTests.swift
+++ b/UITests/BookmarkingTests.swift
@@ -90,6 +90,6 @@ class BookmarkingTests: KIFTestCase, UITextFieldDelegate {
     }
 
     override func tearDown() {
-        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearHistoryItems(tester())
     }
 }

--- a/UITests/ClearPrivateDataTests.swift
+++ b/UITests/ClearPrivateDataTests.swift
@@ -13,10 +13,10 @@ class ClearPrivateDataTests: KIFTestCase, UITextFieldDelegate {
         webRoot = SimplePageServer.start()
     }
 
-    override func afterEach() {
-        BrowserUtils.resetToAboutHome(tester())
+    override func tearDown() {
+        BrowserUtils.clearHistoryItems(tester())
     }
-
+    
     func clearPrivateData(shouldClear: Bool) {
         // clear private data
         tester().tapViewWithAccessibilityLabel("Show Tabs")

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -96,5 +96,6 @@ class DomainAutocompleteTests: KIFTestCase {
         if tester().tryFindingTappableViewWithAccessibilityLabel("Cancel", error: nil) {
             tester().tapViewWithAccessibilityLabel("Cancel")
         }
+        BrowserUtils.clearHistoryItems(tester())
     }
 }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -167,6 +167,39 @@ class BrowserUtils {
         notificationCenter.postNotificationName("LocationChange", object: self, userInfo: info)
     }
 
+    private class func clearHistoryItemAtIndex(index: NSIndexPath, tester: KIFUITestActor) {
+        if let row = tester.waitForCellAtIndexPath(index, inTableViewWithAccessibilityIdentifier: "History List") {
+            tester.swipeViewWithAccessibilityLabel(row.accessibilityLabel, value: row.accessibilityValue, inDirection: KIFSwipeDirection.Left)
+            tester.tapViewWithAccessibilityLabel("Remove")
+        }
+    }
+
+    class func clearHistoryItems(tester: KIFUITestActor, numberOfTests: Int = -1) {
+        resetToAboutHome(tester)
+        tester.tapViewWithAccessibilityLabel("History")
+
+        let historyTable = tester.waitForViewWithAccessibilityIdentifier("History List") as! UITableView
+        if numberOfTests == -1 {
+            for section in 0 ..< historyTable.numberOfSections() {
+                for rowIdx in 0 ..< historyTable.numberOfRowsInSection(0) {
+                    clearHistoryItemAtIndex(NSIndexPath(forRow: 0, inSection: 0), tester: tester)
+                }
+            }
+        } else {
+            var index = 0
+            for section in 0 ..< historyTable.numberOfSections() {
+                for rowIdx in 0 ..< historyTable.numberOfRowsInSection(0) {
+                    clearHistoryItemAtIndex(NSIndexPath(forRow: 0, inSection: 0), tester: tester)
+//                    index++
+                    if ++index == numberOfTests {
+                        return
+                    }
+                }
+            }
+        }
+        tester.tapViewWithAccessibilityLabel("Top sites")
+    }
+
     class func ensureAutocompletionResult(tester: KIFUITestActor, textField: UITextField, prefix: String, completion: String) {
         // searches are async (and debounced), so we have to wait for the results to appear.
         tester.waitForViewWithAccessibilityValue(prefix + completion)

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -179,21 +179,12 @@ class BrowserUtils {
         tester.tapViewWithAccessibilityLabel("History")
 
         let historyTable = tester.waitForViewWithAccessibilityIdentifier("History List") as! UITableView
-        if numberOfTests == -1 {
-            for section in 0 ..< historyTable.numberOfSections() {
-                for rowIdx in 0 ..< historyTable.numberOfRowsInSection(0) {
-                    clearHistoryItemAtIndex(NSIndexPath(forRow: 0, inSection: 0), tester: tester)
-                }
-            }
-        } else {
-            var index = 0
-            for section in 0 ..< historyTable.numberOfSections() {
-                for rowIdx in 0 ..< historyTable.numberOfRowsInSection(0) {
-                    clearHistoryItemAtIndex(NSIndexPath(forRow: 0, inSection: 0), tester: tester)
-//                    index++
-                    if ++index == numberOfTests {
-                        return
-                    }
+        var index = 0
+        for section in 0 ..< historyTable.numberOfSections() {
+            for rowIdx in 0 ..< historyTable.numberOfRowsInSection(0) {
+                clearHistoryItemAtIndex(NSIndexPath(forRow: 0, inSection: 0), tester: tester)
+                if numberOfTests > -1 && ++index == numberOfTests {
+                    return
                 }
             }
         }

--- a/UITests/HistoryTests.swift
+++ b/UITests/HistoryTests.swift
@@ -33,22 +33,29 @@ class HistoryTests: KIFTestCase {
     /**
      * Tests for listed history visits
      */
-    func testHistoryUI() {
+    func testAddHistoryUI() {
         let urls = addHistoryItems(2)
 
         // Check that both appear in the history home panel
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().tapViewWithAccessibilityLabel("History")
 
-        let firstHistoryRow = tester().waitForCellWithAccessibilityLabel(urls[0])
+
+        let firstHistoryRow = tester().waitForCellAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), inTableViewWithAccessibilityIdentifier: "History List")
         XCTAssertNotNil(firstHistoryRow.imageView?.image)
-        let secondHistoryRow = tester().waitForCellWithAccessibilityLabel(urls[1])
+        XCTAssertEqual(firstHistoryRow.textLabel!.text!, "Page 2")
+        XCTAssertEqual(firstHistoryRow.detailTextLabel!.text!, "\(webRoot)/numberedPage.html?page=2")
+
+
+        let secondHistoryRow = tester().waitForCellAtIndexPath(NSIndexPath(forRow: 1, inSection: 0), inTableViewWithAccessibilityIdentifier: "History List")
         XCTAssertNotNil(secondHistoryRow.imageView?.image)
+        XCTAssertEqual(secondHistoryRow.textLabel!.text!, "Page 1")
+        XCTAssertEqual(secondHistoryRow.detailTextLabel!.text!, "\(webRoot)/numberedPage.html?page=1")
 
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 
-    func testDeleteHistoryItemFromSmallList() {
+    func testDeleteHistoryItemFromListWith2Items() {
         // add 2 history items
         // delete all history items
 
@@ -71,7 +78,10 @@ class HistoryTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 
-    func testDeleteHistoryItemFromLargeList() {
+    func testDeleteHistoryItemFromListWithMoreThan100Items() {
+        if tester().tryFindingTappableViewWithAccessibilityLabel("Top sites", error: nil) {
+            tester().tapViewWithAccessibilityLabel("Top sites")
+        }
         for pageNo in 1...102 {
             BrowserUtils.addHistoryEntry("Page \(pageNo)", url: NSURL(string: "\(webRoot)/numberedPage.html?page=\(pageNo)")!)
         }
@@ -91,6 +101,6 @@ class HistoryTests: KIFTestCase {
     }
 
     override func tearDown() {
-        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearHistoryItems(tester(), numberOfTests: 2)
     }
 }

--- a/UITests/NavigationTests.swift
+++ b/UITests/NavigationTests.swift
@@ -72,6 +72,6 @@ class NavigationTests: KIFTestCase, UITextFieldDelegate {
     }
 
     override func tearDown() {
-        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearHistoryItems(tester(), numberOfTests: 5)
     }
 }

--- a/UITests/ReaderViewUITests.swift
+++ b/UITests/ReaderViewUITests.swift
@@ -106,6 +106,6 @@ class ReaderViewUITests: KIFTestCase, UITextFieldDelegate {
     // TODO: Add a reader view display settings test
 
     override func tearDown() {
-        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearHistoryItems(tester(), numberOfTests: 5)
     }
 }

--- a/UITests/ReadingListTest.swift
+++ b/UITests/ReadingListTest.swift
@@ -83,6 +83,6 @@ class ReadingListTests: KIFTestCase, UITextFieldDelegate {
     }
 
     override func tearDown() {
-        BrowserUtils.resetToAboutHome(tester())
+        BrowserUtils.clearHistoryItems(tester(), numberOfTests: 5)
     }
 }

--- a/UITests/SearchTests.swift
+++ b/UITests/SearchTests.swift
@@ -122,5 +122,6 @@ class SearchTests: KIFTestCase {
         if tester().tryFindingTappableViewWithAccessibilityLabel("Cancel", error: nil) {
             tester().tapViewWithAccessibilityLabel("Cancel")
         }
+        BrowserUtils.clearHistoryItems(tester(), numberOfTests: 5)
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1192480
This was not an actual functionality failure (I discovered after much investigation).
Failure caused by the persisting of history items across tests causing the wrong autocomplete to occur.
Failures of history tests also caused by this, and while I was there I realized that the order the tests were executing in caused the short list test to be testing the wrong thing so I fixed that as well.