### PR TITLE
Bug 1182303 - Firefox iOS susceptible to infinite alert loops

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -40,6 +40,8 @@ class Browser: NSObject {
 
     private(set) var screenshot: UIImage?
     var screenshotUUID: NSUUID?
+    var showDialog = false
+    var disableDialog = false
 
     private var helperManager: HelperManager? = nil
     private var configuration: WKWebViewConfiguration? = nil


### PR DESCRIPTION
1. After a page prompts any javascript alert more than once, enable disable dialogue.
2. if user disables dialogue, remove the WKUIDelegate from the page, preventing alerts from taking up the UI thread if it there are infinitely many of them.
3. When the URL changes, reattach the delegate (this was the best way to do this / best way we could come up with so far).