### PR TITLE
Bug 1164067 - Implement Find In Page

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -436,6 +436,9 @@
 		D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A994961A3686BD008AD1AC /* Browser.swift */; };
 		D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ACB4381AD33EBA00748D50 /* WeakList.swift */; };
 		D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */; };
+		D3B6923D1B9F9444004B87A4 /* FindInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923C1B9F9444004B87A4 /* FindInPage.swift */; };
+		D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */; };
+		D3B692411B9F9CC8004B87A4 /* FindInPage.js in Resources */ = {isa = PBXBuildFile; fileRef = D3B692401B9F9CC8004B87A4 /* FindInPage.js */; };
 		D3BA7E0C1B0E902A00153782 /* ContextMenu.js in Resources */ = {isa = PBXBuildFile; fileRef = D3BA7E0B1B0E902A00153782 /* ContextMenu.js */; };
 		D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */; };
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
@@ -1649,6 +1652,9 @@
 		D3A994961A3686BD008AD1AC /* Browser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
 		D3ACB4381AD33EBA00748D50 /* WeakList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakList.swift; sourceTree = "<group>"; };
 		D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
+		D3B6923C1B9F9444004B87A4 /* FindInPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPage.swift; sourceTree = "<group>"; };
+		D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageHelper.swift; sourceTree = "<group>"; };
+		D3B692401B9F9CC8004B87A4 /* FindInPage.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FindInPage.js; sourceTree = "<group>"; };
 		D3BA7E0B1B0E902A00153782 /* ContextMenu.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ContextMenu.js; sourceTree = "<group>"; };
 		D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextMenuHelper.swift; sourceTree = "<group>"; };
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -2706,6 +2712,8 @@
 				D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */,
 				0BA1E02D1B046F1E007675AF /* ErrorPageHelper.swift */,
 				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
+				D3B6923C1B9F9444004B87A4 /* FindInPage.swift */,
+				D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */,
 				0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */,
 				7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
@@ -3201,6 +3209,7 @@
 				746B6A781B277C1800EA83E3 /* SessionRestore.html */,
 				D3BA7E0B1B0E902A00153782 /* ContextMenu.js */,
 				0BF42D381A7C0E8900889E28 /* Favicons.js */,
+				D3B692401B9F9CC8004B87A4 /* FindInPage.js */,
 				0BDA568A1B26B1BE008C9B96 /* LoginsHelper.js */,
 				E49C0EB01B46109C009092BB /* WindowCloseHelper.js */,
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
@@ -4308,6 +4317,7 @@
 				E69922171B94E3EF007C480D /* Licenses.html in Resources */,
 				E414F0791A8445A500283322 /* FennecAurora.entitlements in Resources */,
 				2F1BDF921A8523B000213B54 /* LICENSE in Resources */,
+				D3B692411B9F9CC8004B87A4 /* FindInPage.js in Resources */,
 				E4CD9F5B1A71506C00318571 /* Reader.css in Resources */,
 				E4B7B7611A793CF20022C5E0 /* CharisSILB.ttf in Resources */,
 				E4B7B7621A793CF20022C5E0 /* CharisSILBI.ttf in Resources */,
@@ -4788,6 +4798,7 @@
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
+				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
@@ -4820,6 +4831,7 @@
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */,
 				E4B3344F1BBF2393004E2BFF /* ADJActivityPackage.m in Sources */,
+				D3B6923D1B9F9444004B87A4 /* FindInPage.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				0AE491A61A41C88C0046C724 /* BackForwardListViewController.swift in Sources */,

