### PR TITLE
Fixes 1201079 - Stop appending a forward slash to every URL

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -190,7 +190,7 @@ class BrowserLocationView: UIView {
     }
 
     private func updateTextWithURL() {
-        if let httplessURL = url?.absoluteStringWithoutHTTPScheme(), let baseDomain = url?.baseDomain() {
+        if let httplessURL = url?.absoluteDisplayString(), let baseDomain = url?.baseDomain() {
             // Highlight the base domain of the current URL.
             let attributedString = NSMutableAttributedString(string: httplessURL)
             let nsRange = NSMakeRange(0, httplessURL.characters.count)

--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -9,8 +9,26 @@ import Shared
 class NSURLExtensionsTests : XCTestCase {
     func testRemovesHTTPFromURL() {
         let url = NSURL(string: "http://google.com")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testRemovesHTTPAndTrailingSlashFromURL() {
+        let url = NSURL(string: "http://google.com/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testRemovesHTTPButNotTrailingSlashFromURL() {
+        let url = NSURL(string: "http://google.com/foo/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "google.com/foo/")
         } else {
             XCTFail("Actual url is nil")
         }
@@ -18,8 +36,26 @@ class NSURLExtensionsTests : XCTestCase {
 
     func testKeepsHTTPSInURL() {
         let url = NSURL(string: "https://google.com")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "https://google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testKeepsHTTPSAndRemovesTrailingSlashInURL() {
+        let url = NSURL(string: "https://google.com/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "https://google.com")
+        } else {
+            XCTFail("Actual url is nil")
+        }
+    }
+
+    func testKeepsHTTPSAndTrailingSlashInURL() {
+        let url = NSURL(string: "https://google.com/foo/")
+        if let actual = url?.absoluteDisplayString() {
+            XCTAssertEqual(actual, "https://google.com/foo/")
         } else {
             XCTFail("Actual url is nil")
         }
@@ -27,7 +63,7 @@ class NSURLExtensionsTests : XCTestCase {
 
     func testKeepsAboutSchemeInURL() {
         let url = NSURL(string: "about:home")
-        if let actual = url?.absoluteStringWithoutHTTPScheme() {
+        if let actual = url?.absoluteDisplayString() {
             XCTAssertEqual(actual, "about:home")
         } else {
             XCTFail("Actual url is nil")

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -104,12 +104,17 @@ extension NSURL {
         return nil
     }
 
-    public func absoluteStringWithoutHTTPScheme() -> String? {
+    public func absoluteDisplayString() -> String? {
+        var urlString = self.absoluteString
+        // For http URLs, get rid of the trailing slash if the path is empty or '/'
+        if (self.scheme == "http" || self.scheme == "https") && (self.path == "/" || self.path == nil) && urlString.endsWith("/") {
+            urlString = urlString.substringToIndex(urlString.endIndex.advancedBy(-1))
+        }
         // If it's basic http, strip out the string but leave anything else in
-        if self.absoluteString.hasPrefix("http://") ?? false {
-            return self.absoluteString.substringFromIndex(self.absoluteString.startIndex.advancedBy(7))
+        if urlString.hasPrefix("http://") ?? false {
+            return urlString.substringFromIndex(urlString.startIndex.advancedBy(7))
         } else {
-            return self.absoluteString
+            return urlString
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/mozilla/firefox-ios/pull/1046 but converted to Swift 2.0 for the master branch.