### PR TITLE
Bug 1186604 - Added workaround for UICollectionView contentSize animation jank bug for tab tray

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1308,7 +1308,7 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManager(tabManager: TabManager, didRemoveTab tab: Browser, atIndex: Int) {
-        urlBar.updateTabCount(tabManager.count)
+        urlBar.updateTabCount(max(tabManager.count, 1))
         // browserDelegate is a weak ref (and the tab's webView may not be destroyed yet)
         // so we don't expcitly unset it.
     }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -246,6 +246,10 @@ class TabManager : NSObject {
         for delegate in delegates {
             delegate.get()?.tabManager(self, didRemoveTab: tab, atIndex: index)
         }
+        
+        if count == 0 {
+            addTab()
+        }
 
         if flushToDisk {
         	storeChanges()


### PR DESCRIPTION
This patch fixes:

1. The invisible tabs suddenly appearing from the top when deleting a tab > 7.
2. The 'jump' that occurs when deleting the 5th tab in the list.