### PR TITLE
Bug 1201350 - Change allSucceed() to be an extension on [Success]

### DIFF
--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -178,9 +178,9 @@ public class ClientsSynchronizer: BaseSingleCollectionSynchronizer, Synchronizer
 
     private func uploadClientCommands(toLocalClients localClients: RemoteClientsAndTabs, withServer storageClient: Sync15CollectionClient<ClientPayload>) -> Success {
         return localClients.getCommands() >>== { clientCommands in
-            return allSucceed(clientCommands.map { (clientGUID, commands) -> Success in
+            return clientCommands.map { (clientGUID, commands) -> Success in
                 self.syncClientCommands(clientGUID, commands: commands, clientsAndTabs: localClients, withServer: storageClient)
-            })
+            }.allSucceed()
         }
     }
 

--- a/Utils/DeferredUtils.swift
+++ b/Utils/DeferredUtils.swift
@@ -126,25 +126,15 @@ public func walk<T, U>(items: [T], start: Deferred<Maybe<U>>, f: (T, U) -> Defer
 /**
  * Like `all`, but doesn't accrue individual values.
  */
-public func allSucceed(deferreds: Success...) -> Success {
-    return all(deferreds).bind {
-        (results) -> Success in
-        if let failure = find(results, f: { $0.isFailure }) {
-            return deferMaybe(failure.failureValue!)
+extension Array where Element: Success {
+    public func allSucceed() -> Success {
+        return all(self).bind { results -> Success in
+            if let failure = find(results, f: { $0.isFailure }) {
+                return deferMaybe(failure.failureValue!)
+            }
+
+            return succeed()
         }
-
-        return succeed()
-    }
-}
-
-public func allSucceed(deferreds: [Success]) -> Success {
-    return all(deferreds).bind {
-        (results) -> Success in
-        if let failure = find(results, f: { $0.isFailure }) {
-            return deferMaybe(failure.failureValue!)
-        }
-
-        return succeed()
     }
 }
 


### PR DESCRIPTION
Before:
```
allSucceed(clearables
    .enumerate()
    .filter { (i, _) in toggledIndices[i] }
    .map { (_, clearable) in clearable.clear() }
).upon { result in
    ...
}
```

After:
```
clearables
    .enumerate()
    .filter { (i, _) in toggledIndices[i] }
    .map { (_, clearable) in clearable.clear() }
    .allSucceed()
    .upon { result in
        ...
    }
```