### PR TITLE
Bug 1197137 - Can't select option from Google search drop down

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -62,30 +62,29 @@ function createHighlightOverlay(element) {
 
     highlightDiv.appendChild(rectDiv);
   }
-}
+ }
 
-function handleTouchEnd(event) {
+var handleTouchMove = function (event) {
+  if (longPressTimeout) {
+       var { screenX, screenY } = event.touches[0];
+        // Cancel the context menu if finger has moved beyond the maximum allowed distance.
+       if (Math.abs(touchDownX - screenX) > MAX_RADIUS || Math.abs(touchDownY - screenY) > MAX_RADIUS) {
+         cancel();
+      }
+   }
+ }
+
+var handleTouchEnd = function (event) {
   cancel();
 
-  event.target.removeEventListener("touchend", handleTouchEnd);
-  event.target.removeEventListener("mouseup", handleTouchEnd);
-  event.target.removeEventListener("touchmove", handleTouchMove);
+  removeEventListener("touchend", handleTouchEnd);
+  removeEventListener("mouseup", handleTouchEnd);
+  removeEventListener("touchmove", handleTouchMove);
 
   // If we're showing the context menu, prevent the page from handling the click event.
   if (touchHandled) {
     touchHandled = false;
     event.preventDefault();
-  }
-}
-
-function handleTouchMove(event) {
-  if (longPressTimeout) {
-    var { screenX, screenY } = event.touches[0];
-
-    // Cancel the context menu if finger has moved beyond the maximum allowed distance.
-    if (Math.abs(touchDownX - screenX) > MAX_RADIUS || Math.abs(touchDownY - screenY) > MAX_RADIUS) {
-      cancel();
-    }
   }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1197137

When we remove the mouseup event handler inside the handler for that event we were causing it to cancel the propagation of that event down the DOM to the Google code that was also listening for it.
By placing the handler into a variable and using that to add/cancel the event and by not removing the event ONLY from the target element we can ensure that the event handlers on Googles pages are not affected and still fire.