### PR TITLE
Bug 1194750 - Fixed progress bar from incorrectly animating during tab tray transition

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -46,6 +46,7 @@ private extension TrayToBrowserAnimator {
 
         let finalFrame = calculateExpandedCellFrameFromBVC(bvc)
         bvc.footer.alpha = shouldDisplayFooterForBVC(bvc) ? 1 : 0
+        bvc.urlBar.isTransitioning = true
 
         UIView.animateWithDuration(self.transitionDuration(transitionContext),
             delay: 0, usingSpringWithDamping: 1,
@@ -76,6 +77,7 @@ private extension TrayToBrowserAnimator {
             bvc.startTrackingAccessibilityStatus()
             toggleWebViewVisibility(show: true, usingTabManager: bvc.tabManager)
             bvc.homePanelController?.view.hidden = false
+            bvc.urlBar.isTransitioning = false
             transitionContext.completeTransition(true)
         })
     }
@@ -128,6 +130,7 @@ private extension BrowserToTrayAnimator {
         // Hide views we don't want to show during the animation in the BVC
         bvc.homePanelController?.view.hidden = true
         toggleWebViewVisibility(show: false, usingTabManager: bvc.tabManager)
+        bvc.urlBar.isTransitioning = true
 
         // Since we are hiding the collection view and the snapshot API takes the snapshot after the next screen update,
         // the screenshot ends up being blank unless we set the collection view hidden after the screen update happens. 
@@ -163,6 +166,7 @@ private extension BrowserToTrayAnimator {
                 bvc.homePanelController?.view.hidden = false
                 bvc.stopTrackingAccessibilityStatus()
 
+                bvc.urlBar.isTransitioning = false
                 transitionContext.completeTransition(true)
             })
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -51,6 +51,15 @@ class URLBarView: UIView {
     weak var delegate: URLBarDelegate?
     weak var browserToolbarDelegate: BrowserToolbarDelegate?
     var helper: BrowserToolbarHelper?
+    var isTransitioning: Bool = false {
+        didSet {
+            if isTransitioning {
+                // Cancel any pending/in-progress animations related to the progress bar
+                self.progressBar.setProgress(1, animated: false)
+                self.progressBar.alpha = 0.0
+            }
+        }
+    }
 
     var toolbarIsShowing = false
 
@@ -391,8 +400,10 @@ class URLBarView: UIView {
             self.progressBar.setProgress(progress, animated: true)
             UIView.animateWithDuration(1.5, animations: {
                 self.progressBar.alpha = 0.0
-            }, completion: { _ in
-                self.progressBar.setProgress(0.0, animated: false)
+            }, completion: { finished in
+                if finished {
+                    self.progressBar.setProgress(0.0, animated: false)
+                }
             })
         } else {
             self.progressBar.alpha = 1.0


### PR DESCRIPTION
Looks like the jank was being caused by the setProgress(animated) and UIView.animation blocks firing during the tab tray animation animation. I've added a flag and check to the URLBarView to cancel any progress bar animation when we start performing a transition.