### PR TITLE
Bug 1206204 - Land Request Desktop Site strings

### DIFF
--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -56,10 +56,10 @@ public struct UIConstants {
 
 private struct TempStrings {
     // Bug 1189902 - Offer crash reporting on first run after a crash
-    let crashReportTitle = NSLocalizedString("Oops! Firefox crashed", comment: "Title for prompt displayed to user after the app crashes")
-    let crashReportDescription = NSLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Message displayed in the crash dialog above the buttons used to select when sending reports")
-    let sendReport = NSLocalizedString("Send Report", comment: "Used as a button label for crash dialog prompt")
-    let alwaysSend = NSLocalizedString("Always Send", comment: "Used as a button label for crash dialog prompt")
-    let dontSend = NSLocalizedString("Don't Send", comment: "Used as a button label for crash dialog prompt")
-    let neverSend = NSLocalizedString("Never Send", comment: "Used as a button label for crash dialog prompt")
+    let crashReportTitle = NSLocalizedString("Oops! Firefox crashed", comment: "Pending feature; currently unused string! Title for prompt displayed to user after the app crashes")
+    let crashReportDescription = NSLocalizedString("Send a crash report so Mozilla can fix the problem?", comment: "Pending feature; currently unused string! Message displayed in the crash dialog above the buttons used to select when sending reports")
+    let sendReport = NSLocalizedString("Send Report", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
+    let alwaysSend = NSLocalizedString("Always Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
+    let dontSend = NSLocalizedString("Don't Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
+    let neverSend = NSLocalizedString("Never Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
 }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -62,4 +62,8 @@ private struct TempStrings {
     let alwaysSend = NSLocalizedString("Always Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
     let dontSend = NSLocalizedString("Don't Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
     let neverSend = NSLocalizedString("Never Send", comment: "Pending feature; currently unused string! Used as a button label for crash dialog prompt")
+
+    // Bug 1109675 - Request Desktop Site
+    let requestDesktopSite = NSLocalizedString("Request Desktop Site", comment: "Pending feature; currently unused string! Tooltip label triggered by long pressing the refresh button.")
+    let requestMobileSite = NSLocalizedString("Request Mobile Site", comment: "Pending feature; currently unused string! Tooltip label triggered by long pressing the refresh button a second time.")
 }


### PR DESCRIPTION
Part 1 adds "Pending feature; currently unused string!" to the beginning of unused string comments to avoid l10n confusion. We can safely change the comments later without causing churn once the feature lands.

Parts 2 adds "Request Desktop Site"/"Request Mobile Site" strings.