### PR TITLE
Bug 1157737 - Use MutationObserver to detect that a form has been injected

### DIFF
--- a/Client/Assets/LoginsHelper.js
+++ b/Client/Assets/LoginsHelper.js
@@ -599,19 +599,28 @@ function onBlur(event) {
   LoginManagerContent.onUsernameInput(event)
 }
 
-window.addEventListener("load", function(event) {
+var documentBody = document.querySelector('body')
+var observer = new MutationObserver(function(mutations) {
+    findLogins()
+});
+
+observer.observe(documentBody, { attributes: false, childList: true, characterData: false });
+
+function findLogins(event) {
   try {
     for (var i = 0; i < document.forms.length; i++) {
       LoginManagerContent._asyncFindLogins(document.forms[i], { })
-                         .then(function(res) {
-                            LoginManagerContent.loginsFound(res.form, res.loginsFound);
-                         }).then(null, log);
-    }
-  } catch(ex) {
-    // Eat errors to avoid leaking them to the page
-    log(ex);
-  }
-})
+        .then(function(res) {
+          LoginManagerContent.loginsFound(res.form, res.loginsFound);
+        }).then(null, log);
+     }
+   } catch(ex) {
+     // Eat errors to avoid leaking them to the page
+     log(ex);
+   }
+ }
+
+window.addEventListener("load", findLogins);
 
 window.addEventListener("submit", function(event) {
   try {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1157737

Question: Is searching the DOM for a form injected be and then calling `findLogins` more efficient than just using `findLogins` and possibly executing it _every_ time there is a mutation regardless of whether a form has been injected?