### PR TITLE
Fixes 1205004 - Use new webViewWebContentProcessDidTerminate API

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -510,6 +510,15 @@ extension TabManager : WKNavigationDelegate {
         }
         UIApplication.sharedApplication().networkActivityIndicatorVisible = false
     }
+
+    /// Called when the WKWebView's content process has gone away. If this happens for the currently selected tab
+    /// then we immediately reload it.
+
+    func webViewWebContentProcessDidTerminate(webView: WKWebView) {
+        if let browser = selectedTab where browser.webView == webView {
+            webView.reload()
+        }
+    }
 }
 
 // WKNavigationDelegates must implement NSObjectProtocol


### PR DESCRIPTION
This patch deals with the new `webViewWebContentProcessDidTerminate` delegate method. If that delegate method is called, we do the following:

We find the `Browser` (tab) instance that owns the `WKWebView` that has just died. If that `Browser` is the currently selected one, we reload it right away. If it is not then we set its `webContentProcessDidTerminate` flag and reload it when it becomes active again.