### PR TITLE
Bug 1199338 - Replaced topLayoutGuide constraints with visual format for TabTray nav bar

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -252,9 +252,15 @@ class TabTrayController: UIViewController, UITabBarDelegate, UICollectionViewDel
     }
 
     private func makeConstraints() {
+        let viewBindings: [String: AnyObject] = [
+            "topLayoutGuide" : topLayoutGuide,
+            "navBar" : navBar
+        ]
+
+        let topConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[topLayoutGuide][navBar]", options: [], metrics: nil, views: viewBindings)
+        view.addConstraints(topConstraints)
+
         navBar.snp_makeConstraints { make in
-            let topLayoutGuide = self.topLayoutGuide as! UIView
-            make.top.equalTo(topLayoutGuide.snp_bottom)
             make.height.equalTo(UIConstants.ToolbarHeight)
             make.left.right.equalTo(self.view)
         }


### PR DESCRIPTION
SnapKit doesn't support the change to topLayoutGuide being an instance of UILayoutSupport instead of UIView yet so I've replaced it with old school visual format style constraint.