### PR TITLE
Bug 1191687 - Fall back to default context menu for VoiceOver users on iOS <9

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -68,7 +68,6 @@ function handleTouchEnd(event) {
   cancel();
 
   event.target.removeEventListener("touchend", handleTouchEnd);
-  event.target.removeEventListener("mouseup", handleTouchEnd);
   event.target.removeEventListener("touchmove", handleTouchMove);
 
   // If we're showing the context menu, prevent the page from handling the click event.
@@ -100,10 +99,7 @@ addEventListener("touchstart", function (event) {
   var element = event.target;
 
   // Listen for touchend or move events to cancel the context menu timeout.
-  // Also listen for mouseup due to touchend not being fired with VoiceOver enabled.
-  // Open bug filed as rdar://22256909.
   element.addEventListener("touchend", handleTouchEnd);
-  element.addEventListener("mouseup", handleTouchEnd);
   element.addEventListener("touchmove", handleTouchMove);
 
   do {


### PR DESCRIPTION
Removes the `mousedown`/`mouseup` workaround and adds an OS/VoiceOver check.