### PR TITLE
Bug 1194387 - Empty Bottom bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -453,7 +453,6 @@ class BrowserViewController: UIViewController {
                 UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
             }
         })
-        toolbar?.hidden = !inline
         view.setNeedsUpdateConstraints()
     }
 
@@ -468,7 +467,6 @@ class BrowserViewController: UIViewController {
                     controller.removeFromParentViewController()
                     self.homePanelController = nil
                     self.webViewContainer.accessibilityElementsHidden = false
-                    self.toolbar?.hidden = false
                     self.startTrackingAccessibilityStatus()
                     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
 


### PR DESCRIPTION
We don't need to toggle the visibility of the toolbar since when we hide the toolbar, we're actually hiding/removing the entire footer.