### PR TITLE
Bug 1199074 - (Swift 2.0) Encode resulting search URL to exclude special symbols

### DIFF
--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -10,6 +10,19 @@ private let TypeSearch = "text/html"
 private let TypeSuggest = "application/x-suggestions+json"
 private let SearchTermsAllowedCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789*-_."
 
+extension NSCharacterSet {
+    class func URLAllowedCharacterSet() -> NSCharacterSet {
+        let characterSet = NSMutableCharacterSet()
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLQueryAllowedCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLUserAllowedCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLPathAllowedCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLPasswordAllowedCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLHostAllowedCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLFragmentAllowedCharacterSet())
+        return characterSet
+    }
+}
+
 class OpenSearchEngine {
     static let PreferredIconSize = 30
 
@@ -47,10 +60,11 @@ class OpenSearchEngine {
 
     private func getURLFromTemplate(searchTemplate: String, query: String) -> NSURL? {
         let allowedCharacters = NSCharacterSet(charactersInString: SearchTermsAllowedCharacters)
-
         if let escapedQuery = query.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters) {
             let urlString = searchTemplate.stringByReplacingOccurrencesOfString("{searchTerms}", withString: escapedQuery, options: NSStringCompareOptions.LiteralSearch, range: nil)
-            return NSURL(string: urlString)
+            if let encodedUrlString = urlString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLAllowedCharacterSet()) {
+                return NSURL(string: encodedUrlString)
+            }
         }
 
         return nil


### PR DESCRIPTION
Turns out the wikipedia search link from OpenSearch includes japanese symbols which are not UTF8 (probably 16 or 32). NSURL struggles to encode a url with non-UTF8 characters so I've added a NSCharacterSet that includes all acceptable URL characters and excludes any symbols. This will result in non-UTF8 characters and UTF8 symbolicate characters to get percent encoded so NSURL can work.