### PR TITLE
Bug 1183905 - Add last Sync timestamp to Sync Now settings option

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -219,8 +219,17 @@ private class SyncNowSetting: WithAccountSetting {
         return profile.syncManager.isSyncing ? syncingTitle : syncNowTitle
     }
 
+    override var status: NSAttributedString? {
+        let attributedString = NSMutableAttributedString(string: "Last synced 4 minutes ago")
+        let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
+        let range = NSMakeRange(0, attributedString.length)
+        attributedString.setAttributes(attributes, range: range)
+        return attributedString
+    }
+
     override func onConfigureCell(cell: UITableViewCell) {
         cell.textLabel?.attributedText = title
+        cell.detailTextLabel?.attributedText = status
         cell.accessoryType = accessoryType
         cell.accessoryView = nil
         cell.userInteractionEnabled = !profile.syncManager.isSyncing

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -220,11 +220,16 @@ private class SyncNowSetting: WithAccountSetting {
     }
 
     override var status: NSAttributedString? {
-        let attributedString = NSMutableAttributedString(string: "Last synced 4 minutes ago")
-        let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
-        let range = NSMakeRange(0, attributedString.length)
-        attributedString.setAttributes(attributes, range: range)
-        return attributedString
+        if let timestamp = profile.prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime) {
+            let lastSyncPrefix = NSLocalizedString("Last synced", comment: "Last synced prefix beside Sync Now setting option")
+            let attributedString = NSMutableAttributedString(string: "\(lastSyncPrefix) \(NSDate.fromTimestamp(timestamp).toRelativeTimeString())")
+            let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
+            let range = NSMakeRange(0, attributedString.length)
+            attributedString.setAttributes(attributes, range: range)
+            return attributedString
+        }
+
+        return nil
     }
 
     override func onConfigureCell(cell: UITableViewCell) {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -442,9 +442,6 @@ public class BrowserProfile: Profile {
          */
         var syncLock = OSSpinLock() {
             didSet {
-                if oldValue == syncLock {
-                    return
-                }
                 let notification = syncLock == 0 ? ProfileDidFinishSyncingNotification : ProfileDidStartSyncingNotification
                 NSNotificationCenter.defaultCenter().postNotification(NSNotification(name: notification, object: nil))
             }
@@ -470,11 +467,14 @@ public class BrowserProfile: Profile {
 
             let center = NSNotificationCenter.defaultCenter()
             center.addObserver(self, selector: "onLoginDidChange:", name: NotificationDataLoginDidChange, object: nil)
+            center.addObserver(self, selector: "onFinishSyncing:", name: ProfileDidFinishSyncingNotification, object: nil)
         }
 
         deinit {
             // Remove 'em all.
-            NSNotificationCenter.defaultCenter().removeObserver(self)
+            let center = NSNotificationCenter.defaultCenter()
+            center.removeObserver(self, name: NotificationDataLoginDidChange, object: nil)
+            center.removeObserver(self, name: ProfileDidFinishSyncingNotification, object: nil)
         }
 
         // Simple in-memory rate limiting.
@@ -492,6 +492,10 @@ public class BrowserProfile: Profile {
                     self.syncLogins()
                 }
             }
+        }
+
+        @objc func onFinishSyncing(notification: NSNotification) {
+            profile.prefs.setTimestamp(NSDate.now(), forKey: PrefsKeys.KeyLastSyncFinishTime)
         }
 
         var prefsForSync: Prefs {

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -6,6 +6,7 @@ import Foundation
 
 public struct PrefsKeys {
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
+    public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
 }
 
 public protocol Prefs {


### PR DESCRIPTION
First pass at adding a timestamp label to the settings view that indicates when we last synced to give the user some feedback as to when the synced last.