### PR TITLE
Bug 1197465 - Don't send referrer from error pages

### DIFF
--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -3,6 +3,9 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
+<head>
+  <meta name="referrer" content="never">
+</head>
 <body>
 <script>
   /**


### PR DESCRIPTION
Verified that the `Referer` header is gone using the Safari Web inspector.