### PR TITLE
Bug 1204539 - don't add logins helper if we're in a private browsing tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1092,10 +1092,12 @@ extension BrowserViewController: BrowserDelegate {
 
         let favicons = FaviconManager(browser: browser, profile: profile)
         browser.addHelper(favicons, name: FaviconManager.name())
-
-        // Temporarily disable password support until the new code lands
-        let logins = LoginsHelper(browser: browser, profile: profile)
-        browser.addHelper(logins, name: LoginsHelper.name())
+        
+        // only add the logins helper if the tab is not a private browsing tab
+        if !browser.isPrivate {
+            let logins = LoginsHelper(browser: browser, profile: profile)
+            browser.addHelper(logins, name: LoginsHelper.name())
+        }
 
         let contextMenuHelper = ContextMenuHelper(browser: browser)
         contextMenuHelper.delegate = self


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1204539

Don't add LoginsHelper.js to the browser window if the tab is a private browsing tab