### PR TITLE
Bug 1200555 - Storage Tests on Swift 2.0

### DIFF
--- a/Account/FxAClient10.swift
+++ b/Account/FxAClient10.swift
@@ -229,7 +229,7 @@ public class FxAClient10 {
 
         var URL: NSURL = self.URL.URLByAppendingPathComponent("/account/login")
         if getKeys {
-            let components = NSURLComponents(URL: self.URL.URLByAppendingPathComponent("/account/login"), resolvingAgainstBaseURL: false)!
+            let components = NSURLComponents(URL: URL, resolvingAgainstBaseURL: false)!
             components.query = "keys=true"
             URL = components.URL!
         }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "Alamofire/Alamofire" "1bc35abfa7c167ba54af4e87158af7945cc9984e"
 github "mozilla/Base32" "d2136486487a77336ae18b1bd2f9a3f689ec44e5"
 github "mozilla/Deferred" "f3d9a179cfa96a0d9b82dd575c95c29c026248bd"
-github "swisspol/GCDWebServer" "3.2.5"
+github "swisspol/GCDWebServer" "ae88198f2001226ef6d7b7a0b53cb42078ff910c"
 github "kif-framework/KIF" "5ab1d0f9288d8bb74c0e97e0e1aed0dd7771264e"
 github "ZaBlanc/RaptureXML" "76b59ec0abf68c06d27cc027d7750b6a4da08650"
 github "rs/SDWebImage" "5a5c65d7996c09931a3384e86a8b96ff8f4ac5e7"

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -285,7 +285,7 @@ public class SQLiteLogins: BrowserLogins {
         ", is_deleted " +
         ", sync_status " +
         ") " +
-        "VALUES (?,?,?,?,?,?,?,?, 1, ?,?, " +
+        "VALUES (?,?,?,?,?,1,?,?,?,?,?, " +
         "?, ?, 0, \(SyncStatus.New.rawValue)" +         // Metadata.
         ")"
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1200555
Includes crash bug in dependency GCDWebServer 

ensure that logins are saved with the correct values in the correct fields
ensure that the favicon table is correctly created before the Favicons test suite runs
Update Cartfile to get latest version of GCDWebServer that doesn't crash in background threads.