### PR TITLE
Bug 1193462 - Sign in from tour/remote tabs now takes you directly to signin page

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -299,9 +299,11 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
     }
 
     func SELdidClickSettingsItem() {
-        let controller = SettingsNavigationController()
-        controller.profile = profile
-        controller.tabManager = tabManager
+        let settingsTableViewController = SettingsTableViewController()
+        settingsTableViewController.profile = profile
+        settingsTableViewController.tabManager = tabManager
+
+        let controller = SettingsNavigationController(rootViewController: settingsTableViewController)
         controller.popoverDelegate = self
 		controller.modalPresentationStyle = UIModalPresentationStyle.FormSheet
         presentViewController(controller, animated: true, completion: nil)

--- a/Client/Frontend/Intro/IntroViewController.swift
+++ b/Client/Frontend/Intro/IntroViewController.swift
@@ -104,6 +104,7 @@ class IntroViewController: UIViewController, UIScrollViewDelegate {
 
         scrollView = IntroOverlayScrollView()
         scrollView.backgroundColor = UIColor.clearColor()
+        scrollView.accessibilityLabel = NSLocalizedString("Intro Tour Carousel", comment: "Accessibility label for the introduction tour carousel")
         scrollView.delegate = self
         scrollView.bounces = false
         scrollView.pagingEnabled = true

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -5,18 +5,7 @@
 import UIKit
 
 class SettingsNavigationController: UINavigationController {
-    var profile: Profile!
-    var tabManager: TabManager!
     var popoverDelegate: PresentingModalViewControllerDelegate?
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        let rootViewController = SettingsTableViewController()
-        rootViewController.profile = profile
-        rootViewController.tabManager = tabManager
-        self.pushViewController(rootViewController, animated: false)
-    }
 
     func SELdone() {
         if let delegate = popoverDelegate {

--- a/FxAClient/Frontend/SignIn/FxAContentViewController.swift
+++ b/FxAClient/Frontend/SignIn/FxAContentViewController.swift
@@ -8,7 +8,7 @@ import SnapKit
 import UIKit
 import WebKit
 
-protocol FxAContentViewControllerDelegate {
+protocol FxAContentViewControllerDelegate: class {
     func contentViewControllerDidSignIn(viewController: FxAContentViewController, data: JSON) -> Void
     func contentViewControllerDidCancel(viewController: FxAContentViewController)
 }
@@ -30,7 +30,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
         case SignOut = "sign_out"
     }
 
-    var delegate: FxAContentViewControllerDelegate?
+    weak var delegate: FxAContentViewControllerDelegate?
 
     init() {
         super.init(backgroundColor: UIColor(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0, alpha: 1.0), title: NSAttributedString(string: "Firefox Accounts"))
@@ -69,6 +69,7 @@ class FxAContentViewController: SettingsContentViewController, WKScriptMessageHa
             configuration: config
         )
         webView.navigationDelegate = self
+        webView.accessibilityLabel = NSLocalizedString("Web content", comment: "Accessibility label for the main web content view")
 
         // Don't allow overscrolling.
         webView.scrollView.bounces = false

--- a/UITests/NavigationTests.swift
+++ b/UITests/NavigationTests.swift
@@ -71,6 +71,49 @@ class NavigationTests: KIFTestCase, UITextFieldDelegate {
         tester().waitForWebViewElementWithAccessibilityLabel("Top")
     }
 
+    func testTapSignInShowsFxAFromRemoteTabPanel() {
+        tester().tapViewWithAccessibilityLabel("Synced tabs")
+        tester().tapViewWithAccessibilityLabel("Sign in")
+        tester().waitForViewWithAccessibilityLabel("Web content")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().waitForViewWithAccessibilityLabel("Sign in")
+    }
+
+    func testTapSignInShowsFxAFromTour() {
+        // Launch the tour from the settings
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().waitForAnimationsToFinish()
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().waitForAnimationsToFinish()
+        tester().tapViewWithAccessibilityLabel("Show Tour")
+        tester().waitForAnimationsToFinish()
+
+        // Swipe to the end of the tour
+        tester().swipeViewWithAccessibilityLabel("Intro Tour Carousel", inDirection: KIFSwipeDirection.Left)
+        tester().swipeViewWithAccessibilityLabel("Intro Tour Carousel", inDirection: KIFSwipeDirection.Left)
+
+        tester().tapViewWithAccessibilityLabel("Sign in to Firefox")
+        tester().waitForViewWithAccessibilityLabel("Web content")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().waitForAnimationsToFinish()
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testTapSigninShowsFxAFromSettings() {
+        // Navigation to the settings to select the signin option
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().waitForAnimationsToFinish()
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().waitForAnimationsToFinish()
+        tester().tapViewWithAccessibilityLabel("Sign in")
+        tester().waitForViewWithAccessibilityLabel("Web content")
+
+        // Go back to the home screen
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
     override func tearDown() {
         BrowserUtils.clearHistoryItems(tester(), numberOfTests: 5)
     }


### PR DESCRIPTION
Note: I needed to add a new string for the intro view's accessibilityLabel as it didn't exist before.