### PR TITLE
Bug 1199836 - Don't use file:/// URL for session path

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -346,7 +346,7 @@ extension TabManager {
 
     private func tabsStateArchivePath() -> String {
         let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
-        return NSURL(fileURLWithPath: documentsPath).URLByAppendingPathComponent("tabsState.archive").absoluteString
+        return NSURL(fileURLWithPath: documentsPath).URLByAppendingPathComponent("tabsState.archive").path!
     }
 
     private func preserveTabsInternal() {


### PR DESCRIPTION
Booboo from [replacing `stringByAppendingPathComponent`](https://github.com/mozilla/firefox-ios/commit/0bc7354ef0befd8e6624e87862b809cfbede3a12#diff-221fd685cced62e8c7406c0b5f24ed6cR349
). We want a regular absolute path URL, not a `file:///` URL.