### PR TITLE
Bug 1193013 - Fixed incorrect math when calculating frame transforms for tab tray -> browser animation

### DIFF
--- a/Utils/Extensions/GeometryExtensions.swift
+++ b/Utils/Extensions/GeometryExtensions.swift
@@ -14,20 +14,3 @@ extension CGRect {
         }
     }
 }
-
-/**
-Generates the affine transform for transforming the first CGRect into the second one
-
-:param: frame   CGRect to transform from
-:param: toFrame CGRect to transform to
-
-:returns: CGAffineTransform that transforms the first CGRect into the second
-*/
-func CGAffineTransformMakeRectToRect(frame: CGRect, toFrame: CGRect) -> CGAffineTransform {
-    let scale = toFrame.size.width / frame.size.width
-    let tx = toFrame.origin.x + toFrame.width / 2 - (frame.origin.x + frame.width / 2)
-    let ty = toFrame.origin.y - frame.origin.y * scale * 2
-    let translation = CGAffineTransformMakeTranslation(tx, ty)
-    let scaledAndTranslated = CGAffineTransformScale(translation, scale, scale)
-    return scaledAndTranslated
-}


### PR DESCRIPTION
Fixed the frame calculation math so it doesn't place the toolbar somewhere way above the browser which causes the animnation jank.