### PR TITLE
Bug 1193010 - Fixed UI/sync states for Sync Now button

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -11,6 +11,8 @@ import Sync
 import XCTest
 
 public class MockSyncManager: SyncManager {
+    public var isSyncing = false
+
     public func syncClients() -> SyncResult { return deferResult(.Completed) }
     public func syncClientsThenTabs() -> SyncResult { return deferResult(.Completed) }
     public func syncHistory() -> SyncResult { return deferResult(.Completed) }


### PR DESCRIPTION
This turned out to be a bit of a mess. Essentially we were doing the following:

1. We had no state anywhere indicating if we are actually syncing or not. The only 'state' we had was if we triggered the callback block from syncEverything within the SyncNowSetting class.
2. We were caching the tableView cell for AccountSettings and using that cached copy for updating and handling onClicks. This is problematic because if the user closes the settings VC and comes back, the app uses the cached version instead (and also keeps a strong ref to it so it doens't go away).
3. Since we were using a callback block to check if sync was complete, this is also problematic when the user dismisses and returns back to the Settings VC because this closure references the old self instead of the correct, now visible, self.

Here are some things I've done to fix it:

1. I've attached onto the begin/endSync methods within profile which reliably tell us when sync operations are finished.
2. Added NSNotifications for when syncing starts/finishes so we can reflect the change in our UI no matter which view is visible
3. Added the settings VC as an observer instead of SyncNowSetting because the VC is the 'owner' of the cells and it should hold the responsibility of updating it's state instead of relying on a cached version of it.
4. Added an isSyncing flag to the the BrowserProfile so have a convinent way of checking if we are currently syncing or not. I use this to toggle the title text on the cell when needed.

In general, for async operations like this where there needs to be decoupling between the view/processing, NSNotifications will help in breaking that depdendency. Using this model we can now incorporate a global toast or something to reflect the syncing state without trouble.