### PR TITLE
Bug 1201901 - Update status bar overlay height on layout changes instead of just size changes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -176,14 +176,6 @@ class BrowserViewController: UIViewController {
             coordinator.animateAlongsideTransition({ context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y + 1), animated: true)
                 self.scrollController.showToolbars(animated: false)
-
-                // Update overlay that sits behind the status bar to reflect the new topLayoutGuide length. It seems that
-                // when updateViewConstraints is invoked during rotation, the UILayoutSupport instance hasn't updated
-                // to reflect the new orientation which is why we do it here instead of in updateViewConstraints.
-                self.statusBarOverlay.snp_remakeConstraints { make in
-                    make.top.left.right.equalTo(self.view)
-                    make.height.equalTo(self.topLayoutGuide.length)
-                }
             }, completion: { context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y), animated: false)
             })
@@ -292,6 +284,14 @@ class BrowserViewController: UIViewController {
 
         headerBackdrop.snp_makeConstraints { make in
             make.edges.equalTo(self.header)
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        statusBarOverlay.snp_remakeConstraints { make in
+            make.top.left.right.equalTo(self.view)
+            make.height.equalTo(self.topLayoutGuide.length)
         }
     }
 


### PR DESCRIPTION
The status bar overlay was only being setup on viewSize changes so there is the opportunity for the content to be under the status bar BEFORE a rotation happens since we never properly setup the constraints. This change now keeps the status bar overlay height changes in sync with every post-layout operation on the view controller.