### PR TITLE
Bug 1194750 - Factor in if we're transitioning in our updateProgress method

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -397,7 +397,7 @@ class URLBarView: UIView {
 
     func updateProgressBar(progress: Float) {
         if progress == 1.0 {
-            self.progressBar.setProgress(progress, animated: true)
+            self.progressBar.setProgress(progress, animated: !isTransitioning)
             UIView.animateWithDuration(1.5, animations: {
                 self.progressBar.alpha = 0.0
             }, completion: { finished in
@@ -409,7 +409,7 @@ class URLBarView: UIView {
             if self.progressBar.alpha < 1.0 {
                 self.progressBar.alpha = 1.0
             }
-            self.progressBar.setProgress(progress, animated: (progress > progressBar.progress))
+            self.progressBar.setProgress(progress, animated: (progress > progressBar.progress) && !isTransitioning)
         }
     }
 


### PR DESCRIPTION
Forgot to add in a check to make sure we're taking if we're transitioning into consideration when updating the progress bar