### PR TITLE
Bug 1199701 - Ensure that history is always created before tabs

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -229,6 +229,9 @@ public class BrowserProfile: Profile {
     }
 
     lazy var queue: TabQueue = {
+        if !self.dbCreated {
+            _ = self.history
+        }
         return SQLiteQueue(db: self.db)
     }()
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1199701

The order in which the various startup methods are called differs under swift 2.0 and we occasionally get into a situation whereby the tabs table is created before the history table, causing some of the browserDB views to fail on creation which then causes the history table to fail creation. Ensure that we always instantiate the history table before we create the tabs table

We should think about this when we come to reexamine the architeture of the data layer for November