### PR TITLE
Bug 1195133 - Domain extraction fails for file:/// URIs. (alternative)

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -35,7 +35,7 @@ func failOrSucceed(err: NSError?, op: String) -> Success {
     return failOrSucceed(err, op, ())
 }
 
-private var ignoredSchemes = ["about"]
+private var ignoredSchemes = ["about", "file", "chrome", "wyciwyg"]
 
 public func isIgnoredURL(url: NSURL) -> Bool {
     if let scheme = url.scheme {


### PR DESCRIPTION
This is the alternative approach: just make the insert work. We also ignore file: URIs altogether, but we could make that work if we want.

See #939.