### PR TITLE
Bug 1183166 - Provide 'Open In' when viewing PDF's

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
+		7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */; settings = {ASSET_TAGS = (); }; };
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		7BBFEE9A1BB409B200A305AA /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; settings = {ASSET_TAGS = (); }; };
@@ -1509,6 +1510,7 @@
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
 		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
 		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
+		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
@@ -2551,6 +2553,7 @@
 				DD31E0FA1B382B520077078A /* BrowserPrintPageRenderer.swift */,
 				E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */,
 				E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */,
+				7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -4484,6 +4487,7 @@
 				0B1C05D71A798B1F004C78B0 /* UIImageViewAligned.m in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,
 				0BD19A651A2530840084FBA7 /* Locking.swift in Sources */,
+				7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */,
 				74203E251B276B3D007D481D /* SessionRestoreHandler.swift in Sources */,
 				E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */,
 				74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -17,7 +17,6 @@ private let log = Logger.browserLogger
 
 private let OKString = NSLocalizedString("OK", comment: "OK button")
 private let CancelString = NSLocalizedString("Cancel", comment: "Cancel button")
-private let OpenInString = NSLocalizedString("Open in…", comment: "String indicating that the file can be opened in another application on the device")
 
 private let KVOLoading = "loading"
 private let KVOEstimatedProgress = "estimatedProgress"

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -51,6 +51,8 @@ class BrowserViewController: UIViewController {
     private let snackBars = UIView()
     private let auralProgress = AuralProgressBar()
 
+    private var openInHelper: OpenInHelper?
+
     // location label actions
     private var pasteGoAction: AccessibleAction!
     private var pasteAction: AccessibleAction!
@@ -1419,6 +1421,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 urlBar.updateReaderModeState(ReaderModeState.Unavailable)
                 hideReaderModeBar(animated: false)
             }
+
+            // remove the open in overlay view if it is present
+            openInHelper?.hideOpenInView(forWebView: webView)
         }
     }
 
@@ -1530,6 +1535,11 @@ extension BrowserViewController: WKNavigationDelegate {
             // forward/backward. Strange, but LayoutChanged fixes that.
             UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
         }
