### PR TITLE
Bug 1191687 - Listen for mouseup to work around touchend not being called with VoiceOver

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -67,7 +67,8 @@ function createHighlightOverlay(element) {
 function handleTouchEnd(event) {
   cancel();
 
-  event.target.removeEventListener("touchend", handleTouchEnd, true);
+  event.target.removeEventListener("touchend", handleTouchEnd);
+  event.target.removeEventListener("mouseup", handleTouchEnd);
   event.target.removeEventListener("touchmove", handleTouchMove);
 
   // If we're showing the context menu, prevent the page from handling the click event.
@@ -98,7 +99,11 @@ addEventListener("touchstart", function (event) {
   var data = {};
   var element = event.target;
 
-  element.addEventListener("touchend", handleTouchEnd, true);
+  // Listen for touchend or move events to cancel the context menu timeout.
+  // Also listen for mouseup due to touchend not being fired with VoiceOver enabled.
+  // Open bug filed as rdar://22256909.
+  element.addEventListener("touchend", handleTouchEnd);
+  element.addEventListener("mouseup", handleTouchEnd);
   element.addEventListener("touchmove", handleTouchMove);
 
   do {


### PR DESCRIPTION
Apparently, there's a VoiceOver bug where `touchstart` is fired when clicking on a link, but `touchend` is not. We use `touchstart`/`touchend` to show our context menu, where the former creates a timeout to trigger the dialog if the latter isn't fired. Since it's not fired, we end up showing the context menu after every link click.

I filed this under [rdar://22256909](https://openradar.appspot.com/radar?id=6618222514143232). It looks like `mouseup` events are still dispatched with VoiceOver, so we can use that as a workaround.