### PR TITLE
Bug 1194726 - always remember the last request. Create force reload o…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -656,10 +656,6 @@ class BrowserViewController: UIViewController {
             auralProgress.progress = loading ? 0 : nil
         case KVOURL:
             if let tab = tabManager.selectedTab where tab.webView === webView && !tab.restoring {
-                if webView.URL == nil {
-                    log.debug("restoring nulled WebView")
-                    tab.restore(webView)
-                }
                 updateUIForReaderHomeStateForTab(tab)
             }
         case KVOCanGoBack:
@@ -1255,8 +1251,7 @@ extension BrowserViewController: TabManagerDelegate {
             } else {
                 // The web view can go gray if it was zombified due to memory pressure.
                 // When this happens, the URL is nil, so try restoring the page upon selection.
-                log.info("reloading zombified tab from origin")
-                webView.reloadFromOrigin()
+                tab.reload()
             }
         }
 


### PR DESCRIPTION

https://bugzilla.mozilla.org/show_bug.cgi?id=1194726

Call me crazy but:

Through the whole "Kill the WebContent process" it seems as if what is actually happening is that sometimes the reloadFromOrigin() (or reload()) from the original fix from Brian) is failing - and then we just do nothing.

I've ensured that we always remember the last request (we were not remembering the lastRequest when we first restore!) so that if the reloadFromOrigin() fails, we re-request the URL. It _seems_ to work......

The listening to the URL nullifying seemed to do nothing useful here....