### PR TITLE
Bug 1183970 - Add a test for removing cells from top sites

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -2453,9 +2453,9 @@
 				D33B5B7B1AF1AFC100F4DDE6 /* SearchTests.swift */,
 				D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */,
 				744B0FFD1B4F172E00100422 /* ToolbarTests.swift */,
+				7BB20B6C1B71160200F1657F /* TopSitesTests.swift */,
 				D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */,
 				D39FA1611A83E0EC00EE869C /* Supporting Files */,
-				7BB20B6C1B71160200F1657F /* TopSitesTests.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";

--- a/Client/Frontend/Widgets/ThumbnailCell.swift
+++ b/Client/Frontend/Widgets/ThumbnailCell.swift
@@ -131,6 +131,7 @@ class ThumbnailCell: UICollectionViewCell {
         let removeButton = UIButton()
         removeButton.setImage(UIImage(named: "TileCloseButton"), forState: UIControlState.Normal)
         removeButton.addTarget(self, action: "SELdidRemove", forControlEvents: UIControlEvents.TouchUpInside)
+        removeButton.accessibilityLabel = NSLocalizedString("Remove page", comment: "Button shown in editing mode to remove this site from the top sites panel.")
         removeButton.hidden = true
         removeButton.imageEdgeInsets = ThumbnailCellUX.RemoveButtonInsets
         return removeButton

--- a/UITests/TopSitesTests.swift
+++ b/UITests/TopSitesTests.swift
@@ -58,6 +58,32 @@ class TopSitesTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 
+    func testRemovingSite() {
+        // Load a page
+        tester().tapViewWithAccessibilityIdentifier("url")
+        let url1 = "\(webRoot)/numberedPage.html?page=1"
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url1)\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // Open top sites
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().tapViewWithAccessibilityLabel("Top sites")
+
+        // Verify the row exists and that the Remove Page button is hidden
+        let row = tester().waitForViewWithAccessibilityLabel("127.0.0.1")
+        tester().waitForAbsenceOfViewWithAccessibilityLabel("Remove page")
+
+        // Long press the row and click the remove button
+        row.longPressAtPoint(CGPointZero, duration: 1)
+        tester().tapViewWithAccessibilityLabel("Remove page")
+
+        // Close editing mode
+        tester().tapViewWithAccessibilityLabel("Done")
+
+        // Close top sites
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
     override func tearDown() {
         BrowserUtils.resetToAboutHome(tester())
     }


### PR DESCRIPTION
This is a dupe of https://github.com/mozilla/firefox-ios/pull/919 since I don't have write access to Bryan's fork. Adds a patch that removes a test that is broken from the top sites url change and fixes the deletion test. 