### PR TITLE
Fixes 1204635 - Bring back old Clear Private Data strings

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -11,6 +11,12 @@ import XCGLogger
 private var ShowDebugSettings: Bool = false
 private var DebugSettingsClickCount: Int = 0
 
+// The following are only here because we use master for L10N and otherwise these strings would disappear from the v1.0 release
+private let Bug1204635_S1 = NSLocalizedString("Clear Everything", tableName: "ClearPrivateData", comment: "Title of the Clear private data dialog.")
+private let Bug1204635_S2 = NSLocalizedString("Are you sure you want to clear all of your data? This will also close all open tabs.", tableName: "ClearPrivateData", comment: "Message shown in the dialog prompting users if they want to clear everything")
+private let Bug1204635_S3 = NSLocalizedString("Clear", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to Clear private data dialog")
+private let Bug1204635_S4 = NSLocalizedString("Cancel", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to cancel clear private data dialog")
+
 // A base TableViewCell, to help minimize initialization and allow recycling.
 class SettingsTableViewCell: UITableViewCell {
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {


### PR DESCRIPTION
A bunch of Clear Private Data strings have disappeared on master because they have been replaced with newer strings to follow changes the feature.

However, we still need to build 1.0.x releases with strings from master, so this bug is about bringing back those strings temporarily.

These strings can simply come back as some global variables for example.