### PR TITLE
Bug 1201642 - Make UI for clearing existing private data items individually

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		D3C744D01A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3E171C21A841EAD00AB44CD /* KIFHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = D3E171C11A841EAD00AB44CD /* KIFHelper.js */; };
+		D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */; settings = {ASSET_TAGS = (); }; };
 		D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA777A1A43B2990010CD32 /* SearchTests.swift */; };
 		D3FA77971A43B5390010CD32 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D3FEC38D1AC4B42F00494F45 /* AutocompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */; };
@@ -1543,6 +1544,7 @@
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
 		D3E171C11A841EAD00AB44CD /* KIFHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = KIFHelper.js; sourceTree = "<group>"; };
+		D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTableViewController.swift; sourceTree = "<group>"; };
 		D3FA777A1A43B2990010CD32 /* SearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTests.swift; sourceTree = "<group>"; };
 		D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSearch.swift; sourceTree = "<group>"; };
 		D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocompleteTextField.swift; sourceTree = "<group>"; };
@@ -2152,6 +2154,7 @@
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
 				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
+				D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -4484,6 +4487,7 @@
 				D38B2D491A8D96D00040E6B5 /* GCDWebServerDataResponse.m in Sources */,
 				E4C358551AF144BA00299F7E /* FSReadingList.m in Sources */,
 				D38B2D521A8D96D00040E6B5 /* GCDWebServerStreamedResponse.m in Sources */,
+				D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */,
 				59A68FD5260B8D520F890F4A /* ReaderPanel.swift in Sources */,
 				E42475E21AB73B9B00B23D33 /* SWTableViewCell.m in Sources */,
 				E40FAB0C1A7ABB77009CB80D /* WebServer.swift in Sources */,

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -33,7 +33,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     init() {
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataCleared, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -42,12 +41,11 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataCleared, object: nil)
     }
 
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataCleared:
+        case NotificationFirefoxAccountChanged:
             self.reloadData()
             break
         default:

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -54,7 +54,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
     init() {
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataCleared, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataClearedHistory, object: nil)
     }
 
     override func viewDidLoad() {
@@ -81,12 +81,12 @@ class HistoryPanel: SiteTableViewController, HomePanel {
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataCleared, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataClearedHistory, object: nil)
     }
 
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataCleared:
+        case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
             resyncHistory()
             break
         default:

--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -231,7 +231,6 @@ class ReadingListPanel: UITableViewController, HomePanel, SWTableViewCellDelegat
     init() {
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataCleared, object: nil)
     }
 
     required init!(coder aDecoder: NSCoder) {
@@ -266,12 +265,11 @@ class ReadingListPanel: UITableViewController, HomePanel, SWTableViewCellDelegat
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataCleared, object: nil)
     }
 
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataCleared:
+        case NotificationFirefoxAccountChanged:
             refreshReadingList()
             break
         default:

