### PR TITLE
Bug 1194388 - Added background to url bar/footer on BVC so we don't see black underneath during transition

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -42,7 +42,7 @@ private extension TrayToBrowserAnimator {
         container.layoutIfNeeded()
 
         // Reset any transform we had previously on the header and transform them to where the cell will be animating from
-        transformToolbarsToFrame([bvc.header, bvc.footer, bvc.readerModeBar], toRect: cell.frame)
+        transformToolbarsToFrame([bvc.header, bvc.footer, bvc.readerModeBar, bvc.footerBackdrop, bvc.headerBackdrop], toRect: cell.frame)
 
         let finalFrame = calculateExpandedCellFrameFromBVC(bvc)
         bvc.footer.alpha = shouldDisplayFooterForBVC(bvc) ? 1 : 0
@@ -57,7 +57,7 @@ private extension TrayToBrowserAnimator {
             cell.frame = finalFrame
             container.layoutIfNeeded()
             cell.title.transform = CGAffineTransformMakeTranslation(0, -cell.title.frame.height)
-            resetTransformsForViews([bvc.header, bvc.footer, bvc.readerModeBar])
+            resetTransformsForViews([bvc.header, bvc.footer, bvc.readerModeBar, bvc.footerBackdrop, bvc.headerBackdrop])
 
             bvc.urlBar.updateAlphaForSubviews(1)
 
@@ -146,7 +146,7 @@ private extension BrowserToTrayAnimator {
                 cell.frame = finalFrame
                 cell.title.transform = CGAffineTransformIdentity
                 cell.layoutIfNeeded()
-                transformToolbarsToFrame([bvc.header, bvc.footer, bvc.readerModeBar], toRect: finalFrame)
+                transformToolbarsToFrame([bvc.header, bvc.footer, bvc.readerModeBar, bvc.footerBackdrop, bvc.headerBackdrop], toRect: finalFrame)
 
                 bvc.urlBar.updateAlphaForSubviews(0)
                 bvc.footer.alpha = 0

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -61,7 +61,9 @@ class BrowserViewController: UIViewController {
 
     // These views wrap the urlbar and toolbar to provide background effects on them
     var header: UIView!
+    var headerBackdrop: UIView!
     var footer: UIView!
+    var footerBackdrop: UIView!
     private var footerBackground: UIView!
     private var topTouchArea: UIButton!
 
@@ -174,6 +176,13 @@ class BrowserViewController: UIViewController {
         super.viewDidLoad()
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELBookmarkStatusDidChange:", name: BookmarkStatusChangedNotification, object: nil)
         KeyboardHelper.defaultHelper.addDelegate(self)
+
+        footerBackdrop = UIView()
+        footerBackdrop.backgroundColor = UIColor.whiteColor()
+        view.addSubview(footerBackdrop)
+        headerBackdrop = UIView()
+        headerBackdrop.backgroundColor = UIColor.whiteColor()
+        view.addSubview(headerBackdrop)
 
         webViewContainer = UIView()
         view.addSubview(webViewContainer)
@@ -344,6 +353,9 @@ class BrowserViewController: UIViewController {
             make.left.right.equalTo(self.view)
         }
         header.setNeedsUpdateConstraints()
+        headerBackdrop.snp_remakeConstraints { make in
+            make.edges.equalTo(self.header)
+        }
 
         readerModeBar?.snp_remakeConstraints { make in
             make.top.equalTo(self.header.snp_bottom).constraint
@@ -377,6 +389,10 @@ class BrowserViewController: UIViewController {
             scrollController.footerBottomConstraint = make.bottom.equalTo(self.view.snp_bottom).constraint
             make.top.equalTo(self.snackBars.snp_top)
             make.leading.trailing.equalTo(self.view)
+        }
+
+        footerBackdrop.snp_remakeConstraints { make in
+            make.edges.equalTo(self.footer)
         }
 
         adjustFooterSize(top: nil)


### PR DESCRIPTION
The flash was occurring from the transition from tab tray's black background into the web page loading underneath the toolbars which causes the appearence to go from a dark gray to a lighter color from the web page. A temporary/low risk fix for this is to add a backdrop view beneath the header/footer views that also lies beneath the web view so as the animating is occurring, we're seeing the white behind instead of black and when the web content finishes loading, it will appear above the backdrop. Eventually I'd like to take a hard look at how we handle this transparency because we shouldn't be seeing clipsToBounds to false on the web view.