--- a/Client/Assets/FindInPage.js
+++ b/Client/Assets/FindInPage.js
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+"use strict";
+
+var DEBUG_ENABLED = true;
+var ACTIVE_COLOR = "#f88017";
+var INACTIVE_COLOR = "#fcd0a7";
+
+var highlightDiv = null;
+var activeHighlightRect = null;
+var lastSearch;
+var activeIndex = 0;
+
+window.debugResults = [];
+
+function clearSelection() {
+  if (highlightDiv) {
+    document.documentElement.removeChild(highlightDiv);
+    highlightDiv = null;
+  }
+}
+
+function debug(str) {
+  if (DEBUG_ENABLED) {
+    console.log("FindInPage: " + str);
+  }
+}
+
+function findAllRects(text) {
+  debug("Searching: " + text)
+
+  var foundRects = [];
+  clearSelection();
+  window.debugResults = [];
+
+  // Highlight and scroll to the next match. window.getSelection() can return a Range
+  // with no rects for input fields, so skip these.
+  //
+  // There are also weird issues on Google where window.getSelection() returns mis-sized,
+  // mis-aligned rects for the absolutely positioned search suggestions box. Some of these
+  // rect heights are 1px, so we can at least filter those.
+  var scrollTop = document.body.scrollTop;
+  var scrollLeft = document.body.scrollLeft;
+
+  while (true) {
+    var found = window.find(text,
+        /* Case sensitive   */ false,
+        /* Search backwards */ false,
+        /* Wrap             */ false,
+        /* Whole word only  */ false,
+        /* Include iframes  */ false,
+        /* Show dialog      */ false);
+
+    if (!found) {
+      debug("No more results found.");
+      break;
+    }
+
+    var selection = window.getSelection();
+
+    if (selection.rangeCount == 0) {
+      debug("No matches found.");
+      break;
+    }
+
+    if (selection.isCollapsed) {
+      debug("Skipping collapsed node.");
+      continue;
+    }
+
+    var rects = selection.getRangeAt(0).getClientRects();
+
+    if (!rects || rects.length == 0) {
+      debug("No rects in selection.");
+      continue;
+    }
+
+    var rect = rects[0];
+    debug("Checking rect: " + JSON.stringify(rect));
+
+    // Sometimes we get rects that aren't visible on the page. Skip them.
+    // Test case: http://i.word.com/idictionary/hey. Search "h". First results are outside page bounds.
+    var left = rect.left + scrollLeft;
+    var right = rect.right + scrollLeft;
+    var top = rect.top + scrollTop;
+    var bottom = rect.bottom + scrollTop;
+    if (right < 0 || left > document.body.scrollWidth ||
+        bottom < 0 || top > document.body.scrollHeight) {
+      debug("Skipping out-of-bounds rect.");
+      continue;
+    }
+
+    if (rect.width == 0 || rect.height == 0) {
+      debug("Skipping empty rect.");
+      continue;
+    }
+
+    window.debugResults.push(selection.anchorNode);
+    foundRects.push(rect);
+  }
+
+  if (foundRects.length == 0) {
+    debug("No highlight rects created!");
+    return;
+  }
+
+  createHighlightOverlay(foundRects);
+  webkit.messageHandlers.findInPageHandler.postMessage({ totalResults: foundRects.length });
+
+  debug(foundRects.length + " highlighted rects created!");
+}
+
+function updateHighlightedRect() {
+  // Reset the color of the previous highlight.
+  if (activeHighlightRect) {
+    activeHighlightRect.style.backgroundColor = INACTIVE_COLOR;
+  }
+
+  activeHighlightRect = highlightDiv.children[activeIndex];
+  activeHighlightRect.style.backgroundColor = ACTIVE_COLOR;
+
+  // Find the position of the element centered on the screen, then scroll to it.
+  var top = activeHighlightRect.offsetTop - window.innerHeight / 2;
+  var left = activeHighlightRect.offsetLeft - window.innerWidth / 2;
+  left = clamp(left, 0, document.body.scrollWidth);
+  top = clamp(top, 0, document.body.scrollHeight);
+  window.scrollTo(left, top);
+  debug("Scrolled to: " + left + ", " + top);
+}
+
+function clamp(number, min, max) {
+  return Math.max(min, Math.min(number, max));
+}
+
+function createHighlightOverlay(rects) {
+  // Create a parent element to hold each highlight rect.
+  // This allows us to set the opacity for the entire highlight
+  // without worrying about overlapping opacities for each child.
+  highlightDiv = document.createElement("div");
+  highlightDiv.style.pointerEvents = "none";
+  highlightDiv.style.top = "0px";
+  highlightDiv.style.left = "0px";
+  highlightDiv.style.position = "absolute";
+  highlightDiv.style.opacity = 0.3;
+  highlightDiv.style.zIndex = 99999;
+  document.documentElement.appendChild(highlightDiv);
+
+  for (var i = 0; i != rects.length; i++) {
+    var rect = rects[i];
+    var rectDiv = document.createElement("div");
+    var scrollTop = document.body.scrollTop;
+    var scrollLeft = document.body.scrollLeft;
+    var top = rect.top + scrollTop;
+    var left = rect.left + scrollLeft;
+
+    rectDiv.style.top = top + "px";
+    rectDiv.style.left = left + "px";
+    rectDiv.style.width = rect.width + "px";
+    rectDiv.style.height = rect.height + "px";
+    rectDiv.style.position = "absolute";
+    rectDiv.style.backgroundColor = INACTIVE_COLOR;
+    rectDiv.style.pointerEvents = "none";
+
+    highlightDiv.appendChild(rectDiv);
+  }
+}
+
+function updateSearch(text) {
+  if (lastSearch == text) {
+    // The text is the same, so we're either finding either the next or previous result.
+    var totalResults = highlightDiv.children.length;
+    activeIndex = (activeIndex + totalResults) % totalResults;
+  } else {
+    // The search text changed, so start again from the top.
+    lastSearch = text;
+    findAllRects(text);
+    activeIndex = 0;
+  }
+
+  if (highlightDiv) {
+    updateHighlightedRect();
+  }
+
+  webkit.messageHandlers.findInPageHandler.postMessage({ currentResult: activeIndex + 1 });
+}
+
+
+if (!window.__firefox__) {
+  window.__firefox__ = {};
+}
+
+window.__firefox__.find = function (text) {
+  // window.find() will move on from the last result. Reset the range so that
+  // we retry the last result in case it still matches the new search string.
+  window.getSelection().removeAllRanges();
+
+  updateSearch(text);
+};
+
+window.__firefox__.findNext = function (text) {
+  activeIndex++;
+  updateSearch(text);
+};
+
+window.__firefox__.findPrevious = function (text) {
+  activeIndex--;
+  updateSearch(text);
+};
+
+window.__firefox__.findDone = function () {
+  clearSelection();
+};
+
+}) ();

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -14,6 +14,7 @@ protocol BrowserToolbarProtocol {
     var forwardButton: UIButton { get }
     var backButton: UIButton { get }
     var stopReloadButton: UIButton { get }
+    var findInPageButton: UIButton { get }
     var actionButtons: [UIButton] { get }
 
     func updateBackStatus(canGoBack: Bool)
@@ -34,6 +35,7 @@ protocol BrowserToolbarDelegate: class {
     func browserToolbarDidPressBookmark(browserToolbar: BrowserToolbarProtocol, button: UIButton)
     func browserToolbarDidLongPressBookmark(browserToolbar: BrowserToolbarProtocol, button: UIButton)
     func browserToolbarDidPressShare(browserToolbar: BrowserToolbarProtocol, button: UIButton)
+    func browserToolbarDidPressFindInPage(browserToolbar: BrowserToolbarProtocol, button: UIButton)
 }
 
 @objc
@@ -107,6 +109,9 @@ public class BrowserToolbarHelper: NSObject {
         toolbar.bookmarkButton.addGestureRecognizer(longPressGestureBookmarkButton)
         toolbar.bookmarkButton.addTarget(self, action: "SELdidClickBookmark", forControlEvents: UIControlEvents.TouchUpInside)
 
+        toolbar.findInPageButton.setTitle("find", forState: UIControlState.Normal)
+        toolbar.findInPageButton.addTarget(self, action: "SELdidClickFindInPage", forControlEvents: UIControlEvents.TouchUpInside)
+
         setTintColor(buttonTintColor, forButtons: toolbar.actionButtons)
     }
 
@@ -138,6 +143,10 @@ public class BrowserToolbarHelper: NSObject {
         toolbar.browserToolbarDelegate?.browserToolbarDidPressBookmark(toolbar, button: toolbar.bookmarkButton)
     }
 
+    func SELdidClickFindInPage() {
+        toolbar.browserToolbarDelegate?.browserToolbarDidPressFindInPage(toolbar, button: toolbar.bookmarkButton)
+    }
+
     func SELdidLongPressBookmark(recognizer: UILongPressGestureRecognizer) {
         if recognizer.state == UIGestureRecognizerState.Began {
             toolbar.browserToolbarDelegate?.browserToolbarDidLongPressBookmark(toolbar, button: toolbar.bookmarkButton)
@@ -166,6 +175,7 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
     let forwardButton: UIButton
     let backButton: UIButton
     let stopReloadButton: UIButton
+    let findInPageButton: UIButton
     let actionButtons: [UIButton]
 
     var helper: BrowserToolbarHelper?
@@ -178,13 +188,14 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
         stopReloadButton = UIButton()
         shareButton = UIButton()
         bookmarkButton = UIButton()
-        actionButtons = [backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton]
+        findInPageButton = UIButton()
+        actionButtons = [backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton, findInPageButton]
 
         super.init(frame: frame)
 
         self.helper = BrowserToolbarHelper(toolbar: self)
 
-        addButtons(backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton)
+        addButtons(backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton, findInPageButton)
 
         accessibilityNavigationStyle = .Combined
         accessibilityLabel = NSLocalizedString("Navigation Toolbar", comment: "Accessibility label for the navigation toolbar displayed at the bottom of the screen.")

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1051,6 +1051,10 @@ extension BrowserViewController: BrowserToolbarDelegate {
         tabManager.selectedTab?.goForward()
     }
 
+    func browserToolbarDidPressFindInPage(browserToolbar: BrowserToolbarProtocol, button: UIButton) {
+        print("find in page")
+    }
+
     func browserToolbarDidLongPressForward(browserToolbar: BrowserToolbarProtocol, button: UIButton) {
 // See 1159373 - Disable long press back/forward for backforward list
 //        let controller = BackForwardListViewController()

--- a/Client/Frontend/Browser/FindInPage.swift
+++ b/Client/Frontend/Browser/FindInPage.swift
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+
+protocol FindInPageBarDelegate: class {
+    func findInPage(findInPage: FindInPageBar, didTextChange text: String)
+    func findInPage(findInPage: FindInPageBar, didFindPreviousWithText text: String)
+    func findInPage(findInPage: FindInPageBar, didFindNextWithText text: String)
+    func findInPageDidPressDone(findInPage: FindInPageBar)
+}
+
+class FindInPageBar: UIView {
+    weak var delegate: FindInPageBarDelegate?
+    private let searchText = UITextField()
+    private let matchCountView = UILabel()
+
+    var currentResult = 0 {
+        didSet {
+            matchCountView.text = "\(currentResult)/\(totalResults)"
+        }
+    }
+
+    var totalResults = 0 {
+        didSet {
+            matchCountView.text = "\(currentResult)/\(totalResults)"
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = UIColor.whiteColor()
+        layer.borderColor = UIConstants.BorderColor.CGColor
+        layer.borderWidth = 1
+
+        searchText.addTarget(self, action: "didTextChange:", forControlEvents: UIControlEvents.EditingChanged)
+        addSubview(searchText)
+
+        matchCountView.textColor = UIColor.lightGrayColor()
+        matchCountView.text = "0/0"
+        matchCountView.font = UIConstants.DefaultMediumFont
+        addSubview(matchCountView)
+
+        let previousButton = UIButton()
+        previousButton.setTitle("<", forState: UIControlState.Normal)
+        previousButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
+        addSubview(previousButton)
+        previousButton.addTarget(self, action: "didFindPrevious:", forControlEvents: UIControlEvents.TouchUpInside)
+
+        let nextButton = UIButton()
+        nextButton.setTitle(">", forState: UIControlState.Normal)
+        nextButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
+        nextButton.addTarget(self, action: "didFindNext:", forControlEvents: UIControlEvents.TouchUpInside)
+        addSubview(nextButton)
+
+        let doneButton = UIButton()
+        doneButton.setTitle("x", forState: UIControlState.Normal)
+        doneButton.setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
+        doneButton.addTarget(self, action: "didPressDone:", forControlEvents: UIControlEvents.TouchUpInside)
+        addSubview(doneButton)
+
+        searchText.snp_makeConstraints { make in
+            make.leading.equalTo(self).offset(8)
+            make.top.bottom.equalTo(self)
+        }
+
+        matchCountView.snp_makeConstraints { make in
+            make.leading.equalTo(searchText.snp_trailing)
+            make.centerY.equalTo(self)
+        }
+
+        previousButton.snp_makeConstraints { make in
+            make.leading.equalTo(matchCountView.snp_trailing)
+            make.size.equalTo(self.snp_height)
+            make.centerY.equalTo(self)
+        }
+
+        nextButton.snp_makeConstraints { make in
+            make.leading.equalTo(previousButton.snp_trailing)
+            make.size.equalTo(self.snp_height)
+            make.centerY.equalTo(self)
+        }
+
+        doneButton.snp_makeConstraints { make in
+            make.leading.equalTo(nextButton.snp_trailing)
+            make.size.equalTo(self.snp_height)
+            make.centerY.equalTo(self)
+            make.trailing.equalTo(self)
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        return searchText.becomeFirstResponder()
+    }
+
+    @objc func didFindPrevious(sender: UIButton) {
+        delegate?.findInPage(self, didFindPreviousWithText: searchText.text ?? "")
+    }
+
+    @objc func didFindNext(sender: UIButton) {
+        delegate?.findInPage(self, didFindNextWithText: searchText.text ?? "")
+    }
+
+    @objc func didTextChange(sender: UITextField) {
+        delegate?.findInPage(self, didTextChange: searchText.text ?? "")
+    }
+
+    @objc func didPressDone(sender: UIButton) {
+        searchText.text = ""
+        delegate?.findInPageDidPressDone(self)
+    }
+}

--- a/Client/Frontend/Browser/FindInPageHelper.swift
+++ b/Client/Frontend/Browser/FindInPageHelper.swift
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import WebKit
+
+protocol FindInPageHelperDelegate: class {
+    func findInPageHelper(findInPageHelper: FindInPageHelper, didUpdateCurrentResult currentResult: Int)
+    func findInPageHelper(findInPageHelper: FindInPageHelper, didUpdateTotalResults totalResults: Int)
+}
+
+class FindInPageHelper: BrowserHelper {
+    weak var delegate: FindInPageHelperDelegate?
+    private weak var browser: Browser?
+
+    class func name() -> String {
+        return "FindInPage"
+    }
+
+    required init(browser: Browser) {
+        self.browser = browser
+
+        if let path = NSBundle.mainBundle().pathForResource("FindInPage", ofType: "js"), source = try? NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String {
+            let userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
+            browser.webView!.configuration.userContentController.addUserScript(userScript)
+        }
+    }
+
+    func scriptMessageHandlerName() -> String? {
+        return "findInPageHandler"
+    }
+
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        let data = message.body as! [String: Int]
+
+        if let currentResult = data["currentResult"] {
+            delegate?.findInPageHelper(self, didUpdateCurrentResult: currentResult)
+        }
+
+        if let totalResults = data["totalResults"] {
+            delegate?.findInPageHelper(self, didUpdateTotalResults: totalResults)
+        }
+    }
+}

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -158,6 +158,8 @@ class URLBarView: UIView {
 
     lazy var stopReloadButton: UIButton = { return UIButton() }()
 
+    lazy var findInPageButton: UIButton = { return UIButton() }()
+
     lazy var actionButtons: [UIButton] = {
         return [self.shareButton, self.bookmarkButton, self.forwardButton, self.backButton, self.stopReloadButton]
     }()


### PR DESCRIPTION
Early Find In Page prototype using `window.find`. It mostly works OK, though there are weird issues whenever the page contains matching absolutely positioned elements. Using this on Google, for example, causes the search input field to gain focus, which shows a search suggestions popup, and then there's some wonky behavior with random rects that aren't near the matching elements.

A few notes:
* The find highlight must be translucent since we overlay the highlight onto the page.
* We can make case sensitive searches if wanted.
* We can limit searches to whole word matches if wanted.