--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -47,7 +47,6 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
     init() {
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataCleared, object: nil)
     }
 
     required init!(coder aDecoder: NSCoder) {
@@ -72,7 +71,6 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataCleared, object: nil)
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -88,7 +86,7 @@ class RemoteTabsPanel: UITableViewController, HomePanel {
 
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataCleared:
+        case NotificationFirefoxAccountChanged:
             refreshTabs()
             break
         default:

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -56,7 +56,7 @@ class TopSitesPanel: UIViewController {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataCleared, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataClearedHistory, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -81,12 +81,12 @@ class TopSitesPanel: UIViewController {
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataCleared, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataClearedHistory, object: nil)
     }
     
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataCleared:
+        case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
             refreshHistory(self.layout.thumbnailCount)
             break
         default:

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+
+private let SectionToggles = 0
+private let SectionButton = 1
+private let NumberOfSections = 2
+private let SectionHeaderIdentifier = "SectionHeaderIdentifier"
+private let HeaderHeight: CGFloat = 44
+
+class ClearPrivateDataTableViewController: UITableViewController {
+    private var clearButton: UITableViewCell?
+
+    var profile: Profile!
+    var tabManager: TabManager!
+
+    private lazy var clearables: [Clearable] = {
+        return [
+            HistoryClearable(profile: self.profile),
+            CacheClearable(tabManager: self.tabManager),
+            CookiesClearable(tabManager: self.tabManager),
+            SiteDataClearable(tabManager: self.tabManager),
+            PasswordsClearable(profile: self.profile),
+        ]
+    }()
+
+    private lazy var toggledIndices: [Bool] = {
+        return [Bool](count: self.clearables.count, repeatedValue: true)
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = NSLocalizedString("Clear Private Data", comment: "Navigation title for clearing private data.")
+
+        tableView.registerClass(SettingsTableSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderIdentifier)
+
+        tableView.separatorColor = UIConstants.TableViewSeparatorColor
+        tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+
+        tableView.tableFooterView = UIView()
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: nil)
+
+        if indexPath.section == SectionToggles {
+            cell.textLabel?.text = clearables[indexPath.item].label
+            let control = UISwitch()
+            control.onTintColor = UIConstants.ControlTintColor
+            control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
+            control.on = true
+            cell.accessoryView = control
+            cell.selectionStyle = .None
+            control.tag = indexPath.item
+        } else {
+            assert(indexPath.section == SectionButton)
+            cell.textLabel?.text = NSLocalizedString("Clear Private Data", comment: "Button in settings that clears private data for the selected items.")
+            cell.textLabel?.textAlignment = NSTextAlignment.Center
+            cell.textLabel?.textColor = UIConstants.DestructiveRed
+            clearButton = cell
+        }
+
+        // Make the separator line fill the entire table width.
+        cell.separatorInset = UIEdgeInsetsZero
+
+        return cell
+    }
+
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return NumberOfSections
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == SectionToggles {
+            return clearables.count
+        }
+
+        assert(section == SectionButton)
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        guard indexPath.section == SectionButton else { return false }
+
+        // Highlight the button only if at least one clearable is enabled.
+        return toggledIndices.contains(true)
+    }
+
+    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        guard indexPath.section == SectionButton else { return }
+
+        clearables
+            .enumerate()
+            .filter { (i, _) in toggledIndices[i] }
+            .map { (_, clearable) in clearable.clear() }
+            .allSucceed()
+            .upon { result in
+                // TODO: Need some kind of success/failure UI. Bug 1202093.
+                if result.isSuccess {
+                    print("Private data cleared")
+                } else {
+                    print("Error clearing private data")
+                    assertionFailure("\(result.failureValue)")
+                }
+
+                dispatch_async(dispatch_get_main_queue()) {
+                    self.navigationController?.popViewControllerAnimated(true)
+                }
+        }
+    }
+
+    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return tableView.dequeueReusableHeaderFooterViewWithIdentifier(SectionHeaderIdentifier) as! SettingsTableSectionHeaderView
+    }
+
+    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return HeaderHeight
+    }
+
+    @objc func switchValueChanged(toggle: UISwitch) {
+        toggledIndices[toggle.tag] = toggle.on
+
+        // Dim the clear button if no clearables are selected.
+        clearButton?.textLabel?.textColor = toggledIndices.contains(true) ? UIConstants.DestructiveRed : UIColor.lightGrayColor()
+    }
+}

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -10,7 +10,7 @@ protocol Clearable {
     func clear() -> Success
 }
 
