### PR TITLE
Bug 1178119 - Dont force uppercase on strings through code

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -265,7 +265,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         default:
             assertionFailure("Invalid history section \(section)")
         }
-        return title.uppercaseString
+        return title
     }
 
     func categoryForDate(date: MicrosecondTimestamp) -> Int {

--- a/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -156,7 +156,7 @@ class SearchSettingsTableViewController: UITableViewController {
         } else {
             sectionTitle = NSLocalizedString("Quick-search Engines", comment: "Title for quick-search engines settings section.")
         }
-        headerView.titleLabel.text = sectionTitle.uppercaseString
+        headerView.titleLabel.text = sectionTitle
 
         return headerView
     }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -812,7 +812,7 @@ class SettingsTableViewController: UITableViewController {
         let headerView = tableView.dequeueReusableHeaderFooterViewWithIdentifier(SectionHeaderIdentifier) as! SettingsTableSectionHeaderView
         let section = settings[section]
         if let sectionTitle = section.title?.string {
-            headerView.titleLabel.text = sectionTitle.uppercaseString
+            headerView.titleLabel.text = sectionTitle
         }
 
         return headerView


### PR DESCRIPTION
Removing uppercaseString calls changes the following strings from being uppercased:

L268 - HistoryPanel.swift
NSLocalizedString("Today", comment: "History tableview section header")
NSLocalizedString("Yesterday", comment: "History tableview section header")
NSLocalizedString("Last week", comment: "History tableview section header")
NSLocalizedString("Last month", comment: "History tableview section header")

L159 - SearchSettingsTableViewController.swift
NSLocalizedString("Default Search Engine", comment: "Title for default search engine settings section.")
NSLocalizedString("Quick-search Engines", comment: "Title for quick-search engines settings section.")

L815 - SettingsTableViewController
NSLocalizedString("General", comment: "General settings section title")
NSLocalizedString("Support", comment: "Support section title")
NSLocalizedString("About", comment: "About settings section title")
NSLocalizedString("Privacy", comment: "Privacy section title")