### PR TITLE
Bug 1195204: Fix location bar elements on iOS 9

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -31,7 +31,11 @@ class BrowserLocationView: UIView {
 
     var url: NSURL? {
         didSet {
+            let wasHidden = lockImageView.hidden
             lockImageView.hidden = url?.scheme != "https"
+            if wasHidden != lockImageView.hidden {
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+            }
             updateTextWithURL()
             setNeedsUpdateConstraints()
         }
@@ -43,8 +47,12 @@ class BrowserLocationView: UIView {
         }
         set (newReaderModeState) {
             if newReaderModeState != self.readerModeButton.readerModeState {
+                let wasHidden = readerModeButton.hidden
                 self.readerModeButton.readerModeState = newReaderModeState
                 readerModeButton.hidden = (newReaderModeState == ReaderModeState.Unavailable)
+                if wasHidden != readerModeButton.hidden {
+                    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+                }
                 UIView.animateWithDuration(0.1, animations: { () -> Void in
                     if newReaderModeState == ReaderModeState.Unavailable {
                         self.readerModeButton.alpha = 0.0
@@ -122,8 +130,15 @@ class BrowserLocationView: UIView {
             make.trailing.centerY.equalTo(self)
             make.width.equalTo(self.readerModeButton.intrinsicContentSize().width + CGFloat(BrowserLocationViewUX.LocationContentInset * 2))
         }
+    }
 
-        accessibilityElements = [lockImageView, urlTextField, readerModeButton]
+    override var accessibilityElements: [AnyObject]! {
+        get {
+            return [lockImageView, urlTextField, readerModeButton].filter { !$0.hidden }
+        }
+        set {
+            super.accessibilityElements = newValue
+        }
     }
 
     required init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Strangely, on iOS 9 setting `hidden` does not suffice in some situations
to hide a view when that view is returned from
`accessibilityElements`. So let us return only non-hidden views from
`accessibilityElements` property. This does fix the bug.

Note that such a behavior is not present when having a minimal example
of view controller with bunch of buttons and labels as direct subviews
of the VC's `view`, some of them `hidden` and some of them not, all
returned by `accessibilityElements` - there, still only the non-`hidden`
views are visible to VoiceOver. So it is interesting that the location
bar exhibits this problem.

While there, let's be safe and do post an `AXLayoutChanged` notification
when the `hidden` status of one of the views changes. Maybe in iOS
10 (or rather iOS X ?), things would stop working if we did not :-),
just like they did in this case in iOS 9.

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)