### PR TITLE
Bug 1194567 - LoginsHelper security fixes

### DIFF
--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -44,6 +44,13 @@ class LoginsHelper: BrowserHelper {
 
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
         let frameInfo = message.frameInfo
+
+        // We don't currently inject the helper into iframes.
+        // Don't listen for messages from iframes, either.
+        if !frameInfo.mainFrame {
+            return
+        }
+
         var res = message.body as! [String: String]
         let type = res["type"]
 

--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -43,9 +43,13 @@ class LoginsHelper: BrowserHelper {
     }
 
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        let frameInfo = message.frameInfo
         var res = message.body as! [String: String]
         let type = res["type"]
-        if let url = browser?.url {
+
+        // We don't use the WKWebView's URL since the page can spoof the URL by using document.location
+        // right before requesting login data. See bug 1194567 for more context.
+        if let url = frameInfo.request.URL {
             if type == "request" {
                 res["username"] = ""
                 res["password"] = ""


### PR DESCRIPTION
First commit: read the URL from the request frame rather than the web view to prevent spoofing.

Second commit: if an iframe fires a request for login credentials, the credentials are sent back to the parent frame. We don't support `LoginsHelper` in subframes anyway, so we should just ignore any such requests.