### PR TITLE
Bug 1200554 - client test failures under swift 2.0

### DIFF
--- a/ClientTests/ClientTests.swift
+++ b/ClientTests/ClientTests.swift
@@ -66,7 +66,7 @@ class ClientTests: XCTestCase {
         let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
 
         let compare: String -> Bool = { ua in
-            let range = ua.rangeOfString("^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) FxiOS/\(appVersion) Mobile/[A-Z0-9]+ Safari/[0-9\\.]+$", options: NSStringCompareOptions.RegularExpressionSearch)
+            let range = ua.rangeOfString("^Mozilla/5\\.0 \\(.+\\) AppleWebKit/[0-9\\.]+ \\(KHTML, like Gecko\\) FxiOS/\(appVersion) Mobile/[A-Za-z0-9]+ Safari/[0-9\\.]+$", options: NSStringCompareOptions.RegularExpressionSearch)
             return range != nil
         }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1200554

Fix regex for user agent to enable it to handle lower case characters
Ensure that HTML percent chars are decoded before testing query in suggestions server