### PR TITLE
Fixes 1201079 - Stop appending a forward slash to every URL

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -190,7 +190,7 @@ class BrowserLocationView: UIView {
     }
 
     private func updateTextWithURL() {
-        if let httplessURL = url?.absoluteStringWithoutHTTPScheme(), let baseDomain = url?.baseDomain() {
+        if let httplessURL = url?.absoluteDisplayString(), let baseDomain = url?.baseDomain() {
             // Highlight the base domain of the current URL.
             var attributedString = NSMutableAttributedString(string: httplessURL)
             let nsRange = NSMakeRange(0, count(httplessURL))

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -9,8 +9,26 @@ import Shared
 class NSURLExtensionsTests : XCTestCase {
     func testRemovesHTTPFromURL() {
         let url = NSURL(string: "http://google.com")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testRemovesHTTPAndTrailingSlashFromURL() {
+        let url = NSURL(string: "http://google.com/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testRemovesHTTPButNotTrailingSlashFromURL() {
+        let url = NSURL(string: "http://google.com/foo/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "google.com/foo/")
         } else {
             XCTFail("Actual url is nil")
         }
@@ -18,8 +36,26 @@ class NSURLExtensionsTests : XCTestCase {
 
     func testKeepsHTTPSInURL() {
         let url = NSURL(string: "https://google.com")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "https://google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testKeepsHTTPSAndRemovesTrailingSlashInURL() {
+        let url = NSURL(string: "https://google.com/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "https://google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testKeepsHTTPSAndTrailingSlashInURL() {
+        let url = NSURL(string: "https://google.com/foo/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "https://google.com/foo/")
         } else {
             XCTFail("Actual url is nil")
         }
@@ -27,7 +63,7 @@ class NSURLExtensionsTests : XCTestCase {
 
     func testKeepsAboutSchemeInURL() {
         let url = NSURL(string: "about:home")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "about:home")
         } else {
             XCTFail("Actual url is nil")

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -104,8 +104,12 @@ extension NSURL {
         return nil
     }
 
-    public func absoluteStringWithoutHTTPScheme() -> String? {
-        if let urlString = self.absoluteString {
+    public func absoluteDisplayString() -> String? {
+        if var urlString = self.absoluteString {
+            // For http URLs, get rid of the trailing slash if the path is empty or '/'
+            if (self.scheme == "http" || self.scheme == "https") && (self.path == "/" || self.path == nil) && urlString.endsWith("/") {
+                urlString = urlString.substringToIndex(advance(urlString.endIndex, -1))
+            }
             // If it's basic http, strip out the string but leave anything else in
             if urlString.hasPrefix("http://") ?? false {
                 return urlString.substringFromIndex(advance(urlString.startIndex, 7))


### PR DESCRIPTION
This patch makes sure that we do not display a trailing slash for an `NSURL` that has an empty (`/`) or `nil` path component.

If the `NSURL` contains a non-empty path that ends with a trailing slash then we do not do anything. This is because that will actually result in a different URL. So for example `http://www.apple.com/iphone/` will not be changed. This is the same as *Firefox Desktop* handles it.

I have merged this logic in `absoluteStringWithoutHTTPScheme`, which is called by the `BrowserLocationView.updateTextWithURL()` to update the currently displayed URL. Because this now does more than just remove the `http://` part, I have renamed that function to `absoluteDisplayString`.

Also included tests to make sure this works on URLs with and without trailing slashes with both empty and non-empty path compoments.

Feels good to write a patch 😎