+
+        // add the open in overlay view if it is required
+        guard let url = webView.URL, let openInHelper = OpenInHelperFactory.helperForURL(url) else { return }
+        openInHelper.showOpenInView(inView: webViewContainer, forWebView: webView)
+        self.openInHelper = openInHelper
     }
 
     private func postLocationChangeNotificationForTab(tab: Browser, navigation: WKNavigation?) {

--- a/Client/Frontend/Browser/OpenPdfHelper.swift
+++ b/Client/Frontend/Browser/OpenPdfHelper.swift
@@ -17,6 +17,7 @@ struct OpenInViewUX {
     static let TextFont = UIFont.systemFontOfSize(16)
     static let TextColor = UIColor(red: 74.0/255.0, green: 144.0/255.0, blue: 226.0/255.0, alpha: 1.0)
     static let TextOffset = -15
+    static let OpenInString = NSLocalizedString("Open in…", comment: "String indicating that the file can be opened in another application on the device")
 }
 
 enum FileType : String {
@@ -43,9 +44,6 @@ struct OpenInHelperFactory {
 class OpenPdfInHelper: NSObject, OpenInHelper, UIDocumentInteractionControllerDelegate {
     private var view: OpenInView?
     private var docController: UIDocumentInteractionController? = nil
-
-    private var parentView: UIView!
-    private var webView: WKWebView!
 
     init(url: NSURL) {
         super.init()
@@ -100,7 +98,7 @@ class OpenPdfInHelper: NSObject, OpenInHelper, UIDocumentInteractionControllerDe
 
     func hideOpenInView(forWebView webView: WKWebView) {
         webView.snp_updateConstraints { make in
-            make.edges.equalTo(EdgeInsetsMake(0, left: 0, bottom: 0, right: 0))
+            make.edges.equalTo(EdgeInsetsZero)
         }
         view?.removeFromSuperview()
         view = nil
@@ -126,7 +124,7 @@ class OpenInView: UIView {
     init() {
         super.init(frame: CGRectZero)
         openInButton.setTitleColor(OpenInViewUX.TextColor, forState: UIControlState.Normal)
-        openInButton.setTitle(NSLocalizedString("Open in...", comment: "String indicating that the file can be opened in another application"), forState: UIControlState.Normal)
+        openInButton.setTitle(OpenInViewUX.OpenInString, forState: UIControlState.Normal)
         openInButton.titleLabel?.font = OpenInViewUX.TextFont
         openInButton.sizeToFit()
         self.addSubview(openInButton)

--- a/Client/Frontend/Browser/OpenPdfHelper.swift
+++ b/Client/Frontend/Browser/OpenPdfHelper.swift
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+import SnapKit
+
+import Shared
+
+import XCGLogger
+
+private let log = Logger.browserLogger
+
+struct OpenInViewUX {
+    static let ViewHeight: CGFloat = 40.0
+    static let TextFont = UIFont.systemFontOfSize(16)
+    static let TextColor = UIColor(red: 74.0/255.0, green: 144.0/255.0, blue: 226.0/255.0, alpha: 1.0)
+    static let TextOffset = -15
+}
+
+enum FileType : String {
+    case PDF = "pdf"
+}
+
+protocol OpenInHelper {
+    static func canOpen(url: NSURL) -> Bool
+    func showOpenInView(inView parentView: UIView, forWebView webView: WKWebView)
+    func hideOpenInView(forWebView webView: WKWebView)
+    func open()
+}
+
+struct OpenInHelperFactory {
+    static func helperForURL(url: NSURL) -> OpenInHelper? {
+        if OpenPdfInHelper.canOpen(url) {
+            return OpenPdfInHelper(url: url)
+        }
+
+        return nil
+    }
+}
+
+class OpenPdfInHelper: NSObject, OpenInHelper, UIDocumentInteractionControllerDelegate {
+    private var view: OpenInView?
+    private var docController: UIDocumentInteractionController? = nil
+
+    private var parentView: UIView!
+    private var webView: WKWebView!
+
+    init(url: NSURL) {
+        super.init()
+        let contentsOfFile = NSData(contentsOfURL: url)
+        let dirPaths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory,
+            .UserDomainMask, true)
+
+        let dirPath = NSURL(fileURLWithPath: dirPaths[0]).URLByAppendingPathComponent("pdfs")
+        let fileManager = NSFileManager.defaultManager()
+        do {
+            guard let lastPathComponent = url.lastPathComponent else {
+                log.error("failed to create proper URL")
+                return
+            }
+            let filePath = dirPath.URLByAppendingPathComponent(lastPathComponent)
+            try fileManager.createDirectoryAtURL(dirPath, withIntermediateDirectories: true, attributes: nil)
+            if fileManager.createFileAtPath(filePath.absoluteString, contents: contentsOfFile, attributes: nil) {
+                let openInURL = NSURL(fileURLWithPath: filePath.absoluteString)
+                docController = UIDocumentInteractionController(URL: openInURL)
+                docController?.delegate = self
+            } else {
+                log.error("Unable to create local version of PDF file at \(filePath)")
+            }
+        } catch {
+            log.error("Error on creating directory at \(dirPath)")
+        }
+    }
+    
+    static func canOpen(url: NSURL) -> Bool {
+        guard let pathExtension = url.pathExtension else { return false }
+        return pathExtension == FileType.PDF.rawValue && UIApplication.sharedApplication().canOpenURL(NSURL(string: "itms-books:")!)
+    }
+
+    func showOpenInView(inView parentView: UIView, forWebView webView: WKWebView) {
+        let overlayView = OpenInView()
+
+        overlayView.openInButton.addTarget(self, action: "open", forControlEvents: .TouchUpInside)
+        parentView.addSubview(overlayView)
+        overlayView.snp_makeConstraints { make in
+            make.trailing.equalTo(parentView)
+            make.leading.equalTo(parentView)
+            make.height.equalTo(OpenInViewUX.ViewHeight)
+            make.bottom.equalTo(webView.snp_top)
+        }
+
+        webView.snp_updateConstraints { make in
+            make.edges.equalTo(EdgeInsetsMake(OpenInViewUX.ViewHeight, left: 0, bottom: 0, right: 0))
+        }
+
+        view = overlayView
+    }
+
+    func hideOpenInView(forWebView webView: WKWebView) {
+        webView.snp_updateConstraints { make in
+            make.edges.equalTo(EdgeInsetsMake(0, left: 0, bottom: 0, right: 0))
+        }
+        view?.removeFromSuperview()
+        view = nil
+    }
+
+    func open() {
+        guard let parentView = view?.superview, docController = self.docController else { print("view doesn't have a superview so can't open anything"); return }
+        // iBooks should be installed by default on all devices we care about, so regardless of whether or not there are other pdf-capable
+        // apps on this device, if we can open in iBooks we can open this PDF
+        // simulators do not have iBooks so the open in view will not work on the simulator
+        if UIApplication.sharedApplication().canOpenURL(NSURL(string: "itms-books:")!) {
+            log.info("iBooks installed: attempting to open pdf")
+            docController.presentOpenInMenuFromRect(CGRectZero, inView: parentView, animated: true)
+        } else {
+            log.info("iBooks is not installed")
+        }
+    }
+}
+
+class OpenInView: UIView {
+    let openInButton = UIButton()
+
+    init() {
+        super.init(frame: CGRectZero)
+        openInButton.setTitleColor(OpenInViewUX.TextColor, forState: UIControlState.Normal)
+        openInButton.setTitle(NSLocalizedString("Open in...", comment: "String indicating that the file can be opened in another application"), forState: UIControlState.Normal)
+        openInButton.titleLabel?.font = OpenInViewUX.TextFont
+        openInButton.sizeToFit()
+        self.addSubview(openInButton)
+        openInButton.snp_makeConstraints { make in
+            make.centerY.equalTo(self)
+            make.height.equalTo(self)
+            make.trailing.equalTo(self).offset(OpenInViewUX.TextOffset)
+        }
+        self.backgroundColor = UIColor.whiteColor()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setHeight(height: CGFloat) {
+        var frame = self.frame
+        frame.size.height = height
+        self.frame = frame
+    }
+}

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-books</string>
+	</array>
 	<key>AppID</key>
 	<string>$(MOZ_APP_ID)</string>
 	<key>BreakpadProduct</key>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1183166
Opens PDF's in whatever application is capable of handling it
No tests as iBooks/other apps that open PDFs don't exist on simulator.

Uses a helper to handle all the UI keeping it out of BrowserViewController

Made so that open in helpers for other types of file can be added later if desired.

needs looking at from a designer as the Open In View is rather slapdash