### PR TITLE
Bug 1202662 - Don't attempt to blindly call sqlite3_changes on a DB connection that might have raised an error.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -137,7 +137,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(application: UIApplication) {
         self.profile?.syncManager.endTimedSyncs()
 
-        let taskId = application.beginBackgroundTaskWithExpirationHandler { _ in }
+        var taskId: UIBackgroundTaskIdentifier = 0
+        taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
+            log.warning("Running out of background time, but we have a profile shutdown pending.")
+            application.endBackgroundTask(taskId)
+        }
         self.profile?.shutdown()
         application.endBackgroundTask(taskId)
     }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -142,8 +142,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             log.warning("Running out of background time, but we have a profile shutdown pending.")
             application.endBackgroundTask(taskId)
         }
-        self.profile?.shutdown()
-        application.endBackgroundTask(taskId)
+
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+            self.profile?.shutdown()
+            application.endBackgroundTask(taskId)
+        }
     }
 
     private func setUpWebServer(profile: Profile) {

--- a/Storage/SQL/DeferredDBOperation.swift
+++ b/Storage/SQL/DeferredDBOperation.swift
@@ -87,7 +87,9 @@ class DeferredDBOperation<T>: Deferred<Maybe<T>>, Cancellable {
 
             var error: NSError? = nil
             result = self.block(connection: db, err: &error)
-            log.debug("Modified rows: \(db.numberOfRowsModified).")
+            if error == nil {
+                log.debug("Modified rows: \(db.numberOfRowsModified).")
+            }
             self.connection = nil
             return error
         }


### PR DESCRIPTION
Needs a `v1.0` branch.