### PR TITLE
Fixes 1192462 - Augment import-locales.sh and/or update-xliff.py

### DIFF
--- a/scripts/import-locales.sh
+++ b/scripts/import-locales.sh
@@ -12,6 +12,35 @@ fi
 
 svn co --non-interactive --trust-server-cert https://svn.mozilla.org/projects/l10n-misc/trunk/firefox-ios firefox-ios-l10n
 
+#
+# TODO Add incomplete locales here that are NOT to be included.
+# TODO Look at https://l10n.mozilla-community.org/~flod/webstatus/?product=firefox-ios to find out which locales are not at 100%
+#
+
+INCOMPLETE_LOCALES=(
+    "da"
+    "eo"
+    "es"
+    "gl"
+    "is"
+    "ko"
+    "lt"
+    "ru"
+    "sk"
+    "son"
+    "tl"
+    "uz"
+    "zh-CN"
+    "zh-TW"
+)
+
+if [ $1 == "--only-complete" ]; then
+  for i in "${!INCOMPLETE_LOCALES[@]}"; do
+    echo "Removing incomplete locale ${INCOMPLETE_LOCALES[$i]}"
+    rm -rf "firefox-ios-l10n/${INCOMPLETE_LOCALES[$i]}"
+  done
+fi
+
 # Cleanup files (remove unwanted sections, map sv-SE to sv)
 scripts/update-xliff.py firefox-ios-l10n
 


### PR DESCRIPTION
This change to `import-locales.sh` adds a `--only-complete` flag to the script. If this is specified then the script will remove locales that are not complete, after checking out the initial l10n repository.

To keep things simple, the list of incomplete locales is kept inside the script. This means that before we do a final build, this list needs to be updated. The best place to see what locales are ready to go is the [https://l10n.mozilla-community.org/~flod/webstatus/?product=firefox-ios](L10N Dashboard).