### PR TITLE
Bug 1203619 - 'Your Rights' in settings needs similar foreground color attribute style change

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -497,7 +497,8 @@ private class LicenseAndAcknowledgementsSetting: Setting {
 // Opens about:rights page in the content view controller
 private class YourRightsSetting: Setting {
     override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Your Rights", comment: "Your Rights settings section title"))
+        return NSAttributedString(string: NSLocalizedString("Your Rights", comment: "Your Rights settings section title"), attributes:
+            [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
     }
 
     override var url: NSURL? {


### PR DESCRIPTION
Same fix as https://github.com/mozilla/firefox-ios/pull/920 - adds a TableViewRowTextColor attribute 