### PR TITLE
Feature: Customize Home Panel Ordering

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
+		E6870E161B8E545600EE27A1 /* PanelSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6870E151B8E545600EE27A1 /* PanelSettingsViewController.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
 		E69922131B94E3EF007C480D /* about.css in Resources */ = {isa = PBXBuildFile; fileRef = E699220E1B94E3EF007C480D /* about.css */; };
@@ -1671,6 +1672,7 @@
 		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
 		E638F21D1B62B5E700B080C0 /* Breakpad.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Breakpad.xcodeproj; path = "ThirdParty/google-breakpad/src/client/ios/Breakpad.xcodeproj"; sourceTree = "<group>"; };
 		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
+		E6870E151B8E545600EE27A1 /* PanelSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanelSettingsViewController.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
 		E699220E1B94E3EF007C480D /* about.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = about.css; sourceTree = "<group>"; };
@@ -2150,6 +2152,7 @@
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
 				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
+				E6870E151B8E545600EE27A1 /* PanelSettingsViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -4452,6 +4455,7 @@
 				0B5142CC1AE1BAF50014D0B3 /* UIViewExtensions.swift in Sources */,
 				E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */,
 				E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */,
+				E6870E161B8E545600EE27A1 /* PanelSettingsViewController.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -460,19 +460,7 @@ class BrowserViewController: UIViewController {
 
     private func showHomePanelController(inline inline: Bool) {
         homePanelIsInline = inline
-
-        if homePanelController == nil {
-            homePanelController = HomePanelViewController()
-            homePanelController!.profile = profile
-            homePanelController!.delegate = self
-            homePanelController!.url = tabManager.selectedTab?.displayURL
-            homePanelController!.view.alpha = 0
-
-            addChildViewController(homePanelController!)
-            view.addSubview(homePanelController!.view)
-            homePanelController!.didMoveToParentViewController(self)
-        }
-
+        
         let panelNumber = tabManager.selectedTab?.url?.fragment
 
         // splitting this out to see if we can get better crash reports when this has a problem
@@ -482,7 +470,21 @@ class BrowserViewController: UIViewController {
                 newSelectedButtonIndex = lastInt
             }
         }
-        homePanelController?.selectedButtonIndex = newSelectedButtonIndex
+
+        // Create a new instance of the home panel if we don't have one or else just update it's selected index
+        if homePanelController == nil {
+            let viewController = HomePanelViewController(profile: profile)
+            viewController.delegate = self
+            viewController.view.alpha = 0
+
+            addChildViewController(viewController)
+            view.addSubview(viewController.view)
+            viewController.didMoveToParentViewController(self)
+
+            homePanelController = viewController
+        } else {
+            homePanelController?.selectedIndex = newSelectedButtonIndex
+        }
 
         // We have to run this animation, even if the view is already showing because there may be a hide animation running
         // and we want to be sure to override its results.

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -37,20 +37,64 @@ protocol HomePanelDelegate: class {
     optional func homePanelWillEnterEditingMode(homePanel: HomePanel)
 }
 
-class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelDelegate {
-    var profile: Profile!
-    var notificationToken: NSObjectProtocol!
-    var panels: [HomePanelDescriptor]!
-    var url: NSURL?
+class HomePanelViewController: UIViewController {
+    var profile: Profile {
+        didSet {
+            panels = HomePanels.enabledPanelsForProfile(profile)
+        }
+    }
+
+    var panels: [HomePanelDescriptor] {
+        didSet {
+            remakeButtons()
+            selectAndDisplayPanelAtIndex(selectedIndex)
+        }
+    }
+
+    var selectedIndex: Int = 0 {
+        didSet {
+            if oldValue != selectedIndex {
+                selectAndDisplayPanelAtIndex(selectedIndex)
+            }
+        }
+    }
+
     weak var delegate: HomePanelViewControllerDelegate?
 
-    private var buttonContainerView: UIView!
-    private var buttonContainerBottomBorderView: UIView!
-    private var controllerContainerView: UIView!
-    private var buttons: [UIButton] = []
+    lazy private var buttonContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = HomePanelViewControllerUX.BackgroundColor
+        view.clipsToBounds = true
+        view.accessibilityNavigationStyle = .Combined
+        view.accessibilityLabel = NSLocalizedString("Panel Chooser", comment: "Accessibility label for the Home panel's top toolbar containing list of the home panels (top sites, bookmarsk, history, remote tabs, reading list).")
 
+        let bottomBorderView = UIView()
+        bottomBorderView.backgroundColor = HomePanelViewControllerUX.ButtonContainerBorderColor
+        view.addSubview(bottomBorderView)
+
+        bottomBorderView.snp_makeConstraints { make in
+            make.top.equalTo(view.snp_bottom).offset(-1)
+            make.left.right.bottom.equalTo(view)
+        }
+
+        return view
+    }()
+
+    lazy private var controllerContainerView = UIView()
+
+    private var buttons = [UIButton]()
     private var finishEditingButton: UIButton?
     private var editingPanel: HomePanel?
+
+    init(profile: Profile) {
+        self.profile = profile
+        self.panels = HomePanels.enabledPanelsForProfile(profile)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         view.backgroundColor = HomePanelViewControllerUX.BackgroundColor
@@ -61,18 +105,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
             view.addSubview(blur)
         }
 
-        buttonContainerView = UIView()
-        buttonContainerView.backgroundColor = HomePanelViewControllerUX.BackgroundColor
-        buttonContainerView.clipsToBounds = true
-        buttonContainerView.accessibilityNavigationStyle = .Combined
-        buttonContainerView.accessibilityLabel = NSLocalizedString("Panel Chooser", comment: "Accessibility label for the Home panel's top toolbar containing list of the home panels (top sites, bookmarsk, history, remote tabs, reading list).")
         view.addSubview(buttonContainerView)
-
-        self.buttonContainerBottomBorderView = UIView()
-        buttonContainerView.addSubview(buttonContainerBottomBorderView)
-        buttonContainerBottomBorderView.backgroundColor = HomePanelViewControllerUX.ButtonContainerBorderColor
-
-        controllerContainerView = UIView()
         view.addSubview(controllerContainerView)
 
         blur?.snp_makeConstraints { make in
@@ -82,11 +115,6 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
         buttonContainerView.snp_makeConstraints { make in
             make.top.left.right.equalTo(self.view)
             make.height.equalTo(HomePanelViewControllerUX.ButtonContainerHeight)
-        }
-
-        buttonContainerBottomBorderView.snp_makeConstraints { make in
-            make.top.equalTo(self.buttonContainerView.snp_bottom).offset(-1)
-            make.left.right.bottom.equalTo(self.buttonContainerView)
         }
 
         controllerContainerView.snp_makeConstraints { make in
@@ -103,93 +131,74 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         self.panels = HomePanels.enabledPanelsForProfile(profile)
-        updateButtons()
-    }
-
-    func SELhandleDismissKeyboardGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {
-        view.window?.rootViewController?.view.endEditing(true)
-    }
-
-    var selectedButtonIndex: Int? = nil {
-        didSet {
-            if oldValue == selectedButtonIndex {
-                // Prevent flicker, allocations, and disk access: avoid duplicate view controllers.
-                return
-            }
-
-            if let index = oldValue {
-                if index < buttons.count {
-                    let currentButton = buttons[index]
-                    currentButton.selected = false
-                }
-            }
-
-            hideCurrentPanel()
-
-            if let index = selectedButtonIndex {
-                if index < buttons.count {
-                    let newButton = buttons[index]
-                    newButton.selected = true
-                }
-
-                if index < panels.count {
-                    let panel = self.panels[index].makeViewController(profile: profile)
-                    (panel as? HomePanel)?.homePanelDelegate = self
-                    panel.view.accessibilityNavigationStyle = .Combined
-                    panel.view.accessibilityLabel = self.panels[index].accessibilityLabel
-                    self.showPanel(panel)
-                }
-            }
-        }
     }
 
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
         return UIStatusBarStyle.LightContent
     }
+}
 
-    private func hideCurrentPanel() {
-        if let panel = childViewControllers.first {
-            panel.willMoveToParentViewController(nil)
-            panel.view.removeFromSuperview()
-            panel.removeFromParentViewController()
-        }
+// MARK: - Selectors
+private extension HomePanelViewController {
+    @objc func SELhandleDismissKeyboardGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {
+        view.window?.rootViewController?.view.endEditing(true)
     }
 
-    private func showPanel(panel: UIViewController) {
-        addChildViewController(panel)
-        controllerContainerView.addSubview(panel.view)
-        panel.view.snp_makeConstraints { make in
-            make.top.equalTo(self.buttonContainerView.snp_bottom)
-            make.left.right.bottom.equalTo(self.view)
-        }
-        panel.didMoveToParentViewController(self)
+    @objc func SELtappedButton(sender: UIButton!) {
+        selectedIndex = sender.tag
+        selectAndDisplayPanelAtIndex(selectedIndex)
+        delegate?.homePanelViewController(self, didSelectPanel: selectedIndex)
     }
 
-    func SELtappedButton(sender: UIButton!) {
-        for (index, button) in buttons.enumerate() {
-            if (button == sender) {
-                selectedButtonIndex = index
-                delegate?.homePanelViewController(self, didSelectPanel: index)
-                break
-            }
-        }
-    }
-
-    func endEditing(sender: UIButton!) {
+    @objc func endEditing(sender: UIButton!) {
         toggleEditingMode(false)
         editingPanel?.endEditing?()
         editingPanel = nil
     }
+}
 
-    private func updateButtons() {
+// MARK: - Helper methods
+private extension HomePanelViewController {
+    func selectAndDisplayPanelAtIndex(index: Int) {
+        // Deselect all the buttons and select the new index
+        buttons.forEach { $0.selected = false }
+        if index < buttons.count {
+            buttons[index].selected = true
+        }
+
+        if let currentPanel = childViewControllers.first {
+            currentPanel.willMoveToParentViewController(nil)
+            currentPanel.view.removeFromSuperview()
+            currentPanel.removeFromParentViewController()
+        }
+
+        // Build the panel at the given index and display it
+        if index < panels.count {
+            let panel = self.panels[index].makeViewController(profile: profile)
+            (panel as? HomePanel)?.homePanelDelegate = self
+            panel.view.accessibilityNavigationStyle = .Combined
+            panel.view.accessibilityLabel = self.panels[index].accessibilityLabel
+
+            addChildViewController(panel)
+            controllerContainerView.addSubview(panel.view)
+            panel.view.snp_makeConstraints { make in
+                make.top.equalTo(self.buttonContainerView.snp_bottom)
+                make.left.right.bottom.equalTo(self.view)
+            }
+            panel.didMoveToParentViewController(self)
+        }
+    }
+
+    func remakeButtons() {
         // Remove any existing buttons if we're rebuilding the toolbar.
         for button in buttons {
             button.removeFromSuperview()
         }
         buttons.removeAll()
 
-        var prev: UIView? = nil
-        for panel in panels {
+        var prev: UIButton?
+        for i in 0..<panels.count {
+            let panel = panels[i]
             let button = UIButton()
             buttonContainerView.addSubview(button)
             button.addTarget(self, action: "SELtappedButton:", forControlEvents: UIControlEvents.TouchUpInside)
@@ -200,8 +209,8 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
                 button.setImage(image, forState: UIControlState.Selected)
             }
             button.accessibilityLabel = panel.accessibilityLabel
+            button.tag = i
             buttons.append(button)
-
             button.snp_remakeConstraints { make in
                 let left = prev?.snp_right ?? self.view.snp_left
                 make.left.equalTo(left)
@@ -212,7 +221,9 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
             prev = button
         }
     }
+}
 
+extension HomePanelViewController: HomePanelDelegate {
     func homePanel(homePanel: HomePanel, didSelectURL url: NSURL, visitType: VisitType) {
         delegate?.homePanelViewController(self, didSelectURL: url, visitType: visitType)
         dismissViewControllerAnimated(true, completion: nil)

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -94,13 +94,16 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
             make.left.right.bottom.equalTo(self.view)
         }
 
-        self.panels = HomePanels().enabledPanels
-        updateButtons()
-
         // Gesture recognizer to dismiss the keyboard in the URLBarView when the buttonContainerView is tapped
         let dismissKeyboardGestureRecognizer = UITapGestureRecognizer(target: self, action: "SELhandleDismissKeyboardGestureRecognizer:")
         dismissKeyboardGestureRecognizer.cancelsTouchesInView = false
         buttonContainerView.addGestureRecognizer(dismissKeyboardGestureRecognizer)
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        self.panels = HomePanels.enabledPanelsForProfile(profile)
+        updateButtons()
     }
 
     func SELhandleDismissKeyboardGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -4,59 +4,124 @@
 
 import Foundation
 import UIKit
+import Shared
 
 /**
  * Data for identifying and constructing a HomePanel.
  */
