### PR TITLE
Bug 1201131 - Retain our Alamofire.Manager in returned closures to allow for transient use of FaviconFetcher, FxAClient10, and TokenServerClient.

### DIFF
--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -75,14 +75,17 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
     private func fetchDataForURL(url: NSURL) -> Deferred<Maybe<NSData>> {
         let deferred = Deferred<Maybe<NSData>>()
         alamofire.request(.GET, url).response { (request, response, data, error) in
-            if error == nil {
-                if let data = data {
-                    deferred.fill(Maybe(success: data))
-                    return
+            // Don't cancel requests just because our Manager is deallocated.
+            withExtendedLifetime(self.alamofire) {
+                if error == nil {
+                    if let data = data {
+                        deferred.fill(Maybe(success: data))
+                        return
+                    }
                 }
-            }
 
-            deferred.fill(Maybe(failure: FaviconFetcherErrorType(description: error?.description ?? "No content.")))
+                deferred.fill(Maybe(failure: FaviconFetcherErrorType(description: error?.description ?? "No content.")))
+            }
         }
         return deferred
     }


### PR DESCRIPTION
This wasn't so much a test problem as a real bug that we happened not to tickle yet.

We introduced separate `Alamofire.Manager` instances to allow for different UAs and cookie policies. Those were scoped to their instances. In our test code (and elsewhere!) we had a pattern like this:

```
let x = SomeThing().triggerARequest().gimme()
```

`SomeThing` owned the `Manager`. As soon as the request was triggered, we'd release `SomeThing`. This happened while the request was still in flight. But releasing `SomeThing` released its `Manager`, and `Manager.deinit` cancels all outstanding requests.

This fix is to retain our `Manager` while the request is in flight. We do this through a very simple `_ = self.alamofire` at the top of the response-handling closure; as soon as the closure exits it'll release the `Manager`, and the right thing will happen.

This makes the Sync live tests work for me.