### PR TITLE
Bug 1199368 - Sites don't load from entered URLs or top sites

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -11,7 +11,7 @@ class URIFixup {
 
         // First check if the URL includes a scheme. This will handle
         // all valid requests starting with "http://", "about:", etc.
-        if url?.scheme != nil {
+        if !(url?.scheme.isEmpty ?? true) {
             return url
         }
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -8,6 +8,11 @@
 	<string>$(MOZ_SOCORRO_PRODUCT_NAME)</string>
 	<key>BreakpadProductDisplay</key>
 	<string>$(MOZ_BUNDLE_DISPLAY_NAME)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>BreakpadReportInterval</key>
 	<string>$(MOZ_BREAKPAD_UPLOAD_FREQUENCY)</string>
 	<key>BreakpadServerType</key>

--- a/Storage/Logins.swift
+++ b/Storage/Logins.swift
@@ -239,7 +239,7 @@ public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatabl
 
     private class func getPasswordOrigin(uriString: String, allowJS: Bool = false) -> String? {
         var realm: String? = nil
-        if let uri = NSURL(string: uriString) {
+        if let uri = NSURL(string: uriString) where !uri.scheme.isEmpty {
             if allowJS && uri.scheme == "javascript" {
                 return "javascript:"
             }


### PR DESCRIPTION
Two separate issues:

1. iOS 9 includes App Transport Security, enabled by default, which prevents requests to non-HTTPS resources. As a general web browser, we obviously need to turn this off.
2. `NSURL.scheme` seems to be returning an empty string now instead of `nil` when it doesn't have a scheme. Seems like a bug to me, but I added an `isEmpty` check in addition to the `nil` test.