### PR TITLE
Bug 1199367 - Use normalizedHost, not baseDomain, on Top Sites.

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -387,7 +387,7 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         //
         // Instead we'll painstakingly re-extract those things here.
 
-        let domainURL = NSURL(string: site.url)?.baseDomain() ?? site.url
+        let domainURL = NSURL(string: site.url)?.normalizedHost() ?? site.url
         cell.textLabel.text = domainURL
         cell.imageWrapper.backgroundColor = UIColor.clearColor()
 
@@ -420,7 +420,7 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
     }
 
     private func createTileForSuggestedSite(cell: ThumbnailCell, site: SuggestedSite) -> ThumbnailCell {
-        cell.textLabel.text = site.title.isEmpty ? NSURL(string: site.url)?.baseDomainAndPath() : site.title
+        cell.textLabel.text = site.title.isEmpty ? NSURL(string: site.url)?.normalizedHostAndPath() : site.title
         cell.imageWrapper.backgroundColor = site.backgroundColor
         cell.backgroundImage.image = nil
 

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -97,9 +97,9 @@ extension NSURL {
         return nil
     }
     
-    public func baseDomainAndPath() -> String? {
-        if let baseDomain = self.baseDomain() {
-            return baseDomain + (self.path ?? "/")
+    public func normalizedHostAndPath() -> String? {
+        if let normalizedHost = self.normalizedHost() {
+            return normalizedHost + (self.path ?? "/")
         }
         return nil
     }


### PR DESCRIPTION
This is branched off some test fixes, so ignore the first commit.

How this looks:

<img width="368" alt="screenshot 2015-09-02 17 58 59" src="https://cloud.githubusercontent.com/assets/91722/9648328/50f4856a-519c-11e5-8ec2-a27319d402d7.png">