-struct HomePanelDescriptor {
-    let makeViewController: (profile: Profile) -> UIViewController
+struct HomePanelDescriptor: CustomStringConvertible {
+    let className: String
+    let makeViewController: PanelGenerator
     let imageName: String
     let accessibilityLabel: String
+
+    var description: String {
+        return "{ \(accessibilityLabel) }"
+    }
+
+    init(className: String, imageName: String, accessibilityLabel: String) {
+        self.className = className
+        self.imageName = imageName
+        self.accessibilityLabel = accessibilityLabel
+        makeViewController = { panelForClassName(className, withProfile: $0)! }
+    }
+
+    init(json: JSON) {
+        let _className = json["className"].asString!
+        imageName = json["imageName"].asString!
+        accessibilityLabel = json["accessibilityLabel"].asString!
+        makeViewController = { panelForClassName(_className, withProfile: $0)! }
+        className = _className
+    }
+
+    func jsonStringify() -> String {
+        let jsonDict = [
+            "className": className,
+            "imageName": imageName,
+            "accessibilityLabel": accessibilityLabel
+        ]
+        return JSON.stringify(jsonDict)
+    }
 }
 
+typealias PanelGenerator = (profile: Profile) -> UIViewController
+
+private enum SupportedPanels: String {
+    case TopSitesPanel = "TopSitesPanel"
+    case BookmarksPanel = "BookmarksPanel"
+    case HistoryPanel = "HistoryPanel"
+    case RemoteTabsPanel = "RemoteTabsPanel"
+    case ReadingListPanel = "ReadingListPanel"
+}
+
+private func panelForClassName(className: String, withProfile profile: Profile) -> UIViewController? {
+    if let panel = SupportedPanels(rawValue: className) {
+        switch panel {
+        case .TopSitesPanel:
+            let vc = TopSitesPanel(profile: profile)
+            return vc
+        case .BookmarksPanel:
+            let vc = BookmarksPanel()
+            vc.profile = profile
+            return vc
+        case .HistoryPanel:
+            let vc = HistoryPanel()
+            vc.profile = profile
+            return vc
+        case .RemoteTabsPanel:
+            let vc = RemoteTabsPanel()
+            vc.profile = profile
+            return vc
+        case .ReadingListPanel:
+            let vc = ReadingListPanel()
+            vc.profile = profile
+            return vc
+        }
+    } else {
+        // Unsupported panel!
+        return nil
+    }
+}
+
+private var defaultPanels: [HomePanelDescriptor] = [
+    HomePanelDescriptor(
+        className: "TopSitesPanel",
+        imageName: "TopSites",
+        accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label")
+    ),
+
+    HomePanelDescriptor(
+        className: "BookmarksPanel",
+        imageName: "Bookmarks",
+        accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label")
+    ),
+
+    HomePanelDescriptor(
+        className: "HistoryPanel",
+        imageName: "History",
+        accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label")
+    ),
+
+    HomePanelDescriptor(
+        className: "RemoteTabsPanel",
+        imageName: "SyncedTabs",
+        accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label")
+    ),
+
+    HomePanelDescriptor(
+        className: "ReadingListPanel",
+        imageName: "ReadingList",
+        accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label")
+    )
+]
+
 class HomePanels {
-    let enabledPanels = [
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                TopSitesPanel(profile: profile)
-            },
-            imageName: "TopSites",
-            accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label")),
+    class func enabledPanelsForProfile(profile: Profile) -> [HomePanelDescriptor] {
 
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = BookmarksPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "Bookmarks",
-            accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label")),
-
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = HistoryPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "History",
-            accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label")),
-
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = RemoteTabsPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "SyncedTabs",
-            accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label")),
-
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = ReadingListPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "ReadingList",
-            accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label")),
-    ]
+        if let jsonStrings = profile.prefs.stringArrayForKey("homePanels.enabled") {
+            return jsonStrings.map { HomePanelDescriptor(json: JSON.parse($0)) }
+        } else {
+            return defaultPanels
+        }
+    }
 }

