### PR TITLE
Fixes 1118404 Make sure we do not auto-redirect/open iTunes Store links

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1376,7 +1376,8 @@ extension BrowserViewController: WKNavigationDelegate {
                 case "about", "http", "https":
                     if isWhitelistedUrl(url) {
                         // If the url is whitelisted, we open it without prompting.
-                        openExternal(url, prompt: false)
+                        // Except when the NavigationType is Other, which means it is JavaScript or Redirect initiated.
+                        openExternal(url, prompt: navigationAction.navigationType == WKNavigationType.Other)
                         decisionHandler(WKNavigationActionPolicy.Cancel)
                     } else {
                         decisionHandler(WKNavigationActionPolicy.Allow)


### PR DESCRIPTION
This patch adds a check to the logic that decided whether to show a confirmation dialog when the user opens a link that triggers an external app. Previously we would simply let all `itunes.apple.com` links open. With this extra check we explicitly ask the user for permission if the load was triggered by JavaScript or by a Reload. This prevents sites from sneaky opening app store links without user approval.

I think the whole *open external app* code needs a revisit. The code looks flawed and incomplete. It will also need a rewrite for iOS 9, where things work in a different way. I have tried to do this with minimal changes to prevent other regressions.

You can test the auto redirect on people.mozilla.com/~sarentz/t/itunes.html which opens an app store link upon loading.

On twitter.com there is a Install button that shows how it works for actual clicks. You need to be logged in to Twitter to see this.