-class ClearableError : MaybeErrorType {
+class ClearableError: MaybeErrorType {
     private let msg: String
     init(msg: String) {
         self.msg = msg
@@ -20,28 +20,25 @@ class ClearableError : MaybeErrorType {
 }
 
 // Clears our browsing history, including favicons and thumbnails.
-class HistoryClearable : Clearable {
+class HistoryClearable: Clearable {
     let profile: Profile
     init(profile: Profile) {
         self.profile = profile
     }
 
-    // TODO: This can be cleaned up!
     func clear() -> Success {
-        let deferred = Success()
-        profile.history.clearHistory().upon { success in
+        return profile.history.clearHistory().bind { success in
             SDImageCache.sharedImageCache().clearDisk()
             SDImageCache.sharedImageCache().clearMemory()
             NSNotificationCenter.defaultCenter().postNotificationName(NotificationPrivateDataClearedHistory, object: nil)
-            deferred.fill(Maybe(success: ()))
+            return Deferred(value: success)
         }
-        return deferred
     }
 }
 
 // Clear all stored passwords. This will clear both Firefox's SQLite storage and the system shared
 // Credential storage.
-class PasswordsClearable : Clearable {
+class PasswordsClearable: Clearable {
     let profile: Profile
     init(profile: Profile) {
         self.profile = profile
@@ -76,7 +73,7 @@ struct ClearableErrorType: MaybeErrorType {
 
 // Clear the web cache. Note, this has to close all open tabs in order to ensure the data
 // cached in them isn't flushed to disk.
-class CacheClearable : Clearable {
+class CacheClearable: Clearable {
     let tabManager: TabManager
     init(tabManager: TabManager) {
         self.tabManager = tabManager
@@ -143,7 +140,7 @@ class SiteDataClearable : Clearable {
 }
 
 // Remove all cookies stored by the site.
-class CookiesClearable : Clearable {
+class CookiesClearable: Clearable {
     let tabManager: TabManager
     init(tabManager: TabManager) {
         self.tabManager = tabManager

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -32,6 +32,7 @@ class HistoryClearable : Clearable {
         profile.history.clearHistory().upon { success in
             SDImageCache.sharedImageCache().clearDisk()
             SDImageCache.sharedImageCache().clearMemory()
+            NSNotificationCenter.defaultCenter().postNotificationName(NotificationPrivateDataClearedHistory, object: nil)
             deferred.fill(Maybe(success: ()))
         }
         return deferred

--- a/Client/Frontend/Settings/Clearables.swift
+++ b/Client/Frontend/Settings/Clearables.swift
@@ -8,6 +8,7 @@ import Shared
 // A base protocol for something that can be cleared.
 protocol Clearable {
     func clear() -> Success
+    var label: String { get }
 }
 
 class ClearableError: MaybeErrorType {
@@ -26,6 +27,10 @@ class HistoryClearable: Clearable {
         self.profile = profile
     }
 
+    var label: String {
+        return NSLocalizedString("Browsing data", comment: "Settings item for clearing browsing history")
+    }
+
     func clear() -> Success {
         return profile.history.clearHistory().bind { success in
             SDImageCache.sharedImageCache().clearDisk()
@@ -42,6 +47,10 @@ class PasswordsClearable: Clearable {
     let profile: Profile
     init(profile: Profile) {
         self.profile = profile
+    }
+
+    var label: String {
+        return NSLocalizedString("Saved logins", comment: "Settings item for clearing passwords and login data")
     }
 
     func clear() -> Success {
@@ -77,6 +86,10 @@ class CacheClearable: Clearable {
     let tabManager: TabManager
     init(tabManager: TabManager) {
         self.tabManager = tabManager
+    }
+
+    var label: String {
+        return NSLocalizedString("Cache", comment: "Settings item for clearing the cache")
     }
 
     func clear() -> Success {
@@ -124,6 +137,10 @@ class SiteDataClearable : Clearable {
         self.tabManager = tabManager
     }
 
+    var label: String {
+        return NSLocalizedString("Offline website data", comment: "Settings item for clearing website data")
+    }
+
     func clear() -> Success {
         // First, close all tabs to make sure they don't hold any thing in memory.
         tabManager.removeAll()
@@ -146,6 +163,10 @@ class CookiesClearable: Clearable {
         self.tabManager = tabManager
     }
 
+    var label: String {
+        return NSLocalizedString("Cookies", comment: "Settings item for clearing cookies")
+    }
+
     func clear() -> Success {
         // First close all tabs to make sure they aren't holding anything in memory.
         tabManager.removeAll()
@@ -166,30 +187,5 @@ class CookiesClearable: Clearable {
         }
 
         return succeed()
-    }
-}
-
-// A Clearable designed to clear all of the locally stored data for our app.
-class EverythingClearable: Clearable {
-    private let clearables: [Clearable]
-
-    init(profile: Profile, tabmanager: TabManager) {
-        clearables = [
-            HistoryClearable(profile: profile),
-            CacheClearable(tabManager: tabmanager),
-            CookiesClearable(tabManager: tabmanager),
-            SiteDataClearable(tabManager: tabmanager),
-            PasswordsClearable(profile: profile),
-        ]
-    }
-
-    func clear() -> Success {
-        let deferred = Success()
-        all(clearables.map({ clearable in
-            clearable.clear()
-        })).upon({ result in
-            deferred.fill(Maybe(success: ()))
-        })
-        return deferred
     }
 }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -614,7 +614,7 @@ private class ClearPrivateDataSetting: Setting {
 
         let clearString = NSLocalizedString("Clear", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to Clear private data dialog")
         alert.addAction(UIAlertAction(title: clearString, style: UIAlertActionStyle.Destructive, handler: { (action) -> Void in
-            clearable.clear() >>== { NSNotificationCenter.defaultCenter().postNotificationName(NotificationPrivateDataCleared, object: nil) }
+            clearable.clear() >>== { NSNotificationCenter.defaultCenter().postNotificationName(NotificationPrivateDataClearedHistory, object: nil) }
         }))
 
         let cancelString = NSLocalizedString("Cancel", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to cancel clear private data dialog")

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -596,6 +596,8 @@ private class ClearPrivateDataSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
 
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
@@ -605,21 +607,10 @@ private class ClearPrivateDataSetting: Setting {
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        let clearable = EverythingClearable(profile: profile, tabmanager: tabManager)
-
-        var title: String { return NSLocalizedString("Clear Everything", tableName: "ClearPrivateData", comment: "Title of the Clear private data dialog.") }
-        var message: String { return NSLocalizedString("Are you sure you want to clear all of your data? This will also close all open tabs.", tableName: "ClearPrivateData", comment: "Message shown in the dialog prompting users if they want to clear everything") }
-
-        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
-
-        let clearString = NSLocalizedString("Clear", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to Clear private data dialog")
-        alert.addAction(UIAlertAction(title: clearString, style: UIAlertActionStyle.Destructive, handler: { (action) -> Void in
-            clearable.clear() >>== { NSNotificationCenter.defaultCenter().postNotificationName(NotificationPrivateDataClearedHistory, object: nil) }
-        }))
-
-        let cancelString = NSLocalizedString("Cancel", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to cancel clear private data dialog")
-        alert.addAction(UIAlertAction(title: cancelString, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in }))
-        navigationController?.presentViewController(alert, animated: true) { () -> Void in }
+        let viewController = ClearPrivateDataTableViewController()
+        viewController.profile = profile
+        viewController.tabManager = tabManager
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Utils/NotificationConstants.swift
+++ b/Utils/NotificationConstants.swift
@@ -7,7 +7,7 @@ public let NotificationDataLoginDidChange = "Data:Login:DidChange"
 // add a property to allow the observation of firefox accounts
 public let NotificationFirefoxAccountChanged = "FirefoxAccountChangedNotification"
 
-public let NotificationPrivateDataCleared = "PrivateDataClearedNotification"
+public let NotificationPrivateDataClearedHistory = "PrivateDataClearedHistoryNotification"
 
 // Fired when the user finishes navigating to a page and the location has changed
 public let NotificationOnLocationChange = "OnLocationChange"


### PR DESCRIPTION
First commit removes the listener from the bookmarks, reader, and remote tab panels, which should not be affected by clearing any private data.

Second commit fires and renames this notification to be history-specific since that's the only case we're handling right now.

Fourth commit is the meat and potatoes.