### PR TITLE
Bug 1194683 - Fixed error in calculating log size when deleting oldest logs

### DIFF
--- a/SharedTests/RollingFileLoggerTests.swift
+++ b/SharedTests/RollingFileLoggerTests.swift
@@ -43,7 +43,7 @@ class RollingFileLoggerTests: XCTestCase {
         let expectedPath = createNewLogFileWithSize(5001)
 
         var directorySize: UInt64 = 0
-        NSFileManager.defaultManager().nr_getAllocatedSize(&directorySize, ofDirectoryAtURL: NSURL(fileURLWithPath: logDir)!, error: nil)
+        NSFileManager.defaultManager().moz_getAllocatedSize(&directorySize, ofDirectoryAtURL: NSURL(fileURLWithPath: logDir)!, forFilesPrefixedWith: "test", error: nil)
 
         // Pre-condition: Folder needs to be larger than the size limit
         XCTAssertGreaterThan(directorySize, sizeLimit, "Log folder should be larger than size limit")
@@ -65,7 +65,7 @@ class RollingFileLoggerTests: XCTestCase {
         logFilePaths.sort { $0 < $1 }
 
         var directorySize: UInt64 = 0
-        NSFileManager.defaultManager().nr_getAllocatedSize(&directorySize, ofDirectoryAtURL: NSURL(fileURLWithPath: logDir)!, error: nil)
+        NSFileManager.defaultManager().moz_getAllocatedSize(&directorySize, ofDirectoryAtURL: NSURL(fileURLWithPath: logDir)!, forFilesPrefixedWith: "test", error: nil)
 
         // Pre-condition: Folder needs to be larger than the size limit
         XCTAssertGreaterThan(directorySize, sizeLimit, "Log folder should be larger than size limit")

--- a/ThirdParty/NRFileManager/NSFileManager+NRFileManager.h
+++ b/ThirdParty/NRFileManager/NSFileManager+NRFileManager.h
@@ -12,5 +12,7 @@
 
 - (BOOL)nr_getAllocatedSize:(unsigned long long *)size ofDirectoryAtURL:(NSURL *)url error:(NSError * __autoreleasing *)error;
 
+- (BOOL)moz_getAllocatedSize:(unsigned long long *)size ofDirectoryAtURL:(NSURL *)url forFilesPrefixedWith:(NSString *)prefix error:(NSError * __autoreleasing *)error;
+
 @end
 

--- a/Utils/RollingFileLogger.swift
+++ b/Utils/RollingFileLogger.swift
@@ -8,7 +8,7 @@ import XCGLogger
 //// A rolling file loggers that saves to a different log file based on given timestamp
 public class RollingFileLogger: XCGLogger {
 
-    private static let FiveMBsInBytes: UInt64 = 5 * 100000
+    private static let TwoMBsInBytes: UInt64 = 2 * 100000
     private let sizeLimit: UInt64
     private let logDirectoryPath: String?
 
@@ -22,7 +22,7 @@ public class RollingFileLogger: XCGLogger {
 
     let root: String
 
-    public init(filenameRoot: String, logDirectoryPath: String?, sizeLimit: UInt64 = FiveMBsInBytes) {
+    public init(filenameRoot: String, logDirectoryPath: String?, sizeLimit: UInt64 = TwoMBsInBytes) {
         root = filenameRoot
         self.sizeLimit = sizeLimit
         self.logDirectoryPath = logDirectoryPath
@@ -77,7 +77,7 @@ public class RollingFileLogger: XCGLogger {
         let logDirURL = NSURL(fileURLWithPath: logDirectoryPath!)
         var dirSize: UInt64 = 0
         var errorValue: NSError?
-        if !NSFileManager.defaultManager().nr_getAllocatedSize(&dirSize, ofDirectoryAtURL: logDirURL, error: &errorValue) {
+        if !NSFileManager.defaultManager().moz_getAllocatedSize(&dirSize, ofDirectoryAtURL: logDirURL, forFilesPrefixedWith: self.root, error: &errorValue) {
             if let errorValue = errorValue {
                 error("Error determining log directory size: \(errorValue)")
             }


### PR DESCRIPTION
Fixed an issue in RollingFileLogger where the size limit was calculated based on folder directory size and not the size of the relevant log files that match the same prefix.