--- a/Client/Frontend/Settings/PanelSettingsViewController.swift
+++ b/Client/Frontend/Settings/PanelSettingsViewController.swift
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+/// View controller where the user can configure their home panels
+class PanelSettingsViewController: UITableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Client/Frontend/Settings/PanelSettingsViewController.swift
+++ b/Client/Frontend/Settings/PanelSettingsViewController.swift
@@ -4,9 +4,107 @@
 
 import UIKit
 
+// Cell that displays the Panel name
+private class PanelCell: UITableViewCell {
+    static let Identifier = "PanelCell"
+
+    lazy var panelTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFontOfSize(UIConstants.DefaultStandardFontSize, weight: UIFontWeightRegular)
+        label.textColor = UIColor.blackColor()
+        return label
+    }()
+
+    lazy var panelIcon: UIImageView = {
+        let icon = UIImageView()
+        icon.contentMode = UIViewContentMode.ScaleAspectFit
+        return icon
+    }()
+
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        showsReorderControl = true
+
+        contentView.addSubview(panelTitleLabel)
+        contentView.addSubview(panelIcon)
+
+        panelIcon.snp_makeConstraints { make in
+            make.centerY.equalTo(contentView)
+            make.left.equalTo(contentView).offset(20)
+            make.size.equalTo(CGSize(width: 32, height: 20))
+        }
+
+        panelTitleLabel.snp_makeConstraints { make in
+            make.centerY.equalTo(contentView)
+            make.left.equalTo(panelIcon.snp_right).offset(20)
+            make.right.equalTo(contentView).offset(-20)
+        }
+    }
+
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View controller where the user can configure their home panels
 class PanelSettingsViewController: UITableViewController {
+    var panels = [HomePanelDescriptor]()
+    var profile: Profile!
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = NSLocalizedString("Panel Settings", comment: "Title for Customize Home Panels setting page")
+        tableView.registerClass(PanelCell.self, forCellReuseIdentifier: PanelCell.Identifier)
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        editing = true
+        panels = HomePanels.enabledPanelsForProfile(profile)
+        tableView.reloadData()
+    }
+
+    override func viewDidDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        let jsonStrings = panels.map { $0.jsonStringify() }
+        profile.prefs.setStringArray(jsonStrings, forKey: "homePanels.enabled")
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return panels.count
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier(PanelCell.Identifier, forIndexPath: indexPath) as! PanelCell
+        let panelDescriptor = panels[indexPath.row]
+        cell.panelTitleLabel.text = panelDescriptor.accessibilityLabel
+        cell.panelIcon.image = UIImage(named: "panelIcon\(panelDescriptor.imageName)")
+        return cell
+    }
+
+    override func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(tableView: UITableView, editingStyleForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCellEditingStyle {
+        return UITableViewCellEditingStyle.None
+    }
+
+    override func tableView(tableView: UITableView, shouldIndentWhileEditingRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return false
+    }
+
+    override func tableView(tableView: UITableView, moveRowAtIndexPath sourceIndexPath: NSIndexPath, toIndexPath destinationIndexPath: NSIndexPath) {
+        let movedPanel = panels[sourceIndexPath.row]
+        panels.removeAtIndex(sourceIndexPath.row)
+        panels.insert(movedPanel, atIndex: destinationIndexPath.row)
+    }
+
+    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+
+    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 1
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -607,6 +607,7 @@ private class CustomizeHomePanelsSetting: Setting {
 
     override func onClick(navigationController: UINavigationController?) {
         let viewController = PanelSettingsViewController()
+        viewController.profile = profile
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -592,6 +592,25 @@ private class SearchSetting: Setting {
     }
 }
 
+// Home panel configuration setting
+private class CustomizeHomePanelsSetting: Setting {
+    let profile: Profile
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var style: UITableViewCellStyle { return .Value1 }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(title: NSAttributedString(string: NSLocalizedString("Customize Home Panels", comment: "Title for custom home panels setting option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = PanelSettingsViewController()
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 private class ClearPrivateDataSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
@@ -725,6 +744,8 @@ class SettingsTableViewController: UITableViewController {
         if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
             generalSettings +=  [UseCompactTabLayoutSetting(settings: self)]
         }
+
+        generalSettings += [CustomizeHomePanelsSetting(settings: self)]
 
         settings += [
             SettingSection(title: nil, children: [

--- a/Providers/NSUserDefaultsPrefs.swift
+++ b/Providers/NSUserDefaultsPrefs.swift
@@ -55,6 +55,10 @@ public class NSUserDefaultsPrefs: Prefs {
         setObject(value, forKey: defaultName)
     }
 
+    public func setStringArray(value: [String], forKey defaultName: String) {
+        setObject(value, forKey: defaultName)
+    }
+
     public func setObject(value: AnyObject?, forKey defaultName: String) {
         userDefaults.setObject(value, forKey: qualifyKey(defaultName))
     }

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -17,6 +17,7 @@ public protocol Prefs {
     func setString(value: String, forKey defaultName: String)
     func setBool(value: Bool, forKey defaultName: String)
     func setObject(value: AnyObject?, forKey defaultName: String)
+    func setStringArray(value: [String], forKey defaultName: String)
     func stringForKey(defaultName: String) -> String?
     func boolForKey(defaultName: String) -> Bool?
     func intForKey(defaultName: String) -> Int32?
@@ -70,6 +71,10 @@ public class MockProfilePrefs : Prefs {
     }
 
     public func setString(value: String, forKey defaultName: String) {
+        things[name(defaultName)] = value
+    }
+
+    public func setStringArray(value: [String], forKey defaultName: String) {
         things[name(defaultName)] = value
     }
 


### PR DESCRIPTION
Just wanted to open this PR to clean up the diffs and commits. 

Motivation:

Part of using home panel addons is the ability for the user to customize which home panels they want to see. This includes removing panels they don't want to see and changing their order. Before getting a Firefox Hub/Home panel addon working, I wanted to be able to have a simple way for users to customize their home panel experience by allowing them to change the order in which they appear. As a side effect, this code starts us on the path of un-hard coding which panels we display to the user and moves that data into a data format (JSON) to allow the application to be extensible. 

Changes:

* Refactors HomePanels.swift to allow reading a user's enabled panels from their profile stored under "homePanels.enabled"
* Adds JSON serializing to our existing HomePanelDescriptor struct to transform the data format used in the application to one we can add to our BrowserProfile
* Adds a new setting option named 'Customize Home Panels' which displays a list of our home panels with the ability to move/reorder them

What's next:

I want to be able to download a .xpi file, infer a similar JSON model for that addon, and add it to the mix of panels we can customize. Part of this will be recognizing when we navigating to an .xpi link, show a simple snackbar, and download the file to disk. From there, the application should be able to scan addons that are on disk, determine which ones support a Firefox hub/home panel interface, and add it to our panel settings screen to allow the user to add it to their enabled selection. Lastly, to display the addon, will need to make a template native view that a hub addon can configure (such as a GridView), implement the HomeProvider/Storage/Home.jsm APIs in swift, and allow the downloaded .xpi to execute it's bootstrap.js code to configure the Firefox hub panel.