### PR TITLE
Bug 1201505 - Add visual cues and modifications to the browsing UI to indicate that we're in private mode

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -595,6 +595,7 @@
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
+		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; settings = {ASSET_TAGS = (); }; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
@@ -1214,6 +1215,20 @@
 			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
 			remoteInfo = Client;
 		};
+		E660BDFE1BB06522009AC090 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD9D052C1A757D8B003CCB21;
+			remoteInfo = SWXMLHashOSX;
+		};
+		E660BE001BB06522009AC090 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CD9D05361A757D8B003CCB21;
+			remoteInfo = SWXMLHashOSXTests;
+		};
 		E69E4E291B9F709A00646EDB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E69E4E241B9F709A00646EDB /* Breakpad.xcodeproj */;
@@ -1719,6 +1734,7 @@
 		E635D41A1B73F06E0078962F /* NSFileManager+NRFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+NRFileManager.h"; sourceTree = "<group>"; };
 		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
 		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
+		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
@@ -2396,6 +2412,8 @@
 				D30B0F2F1AA7D66300C01CA3 /* ThumbnailCell.swift */,
 				0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */,
 				6BB2FD971B017DAB001A189B /* AuralProgressBar.swift */,
+				E660BDD81BB06521009AC090 /* TabsButton.swift */,
+				E660BE051BB0666D009AC090 /* InnerStrokedView.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -2477,7 +2495,9 @@
 			isa = PBXGroup;
 			children = (
 				D38B2D811A8D98380040E6B5 /* SWXMLHash.framework */,
+				E660BDFF1BB06522009AC090 /* SWXMLHash.framework */,
 				D38B2D831A8D98380040E6B5 /* SWXMLHashTests.xctest */,
+				E660BE011BB06522009AC090 /* SWXMLHashOSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3879,6 +3899,20 @@
 			remoteRef = D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		E660BDFF1BB06522009AC090 /* SWXMLHash.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SWXMLHash.framework;
+			remoteRef = E660BDFE1BB06522009AC090 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E660BE011BB06522009AC090 /* SWXMLHashOSXTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SWXMLHashOSXTests.xctest;
+			remoteRef = E660BE001BB06522009AC090 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		E69E4E2A1B9F709A00646EDB /* Breakpad.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -4518,6 +4552,7 @@
 				E47616C71AB74CA600E7DD25 /* ReaderModeBarView.swift in Sources */,
 				E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
+				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; settings = {ASSET_TAGS = (); }; };
+		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; settings = {ASSET_TAGS = (); }; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
@@ -1735,6 +1736,7 @@
 		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
 		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
+		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
@@ -4517,6 +4519,7 @@
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				0AE491A61A41C88C0046C724 /* BackForwardListViewController.swift in Sources */,
+				E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */,
 				0BF648111A9C54E900BA963C /* TopSitesPanel.swift in Sources */,
 				0B1C05D71A798B1F004C78B0 /* UIImageViewAligned.m in Sources */,
 				0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */,

--- a/Client/Assets/Images.xcassets/back.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/back.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "back.png"
+      "filename" : "back.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "back@2x.png"
+      "filename" : "back@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "back@3x.png"
+      "filename" : "back@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Assets/Images.xcassets/bookmark.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/bookmark.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "bookmark.png"
+      "filename" : "bookmark.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "bookmark@2x.png"
+      "filename" : "bookmark@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "bookmark@3x.png"
+      "filename" : "bookmark@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Assets/Images.xcassets/forward.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/forward.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "forward.png"
+      "filename" : "forward.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "forward@2x.png"
+      "filename" : "forward@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "forward@3x.png"
+      "filename" : "forward@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Assets/Images.xcassets/reload.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/reload.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "refresh.png"
+      "filename" : "refresh.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "refresh@2x.png"
+      "filename" : "refresh@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "refresh@3x.png"
+      "filename" : "refresh@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Assets/Images.xcassets/send.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/send.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "send.png"
+      "filename" : "send.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "send@2x.png"
+      "filename" : "send@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "send@3x.png"
+      "filename" : "send@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Assets/Images.xcassets/stop.imageset/Contents.json
+++ b/Client/Assets/Images.xcassets/stop.imageset/Contents.json
@@ -2,22 +2,25 @@
   "images" : [
     {
       "idiom" : "universal",
-      "scale" : "1x",
-      "filename" : "stop.png"
+      "filename" : "stop.png",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "scale" : "2x",
-      "filename" : "stop@2x.png"
+      "filename" : "stop@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "universal",
-      "scale" : "3x",
-      "filename" : "stop@3x.png"
+      "filename" : "stop@3x.png",
+      "scale" : "3x"
     }
   ],
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -16,7 +16,7 @@ protocol BrowserLocationViewDelegate {
     func browserLocationViewLocationAccessibilityActions(browserLocationView: BrowserLocationView) -> [UIAccessibilityCustomAction]?
 }
 
-private struct BrowserLocationViewUX {
+struct BrowserLocationViewUX {
     static let HostFontColor = UIColor.blackColor()
     static let BaseURLFontColor = UIColor.grayColor()
     static let BaseURLPitch = 0.75

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -29,11 +29,11 @@ class BrowserLocationView: UIView {
     var longPressRecognizer: UILongPressGestureRecognizer!
     var tapRecognizer: UITapGestureRecognizer!
 
-    private var _baseURLFontColor: UIColor = BrowserLocationViewUX.BaseURLFontColor {
+    dynamic var baseURLFontColor: UIColor = BrowserLocationViewUX.BaseURLFontColor {
         didSet { updateTextWithURL() }
     }
 
-    private var _hostFontColor: UIColor = BrowserLocationViewUX.HostFontColor {
+    dynamic var hostFontColor: UIColor = BrowserLocationViewUX.HostFontColor {
         didSet { updateTextWithURL() }
     }
 
@@ -202,8 +202,8 @@ class BrowserLocationView: UIView {
             // Highlight the base domain of the current URL.
             let attributedString = NSMutableAttributedString(string: httplessURL)
             let nsRange = NSMakeRange(0, httplessURL.characters.count)
-            attributedString.addAttribute(NSForegroundColorAttributeName, value: _baseURLFontColor, range: nsRange)
-            attributedString.colorSubstring(baseDomain, withColor: _hostFontColor)
+            attributedString.addAttribute(NSForegroundColorAttributeName, value: baseURLFontColor, range: nsRange)
+            attributedString.colorSubstring(baseDomain, withColor: hostFontColor)
             attributedString.addAttribute(UIAccessibilitySpeechAttributePitch, value: NSNumber(double: BrowserLocationViewUX.BaseURLPitch), range: nsRange)
             attributedString.pitchSubstring(baseDomain, withPitch: BrowserLocationViewUX.HostPitch)
             urlTextField.attributedText = attributedString
@@ -231,19 +231,6 @@ extension BrowserLocationView: AccessibilityActionsSource {
             return delegate?.browserLocationViewLocationAccessibilityActions(self)
         }
         return nil
-    }
-}
-
-// MARK: UIAppearance
-extension BrowserLocationView {
-    dynamic var baseURLFontColor: UIColor {
-        get { return _baseURLFontColor }
-        set { _baseURLFontColor = newValue }
-    }
-
-    dynamic var hostFontColor: UIColor {
-        get { return _hostFontColor }
-        set { _hostFontColor = newValue }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -29,6 +29,14 @@ class BrowserLocationView: UIView {
     var longPressRecognizer: UILongPressGestureRecognizer!
     var tapRecognizer: UITapGestureRecognizer!
 
+    private var _baseURLFontColor: UIColor = BrowserLocationViewUX.BaseURLFontColor {
+        didSet { updateTextWithURL() }
+    }
+
+    private var _hostFontColor: UIColor = BrowserLocationViewUX.HostFontColor {
+        didSet { updateTextWithURL() }
+    }
+
     var url: NSURL? {
         didSet {
             let wasHidden = lockImageView.hidden
@@ -194,8 +202,8 @@ class BrowserLocationView: UIView {
             // Highlight the base domain of the current URL.
             let attributedString = NSMutableAttributedString(string: httplessURL)
             let nsRange = NSMakeRange(0, httplessURL.characters.count)
-            attributedString.addAttribute(NSForegroundColorAttributeName, value: BrowserLocationViewUX.BaseURLFontColor, range: nsRange)
-            attributedString.colorSubstring(baseDomain, withColor: BrowserLocationViewUX.HostFontColor)
+            attributedString.addAttribute(NSForegroundColorAttributeName, value: _baseURLFontColor, range: nsRange)
+            attributedString.colorSubstring(baseDomain, withColor: _hostFontColor)
             attributedString.addAttribute(UIAccessibilitySpeechAttributePitch, value: NSNumber(double: BrowserLocationViewUX.BaseURLPitch), range: nsRange)
             attributedString.pitchSubstring(baseDomain, withPitch: BrowserLocationViewUX.HostPitch)
             urlTextField.attributedText = attributedString
@@ -223,6 +231,19 @@ extension BrowserLocationView: AccessibilityActionsSource {
             return delegate?.browserLocationViewLocationAccessibilityActions(self)
         }
         return nil
+    }
+}
+
+// MARK: UIAppearance
+extension BrowserLocationView {
+    dynamic var baseURLFontColor: UIColor {
+        get { return _baseURLFontColor }
+        set { _baseURLFontColor = newValue }
+    }
+
+    dynamic var hostFontColor: UIColor {
+        get { return _hostFontColor }
+        set { _hostFontColor = newValue }
     }
 }
 

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -14,6 +14,7 @@ protocol BrowserToolbarProtocol {
     var forwardButton: UIButton { get }
     var backButton: UIButton { get }
     var stopReloadButton: UIButton { get }
+    var actionButtons: [UIButton] { get }
 
     func updateBackStatus(canGoBack: Bool)
     func updateForwardStatus(canGoForward: Bool)
@@ -44,6 +45,12 @@ public class BrowserToolbarHelper: NSObject {
     let ImageStop = UIImage(named: "stop")
     let ImageStopPressed = UIImage(named: "stopPressed")
 
+    var buttonTintColor = UIColor.darkGrayColor() {
+        didSet {
+            setTintColor(buttonTintColor, forButtons: toolbar.actionButtons)
+        }
+    }
+
     var loading: Bool = false {
         didSet {
             if loading {
@@ -56,6 +63,10 @@ public class BrowserToolbarHelper: NSObject {
                 toolbar.stopReloadButton.accessibilityLabel = NSLocalizedString("Reload", comment: "Accessibility Label for the browser toolbar Reload button")
             }
         }
+    }
+
+    private func setTintColor(color: UIColor, forButtons buttons: [UIButton]) {
+        buttons.forEach { $0.tintColor = color }
     }
 
     init(toolbar: BrowserToolbarProtocol) {
@@ -95,6 +106,8 @@ public class BrowserToolbarHelper: NSObject {
         let longPressGestureBookmarkButton = UILongPressGestureRecognizer(target: self, action: "SELdidLongPressBookmark:")
         toolbar.bookmarkButton.addGestureRecognizer(longPressGestureBookmarkButton)
         toolbar.bookmarkButton.addTarget(self, action: "SELdidClickBookmark", forControlEvents: UIControlEvents.TouchUpInside)
+
+        setTintColor(buttonTintColor, forButtons: toolbar.actionButtons)
     }
 
     func SELdidClickBack() {
@@ -153,6 +166,7 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
     let forwardButton: UIButton
     let backButton: UIButton
     let stopReloadButton: UIButton
+    let actionButtons: [UIButton]
 
     var helper: BrowserToolbarHelper?
 
@@ -164,6 +178,7 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
         stopReloadButton = UIButton()
         shareButton = UIButton()
         bookmarkButton = UIButton()
+        actionButtons = [backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton]
 
         super.init(frame: frame)
 
@@ -213,5 +228,16 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
         CGContextMoveToPoint(context, start.x, start.y)
         CGContextAddLineToPoint(context, end.x, end.y)
         CGContextStrokePath(context)
+    }
+}
+
+// MARK: UIAppearance
+extension BrowserToolbar {
+    dynamic var actionButtonTintColor: UIColor? {
+        get { return helper?.buttonTintColor }
+        set {
+            guard let value = newValue else { return }
+            helper?.buttonTintColor = value
+        }
     }
 }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -314,9 +314,13 @@ private func createTransitionCellFromBrowser(browser: Browser?, withFrame frame:
         cell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
     } else {
         var defaultFavicon = UIImage(named: "defaultFavicon")
-        defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
-        cell.favicon.image = defaultFavicon
-        cell.favicon.tintColor = (browser?.isPrivate ?? false) ? UIColor.whiteColor() : UIColor.darkGrayColor()
+        if browser?.isPrivate ?? false {
+            defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
+            cell.favicon.image = defaultFavicon
+            cell.favicon.tintColor = (browser?.isPrivate ?? false) ? UIColor.whiteColor() : UIColor.darkGrayColor()
+        } else {
+            cell.favicon.image = defaultFavicon
+        }
     }
     return cell
 }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -313,7 +313,10 @@ private func createTransitionCellFromBrowser(browser: Browser?, withFrame frame:
     if let favIcon = browser?.displayFavicon {
         cell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
     } else {
-        cell.favicon.image = UIImage(named: "defaultFavicon")
+        var defaultFavicon = UIImage(named: "defaultFavicon")
+        defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
+        cell.favicon.image = defaultFavicon
+        cell.favicon.tintColor = (browser?.isPrivate ?? false) ? UIColor.whiteColor() : UIColor.darkGrayColor()
     }
     return cell
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -425,6 +425,8 @@ class BrowserViewController: UIViewController {
         } else {
             restoreTabs()
         }
+
+        updateTabCountUsingTabManager(tabManager, animated: false)
     }
 
     private func restoreTabs() {
@@ -1409,10 +1411,10 @@ extension BrowserViewController: TabManagerDelegate {
         return false
     }
 
-    private func updateTabCountUsingTabManager(tabManager: TabManager) {
+    private func updateTabCountUsingTabManager(tabManager: TabManager, animated: Bool = true) {
         if let selectedTab = tabManager.selectedTab {
             let count = selectedTab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
-            urlBar.updateTabCount(max(count, 1))
+            urlBar.updateTabCount(max(count, 1), animated: animated)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -64,11 +64,11 @@ class BrowserViewController: UIViewController {
     let tabManager: TabManager
 
     // These views wrap the urlbar and toolbar to provide background effects on them
-    var header: UIView!
+    var header: BlurWrapper!
     var headerBackdrop: UIView!
     var footer: UIView!
     var footerBackdrop: UIView!
-    private var footerBackground: UIView!
+    private var footerBackground: BlurWrapper?
     private var topTouchArea: UIButton!
 
     // Backdrop used for displaying greyed background for private tabs
@@ -149,7 +149,13 @@ class BrowserViewController: UIViewController {
         if showToolbar {
             toolbar = BrowserToolbar()
             toolbar?.browserToolbarDelegate = self
-            footerBackground = wrapInEffect(toolbar!, parent: footer)
+            footerBackground = BlurWrapper(view: toolbar!)
+
+            // Need to reset the proper blur style
+            if let selectedTab = tabManager.selectedTab where selectedTab.isPrivate {
+                footerBackground!.blurStyle = .Dark
+            }
+            footer.addSubview(footerBackground!)
         }
 
         view.setNeedsUpdateConstraints()
@@ -257,7 +263,8 @@ class BrowserViewController: UIViewController {
         urlBar.translatesAutoresizingMaskIntoConstraints = false
         urlBar.delegate = self
         urlBar.browserToolbarDelegate = self
-        header = wrapInEffect(urlBar, parent: view, backgroundColor: nil)
+        header = BlurWrapper(view: urlBar)
+        view.addSubview(header)
 
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
         pasteGoAction = AccessibleAction(name: NSLocalizedString("Paste & Go", comment: "Paste the URL into the location bar and visit"), handler: { () -> Bool in
@@ -506,23 +513,6 @@ class BrowserViewController: UIViewController {
                 make.bottom.equalTo(self.view.snp_bottom)
             }
         }
-    }
-
-    private func wrapInEffect(view: UIView, parent: UIView) -> UIView {
-        return self.wrapInEffect(view, parent: parent, backgroundColor: UIColor.clearColor())
-    }
-
-    private func wrapInEffect(view: UIView, parent: UIView, backgroundColor: UIColor?) -> UIView {
-        let effect = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.ExtraLight))
-        effect.clipsToBounds = false
-        effect.translatesAutoresizingMaskIntoConstraints = false
-        if let _ = backgroundColor {
-            view.backgroundColor = backgroundColor
-        }
-        effect.addSubview(view)
-
-        parent.addSubview(effect)
-        return effect
     }
 
     private func showHomePanelController(inline inline: Bool) {
@@ -1329,6 +1319,12 @@ extension BrowserViewController: TabManagerDelegate {
 
             let count = tab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
             urlBar.updateTabCount(count, animated: false)
+
+            if tab.isPrivate {
+                applyPrivateModeTheme()
+            } else {
+                applyNormalModeTheme()
+            }
 
             scrollController.browser = selected
             webViewContainer.addSubview(webView)
@@ -2172,3 +2168,99 @@ extension BrowserViewController: UIAlertViewDelegate {
     }
 }
 
+// MARK: Browser Chrome Theming
+extension BrowserViewController {
+
+    func applyPrivateModeTheme() {
+        BrowserLocationView.appearance().baseURLFontColor = UIColor.lightGrayColor()
+        BrowserLocationView.appearance().hostFontColor = UIColor.whiteColor()
+        BrowserLocationView.appearance().backgroundColor = UIConstants.PrivateModeLocationBackgroundColor
+
+        ToolbarTextField.appearance().backgroundColor = UIConstants.PrivateModeLocationBackgroundColor
+        ToolbarTextField.appearance().textColor = UIColor.whiteColor()
+        ToolbarTextField.appearance().clearButtonTintColor = UIColor.whiteColor()
+
+        URLBarView.appearance().locationBorderColor = UIConstants.PrivateModeLocationBorderColor
+        URLBarView.appearance().progressBarTint = UIConstants.PrivateModePurple
+        URLBarView.appearance().cancelTextColor = UIColor.whiteColor()
+        URLBarView.appearance().actionButtonTintColor = UIConstants.PrivateModeActionButtonTintColor
+
+        BrowserToolbar.appearance().actionButtonTintColor = UIConstants.PrivateModeActionButtonTintColor
+
+        TabsButton.appearance().borderColor = UIConstants.PrivateModePurple
+        TabsButton.appearance().borderWidth = 2
+        TabsButton.appearance().titleFont = UIConstants.DefaultMediumBoldFont
+        TabsButton.appearance().titleBackgroundColor = UIConstants.AppBackgroundColor
+        TabsButton.appearance().textColor = UIConstants.PrivateModePurple
+        TabsButton.appearance().insets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+
+        header.blurStyle = .Dark
+        footerBackground?.blurStyle = .Dark
+    }
+
+    func applyNormalModeTheme() {
+        BrowserLocationView.appearance().baseURLFontColor = BrowserLocationViewUX.BaseURLFontColor
+        BrowserLocationView.appearance().hostFontColor = BrowserLocationViewUX.HostFontColor
+        BrowserLocationView.appearance().backgroundColor = UIColor.whiteColor()
+
+        ToolbarTextField.appearance().backgroundColor = UIColor.whiteColor()
+        ToolbarTextField.appearance().textColor = UIColor.blackColor()
+        ToolbarTextField.appearance().clearButtonTintColor = nil
+
+        URLBarView.appearance().locationBorderColor = URLBarViewUX.TextFieldBorderColor
+        URLBarView.appearance().progressBarTint = URLBarViewUX.ProgressTintColor
+        URLBarView.appearance().cancelTextColor = UIColor.blackColor()
+        URLBarView.appearance().actionButtonTintColor = UIColor.darkGrayColor()
+
+        BrowserToolbar.appearance().actionButtonTintColor = UIColor.darkGrayColor()
+
+        TabsButton.appearance().borderColor = TabsButtonUX.borderColor
+        TabsButton.appearance().borderWidth = TabsButtonUX.borderStrokeWidth
+        TabsButton.appearance().titleFont = TabsButtonUX.titleFont
+        TabsButton.appearance().titleBackgroundColor = TabsButtonUX.titleBackgroundColor
+        TabsButton.appearance().textColor = TabsButtonUX.titleColor
+        TabsButton.appearance().insets = TabsButtonUX.titleInsets
+
+        header.blurStyle = .ExtraLight
+        footerBackground?.blurStyle = .ExtraLight
+    }
+}
+
+// A small convienent class for wrapping a view with a blur background that can be modified
+class BlurWrapper: UIView {
+    var blurStyle: UIBlurEffectStyle = .ExtraLight {
+        didSet {
+            let newEffect = UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
+            effectView.removeFromSuperview()
+            effectView = newEffect
+            insertSubview(effectView, belowSubview: wrappedView)
+            effectView.snp_remakeConstraints { make in
+                make.edges.equalTo(self)
+            }
+        }
+    }
+
+    private var effectView: UIVisualEffectView
+    private var wrappedView: UIView
+
+    init(view: UIView) {
+        wrappedView = view
+        effectView = UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
+        super.init(frame: CGRectZero)
+
+        addSubview(effectView)
+        addSubview(wrappedView)
+
+        effectView.snp_makeConstraints { make in
+            make.edges.equalTo(self)
+        }
+
+        wrappedView.snp_makeConstraints { make in
+            make.edges.equalTo(self)
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2216,12 +2216,12 @@ extension BrowserViewController {
 
         BrowserToolbar.appearance().actionButtonTintColor = UIColor.darkGrayColor()
 
-        TabsButton.appearance().borderColor = TabsButtonUX.borderColor
-        TabsButton.appearance().borderWidth = TabsButtonUX.borderStrokeWidth
-        TabsButton.appearance().titleFont = TabsButtonUX.titleFont
-        TabsButton.appearance().titleBackgroundColor = TabsButtonUX.titleBackgroundColor
-        TabsButton.appearance().textColor = TabsButtonUX.titleColor
-        TabsButton.appearance().insets = TabsButtonUX.titleInsets
+        TabsButton.appearance().borderColor = TabsButtonUX.BorderColor
+        TabsButton.appearance().borderWidth = TabsButtonUX.BorderStrokeWidth
+        TabsButton.appearance().titleFont = TabsButtonUX.TitleFont
+        TabsButton.appearance().titleBackgroundColor = TabsButtonUX.TitleBackgroundColor
+        TabsButton.appearance().textColor = TabsButtonUX.TitleColor
+        TabsButton.appearance().insets = TabsButtonUX.TitleInsets
 
         header.blurStyle = .ExtraLight
         footerBackground?.blurStyle = .ExtraLight

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2181,8 +2181,10 @@ extension BrowserViewController {
         ToolbarTextField.appearance().backgroundColor = UIConstants.PrivateModeLocationBackgroundColor
         ToolbarTextField.appearance().textColor = UIColor.whiteColor()
         ToolbarTextField.appearance().clearButtonTintColor = UIColor.whiteColor()
+        ToolbarTextField.appearance().highlightColor = UIConstants.PrivateModeTextHighlightColor
 
         URLBarView.appearance().locationBorderColor = UIConstants.PrivateModeLocationBorderColor
+        URLBarView.appearance().locationActiveBorderColor = UIConstants.PrivateModePurple
         URLBarView.appearance().progressBarTint = UIConstants.PrivateModePurple
         URLBarView.appearance().cancelTextColor = UIColor.whiteColor()
         URLBarView.appearance().actionButtonTintColor = UIConstants.PrivateModeActionButtonTintColor
@@ -2190,7 +2192,7 @@ extension BrowserViewController {
         BrowserToolbar.appearance().actionButtonTintColor = UIConstants.PrivateModeActionButtonTintColor
 
         TabsButton.appearance().borderColor = UIConstants.PrivateModePurple
-        TabsButton.appearance().borderWidth = 2
+        TabsButton.appearance().borderWidth = 1
         TabsButton.appearance().titleFont = UIConstants.DefaultMediumBoldFont
         TabsButton.appearance().titleBackgroundColor = UIConstants.AppBackgroundColor
         TabsButton.appearance().textColor = UIConstants.PrivateModePurple
@@ -2207,9 +2209,11 @@ extension BrowserViewController {
 
         ToolbarTextField.appearance().backgroundColor = UIColor.whiteColor()
         ToolbarTextField.appearance().textColor = UIColor.blackColor()
+        ToolbarTextField.appearance().highlightColor = AutocompleteTextFieldUX.HighlightColor
         ToolbarTextField.appearance().clearButtonTintColor = nil
 
         URLBarView.appearance().locationBorderColor = URLBarViewUX.TextFieldBorderColor
+        URLBarView.appearance().locationActiveBorderColor = URLBarViewUX.TextFieldActiveBorderColor
         URLBarView.appearance().progressBarTint = URLBarViewUX.ProgressTintColor
         URLBarView.appearance().cancelTextColor = UIColor.blackColor()
         URLBarView.appearance().actionButtonTintColor = UIColor.darkGrayColor()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -590,9 +590,13 @@ private class TabManagerDataSource: NSObject, UICollectionViewDataSource {
             tabCell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
         } else {
             var defaultFavicon = UIImage(named: "defaultFavicon")
-            defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
-            tabCell.favicon.image = defaultFavicon
-            tabCell.favicon.tintColor = tab.isPrivate ? UIColor.whiteColor() : UIColor.darkGrayColor()
+            if tab.isPrivate {
+                defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
+                tabCell.favicon.image = defaultFavicon
+                tabCell.favicon.tintColor = UIColor.whiteColor()
+            } else {
+                tabCell.favicon.image = defaultFavicon
+            }
         }
 
         tabCell.background.image = tab.screenshot

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -678,34 +678,6 @@ private class TabTrayCollectionViewLayout: UICollectionViewFlowLayout {
     }
 }
 
-// A transparent view with a rectangular border with rounded corners, stroked
-// with a semi-transparent white border.
-class InnerStrokedView: UIView {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        self.backgroundColor = UIColor.clearColor()
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func drawRect(rect: CGRect) {
-        let strokeWidth = 1.0 as CGFloat
-        let halfWidth = strokeWidth/2 as CGFloat
-
-        let path = UIBezierPath(roundedRect: CGRect(x: halfWidth,
-            y: halfWidth,
-            width: rect.width - strokeWidth,
-            height: rect.height - strokeWidth),
-            cornerRadius: TabTrayControllerUX.CornerRadius)
-        
-        path.lineWidth = strokeWidth
-        UIColor.whiteColor().colorWithAlphaComponent(0.2).setStroke()
-        path.stroke()
-    }
-}
-
 struct EmptyPrivateTabsViewUX {
     static let TitleColor = UIColor.whiteColor()
     static let TitleFont = UIFont.systemFontOfSize(22, weight: UIFontWeightMedium)

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -589,7 +589,10 @@ private class TabManagerDataSource: NSObject, UICollectionViewDataSource {
         if let favIcon = tab.displayFavicon {
             tabCell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
         } else {
-            tabCell.favicon.image = UIImage(named: "defaultFavicon")
+            var defaultFavicon = UIImage(named: "defaultFavicon")
+            defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
+            tabCell.favicon.image = defaultFavicon
+            tabCell.favicon.tintColor = tab.isPrivate ? UIColor.whiteColor() : UIColor.darkGrayColor()
         }
 
         tabCell.background.image = tab.screenshot

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -98,6 +98,7 @@ class TabCell: UICollectionViewCell {
 
         self.closeButton = UIButton()
         self.closeButton.setImage(UIImage(named: "stop"), forState: UIControlState.Normal)
+        self.closeButton.tintColor = UIColor.lightGrayColor()
         self.closeButton.imageEdgeInsets = UIEdgeInsetsMake(TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset, TabTrayControllerUX.CloseButtonEdgeInset)
 
         self.innerStroke = InnerStrokedView(frame: self.backgroundHolder.frame)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -50,17 +50,17 @@ protocol URLBarDelegate: class {
 
 class URLBarView: UIView {
     // Additional UIAppearance-configurable properties
-    dynamic var locationHighlightedBorderColor: UIColor = URLBarViewUX.TextFieldActiveBorderColor {
-        didSet {
-            if inOverlayMode {
-                locationContainer.layer.borderColor = locationHighlightedBorderColor.CGColor
-            }
-        }
-    }
     dynamic var locationBorderColor: UIColor = URLBarViewUX.TextFieldBorderColor {
         didSet {
             if !inOverlayMode {
                 locationContainer.layer.borderColor = locationBorderColor.CGColor
+            }
+        }
+    }
+    dynamic var locationActiveBorderColor: UIColor = URLBarViewUX.TextFieldActiveBorderColor {
+        didSet {
+            if inOverlayMode {
+                locationContainer.layer.borderColor = locationActiveBorderColor.CGColor
             }
         }
     }
@@ -493,7 +493,7 @@ class URLBarView: UIView {
         self.backButton.alpha = inOverlayMode ? 0 : 1
         self.stopReloadButton.alpha = inOverlayMode ? 0 : 1
 
-        let borderColor = inOverlayMode ? locationHighlightedBorderColor : locationBorderColor
+        let borderColor = inOverlayMode ? locationActiveBorderColor : locationBorderColor
         locationContainer.layer.borderColor = borderColor.CGColor
 
         if inOverlayMode {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -345,11 +345,7 @@ class URLBarView: UIView {
         self.actionButtons.forEach { $0.alpha = alpha }
     }
 
-    func updateTabCount(count: Int) {
-        updateTabCount(count, animated: true)
-    }
-
-    func updateTabCount(count: Int, animated: Bool) {
+    func updateTabCount(count: Int, animated: Bool = true) {
         if let _ = self.clonedTabsButton {
             self.clonedTabsButton?.layer.removeAllAnimations()
             self.clonedTabsButton?.removeFromSuperview()

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -48,6 +48,22 @@ protocol URLBarDelegate: class {
 }
 
 class URLBarView: UIView {
+    // Additional UIAppearance-configurable properties
+    dynamic var locationHighlightedBorderColor: UIColor = URLBarViewUX.TextFieldActiveBorderColor {
+        didSet {
+            if inOverlayMode {
+                locationContainer.layer.borderColor = locationHighlightedBorderColor.CGColor
+            }
+        }
+    }
+    dynamic var locationBorderColor: UIColor = URLBarViewUX.TextFieldBorderColor {
+        didSet {
+            if !inOverlayMode {
+                locationContainer.layer.borderColor = locationBorderColor.CGColor
+            }
+        }
+    }
+
     weak var delegate: URLBarDelegate?
     weak var browserToolbarDelegate: BrowserToolbarDelegate?
     var helper: BrowserToolbarHelper?
@@ -101,7 +117,7 @@ class URLBarView: UIView {
         // Enable clipping to apply the rounded edges to subviews.
         locationContainer.clipsToBounds = true
 
-        locationContainer.layer.borderColor = URLBarViewUX.TextFieldBorderColor.CGColor
+        locationContainer.layer.borderColor = self.locationBorderColor.CGColor
         locationContainer.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         locationContainer.layer.borderWidth = URLBarViewUX.TextFieldBorderWidth
 
@@ -489,7 +505,7 @@ class URLBarView: UIView {
         self.backButton.alpha = inOverlayMode ? 0 : 1
         self.stopReloadButton.alpha = inOverlayMode ? 0 : 1
 
-        let borderColor = inOverlayMode ? URLBarViewUX.TextFieldActiveBorderColor : URLBarViewUX.TextFieldBorderColor
+        let borderColor = inOverlayMode ? locationHighlightedBorderColor : locationBorderColor
         locationContainer.layer.borderColor = borderColor.CGColor
 
         if inOverlayMode {
@@ -656,11 +672,11 @@ extension URLBarView: AutocompleteTextFieldDelegate {
     }
 }
 
-// MARK: Customizable view properties exposed through UIAppearance
+// MARK: UIAppearance
 extension URLBarView {
-    dynamic var progressBarTint: UIColor {
-        get { return progressBar.tintColor }
-        set { progressBar.tintColor = newValue }
+    dynamic var progressBarTint: UIColor? {
+        get { return progressBar.progressTintColor }
+        set { progressBar.progressTintColor = newValue }
     }
 
     dynamic var cancelTextColor: UIColor? {
@@ -674,6 +690,11 @@ extension URLBarView {
             guard let value = newValue else { return }
             helper?.buttonTintColor = value
         }
+    }
+
+    dynamic var locationInputBackgroundColor: UIColor? {
+        get { return locationTextField.backgroundColor }
+        set { locationTextField.backgroundColor = newValue }
     }
 }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -791,13 +791,15 @@ class ToolbarTextField: AutocompleteTextField {
         // subviews, find the clear button, and tint it ourselves. Thanks to Mikael Hellman for the tip:
         // http://stackoverflow.com/questions/27944781/how-to-change-the-tint-color-of-the-clear-button-on-a-uitextfield
         for view in subviews as [UIView] {
-            if view is UIButton {
-                let button = view as! UIButton
+            if let button = view as? UIButton {
                 if let image = button.imageForState(.Normal) {
                     if tintedClearImage == nil {
                         tintedClearImage = tintImage(image, color: clearButtonTintColor)
                     }
-                    button.setImage(tintedClearImage, forState: .Normal)
+
+                    if button.imageView?.image != tintedClearImage {
+                        button.setImage(tintedClearImage, forState: .Normal)
+                    }
                 }
             }
         }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -7,7 +7,7 @@ import UIKit
 import Shared
 import SnapKit
 
-private struct URLBarViewUX {
+struct URLBarViewUX {
     static let TextFieldBorderColor = UIColor(rgb: 0xBBBBBB)
     static let TextFieldActiveBorderColor = UIColor(rgb: 0x4A90E2)
     static let TextFieldContentInset = UIOffsetMake(9, 5)
@@ -21,6 +21,7 @@ private struct URLBarViewUX {
     static let URLBarCurveOffsetLeft: CGFloat = -10
     // buffer so we dont see edges when animation overshoots with spring
     static let URLBarCurveBounceBuffer: CGFloat = 8
+    static let ProgressTintColor = UIColor(red:1, green:0.32, blue:0, alpha:1)
 
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -108,17 +108,9 @@ class URLBarView: UIView {
         return locationContainer
     }()
 
-    private lazy var tabsButton: UIButton = {
-        let tabsButton = InsetButton()
-        tabsButton.translatesAutoresizingMaskIntoConstraints = false
-        tabsButton.setTitle("0", forState: UIControlState.Normal)
-        tabsButton.setTitleColor(URLBarViewUX.backgroundColorWithAlpha(1), forState: UIControlState.Normal)
-        tabsButton.titleLabel?.layer.backgroundColor = UIColor.whiteColor().CGColor
-        tabsButton.titleLabel?.layer.cornerRadius = 2
-        tabsButton.titleLabel?.font = UIConstants.DefaultSmallFontBold
-        tabsButton.titleLabel?.textAlignment = NSTextAlignment.Center
-        tabsButton.setContentHuggingPriority(1000, forAxis: UILayoutConstraintAxis.Horizontal)
-        tabsButton.setContentCompressionResistancePriority(1000, forAxis: UILayoutConstraintAxis.Horizontal)
+    private lazy var tabsButton: TabsButton = {
+        let tabsButton = TabsButton()
+        tabsButton.titleLabel.text = "0"
         tabsButton.addTarget(self, action: "SELdidClickAddTab", forControlEvents: UIControlEvents.TouchUpInside)
         tabsButton.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility Label for the tabs button in the browser toolbar")
         return tabsButton
@@ -240,14 +232,10 @@ class URLBarView: UIView {
             make.trailing.equalTo(self)
         }
 
-        tabsButton.titleLabel?.snp_makeConstraints { make in
-            make.size.equalTo(URLBarViewUX.TabsButtonHeight)
-        }
-
         tabsButton.snp_makeConstraints { make in
             make.centerY.equalTo(self.locationContainer)
             make.trailing.equalTo(self)
-            make.width.height.equalTo(UIConstants.ToolbarHeight)
+            make.size.equalTo(UIConstants.ToolbarHeight)
         }
 
         curveShape.snp_makeConstraints { make in
@@ -345,76 +333,77 @@ class URLBarView: UIView {
     }
 
     func updateTabCount(count: Int, animated: Bool) {
-        if let _ = self.clonedTabsButton {
-            self.clonedTabsButton?.layer.removeAllAnimations()
-            self.clonedTabsButton?.removeFromSuperview()
-            self.tabsButton.layer.removeAllAnimations()
-        }
-
-        // make a 'clone' of the tabs button
-        let newTabsButton = InsetButton()
-        self.clonedTabsButton = newTabsButton
-        newTabsButton.addTarget(self, action: "SELdidClickAddTab", forControlEvents: UIControlEvents.TouchUpInside)
-        newTabsButton.setTitleColor(UIConstants.AppBackgroundColor, forState: UIControlState.Normal)
-        newTabsButton.titleLabel?.layer.backgroundColor = UIColor.whiteColor().CGColor
-        newTabsButton.titleLabel?.layer.cornerRadius = 2
-        newTabsButton.titleLabel?.font = UIConstants.DefaultSmallFontBold
-        newTabsButton.titleLabel?.textAlignment = NSTextAlignment.Center
-        newTabsButton.setTitle(count.description, forState: .Normal)
-        addSubview(newTabsButton)
-        newTabsButton.titleLabel?.snp_makeConstraints { make in
-            make.size.equalTo(URLBarViewUX.TabsButtonHeight)
-        }
-        newTabsButton.snp_makeConstraints { make in
-            make.centerY.equalTo(self.locationContainer)
-            make.trailing.equalTo(self)
-            make.size.equalTo(UIConstants.ToolbarHeight)
-        }
-
-        newTabsButton.frame = tabsButton.frame
-
-        // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be
-        // a rotation around a non-origin point
-        if let labelFrame = newTabsButton.titleLabel?.frame {
-            let halfTitleHeight = CGRectGetHeight(labelFrame) / 2
-
-            var newFlipTransform = CATransform3DIdentity
-            newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
-            newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-M_PI_2), 1.0, 0.0, 0.0)
-            newTabsButton.titleLabel?.layer.transform = newFlipTransform
-
-            var oldFlipTransform = CATransform3DIdentity
-            oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
-            oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
-            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(M_PI_2), 1.0, 0.0, 0.0)
-
-            let animate = {
-                newTabsButton.titleLabel?.layer.transform = CATransform3DIdentity
-                self.tabsButton.titleLabel?.layer.transform = oldFlipTransform
-                self.tabsButton.titleLabel?.layer.opacity = 0
-            }
-
-            let completion: (Bool) -> Void = { finished in
-                // remove the clone and setup the actual tab button
-                newTabsButton.removeFromSuperview()
-
-                self.tabsButton.titleLabel?.layer.opacity = 1
-                self.tabsButton.titleLabel?.layer.transform = CATransform3DIdentity
-                self.tabsButton.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) browser toolbar")
-
-                if finished {
-                    self.tabsButton.setTitle(count.description, forState: UIControlState.Normal)
-                    self.tabsButton.accessibilityValue = count.description
-                }
-            }
-
-            if animated {
-                UIView.animateWithDuration(1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
-            } else {
-                completion(true)
-            }
-        }
+        tabsButton.titleLabel.text = "\(count)"
+//        if let _ = self.clonedTabsButton {
+//            self.clonedTabsButton?.layer.removeAllAnimations()
+//            self.clonedTabsButton?.removeFromSuperview()
+//            self.tabsButton.layer.removeAllAnimations()
+//        }
+//
+//        // make a 'clone' of the tabs button
+//        let newTabsButton = InsetButton()
+//        self.clonedTabsButton = newTabsButton
+//        newTabsButton.addTarget(self, action: "SELdidClickAddTab", forControlEvents: UIControlEvents.TouchUpInside)
+//        newTabsButton.setTitleColor(UIConstants.AppBackgroundColor, forState: UIControlState.Normal)
+//        newTabsButton.titleLabel?.layer.backgroundColor = UIColor.whiteColor().CGColor
+//        newTabsButton.titleLabel?.layer.cornerRadius = 2
+//        newTabsButton.titleLabel?.font = UIConstants.DefaultSmallFontBold
+//        newTabsButton.titleLabel?.textAlignment = NSTextAlignment.Center
+//        newTabsButton.setTitle(count.description, forState: .Normal)
+//        addSubview(newTabsButton)
+//        newTabsButton.titleLabel?.snp_makeConstraints { make in
+//            make.size.equalTo(URLBarViewUX.TabsButtonHeight)
+//        }
+//        newTabsButton.snp_makeConstraints { make in
+//            make.centerY.equalTo(self.locationContainer)
+//            make.trailing.equalTo(self)
+//            make.size.equalTo(UIConstants.ToolbarHeight)
+//        }
+//
+//        newTabsButton.frame = tabsButton.frame
+//
+//        // Instead of changing the anchorPoint of the CALayer, lets alter the rotation matrix math to be
+//        // a rotation around a non-origin point
+//        if let labelFrame = newTabsButton.titleLabel?.frame {
+//            let halfTitleHeight = CGRectGetHeight(labelFrame) / 2
+//
+//            var newFlipTransform = CATransform3DIdentity
+//            newFlipTransform = CATransform3DTranslate(newFlipTransform, 0, halfTitleHeight, 0)
+//            newFlipTransform.m34 = -1.0 / 200.0 // add some perspective
+//            newFlipTransform = CATransform3DRotate(newFlipTransform, CGFloat(-M_PI_2), 1.0, 0.0, 0.0)
+//            newTabsButton.titleLabel?.layer.transform = newFlipTransform
+//
+//            var oldFlipTransform = CATransform3DIdentity
+//            oldFlipTransform = CATransform3DTranslate(oldFlipTransform, 0, halfTitleHeight, 0)
+//            oldFlipTransform.m34 = -1.0 / 200.0 // add some perspective
+//            oldFlipTransform = CATransform3DRotate(oldFlipTransform, CGFloat(M_PI_2), 1.0, 0.0, 0.0)
+//
+//            let animate = {
+//                newTabsButton.titleLabel?.layer.transform = CATransform3DIdentity
+//                self.tabsButton.titleLabel?.layer.transform = oldFlipTransform
+//                self.tabsButton.titleLabel?.layer.opacity = 0
+//            }
+//
+//            let completion: (Bool) -> Void = { finished in
+//                // remove the clone and setup the actual tab button
+//                newTabsButton.removeFromSuperview()
+//
+//                self.tabsButton.titleLabel?.layer.opacity = 1
+//                self.tabsButton.titleLabel?.layer.transform = CATransform3DIdentity
+//                self.tabsButton.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility label for the tabs button in the (top) browser toolbar")
+//
+//                if finished {
+//                    self.tabsButton.setTitle(count.description, forState: UIControlState.Normal)
+//                    self.tabsButton.accessibilityValue = count.description
+//                }
+//            }
+//
+//            if animated {
+//                UIView.animateWithDuration(1.5, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: UIViewAnimationOptions.CurveEaseInOut, animations: animate, completion: completion)
+//            } else {
+//                completion(true)
+//            }
+//        }
     }
 
     func updateProgressBar(progress: Float) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -667,6 +667,14 @@ extension URLBarView {
         get { return cancelButton.titleColorForState(UIControlState.Normal) }
         set { return cancelButton.setTitleColor(newValue, forState: UIControlState.Normal) }
     }
+
+    dynamic var actionButtonTintColor: UIColor? {
+        get { return helper?.buttonTintColor }
+        set {
+            guard let value = newValue else { return }
+            helper?.buttonTintColor = value
+        }
+    }
 }
 
 /* Code for drawing the urlbar curve */

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -656,6 +656,19 @@ extension URLBarView: AutocompleteTextFieldDelegate {
     }
 }
 
+// MARK: Customizable view properties exposed through UIAppearance
+extension URLBarView {
+    dynamic var progressBarTint: UIColor {
+        get { return progressBar.tintColor }
+        set { progressBar.tintColor = newValue }
+    }
+
+    dynamic var cancelTextColor: UIColor? {
+        get { return cancelButton.titleColorForState(UIControlState.Normal) }
+        set { return cancelButton.setTitleColor(newValue, forState: UIControlState.Normal) }
+    }
+}
+
 /* Code for drawing the urlbar curve */
 // Curve's aspect ratio
 private let ASPECT_RATIO = 0.729

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -9,6 +9,7 @@ public struct UIConstants {
     static let AboutHomeURL = NSURL(string: "\(WebServer.sharedInstance.base)/about/home/#panel=0")!
 
     static let AppBackgroundColor = UIColor.blackColor()
+    static let PrivateModePurple = UIColor(red: 207 / 255, green: 104 / 255, blue: 255 / 255, alpha: 1)
 
     static let ToolbarHeight: CGFloat = 44
     static let DefaultRowHeight: CGFloat = 58

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -13,6 +13,7 @@ public struct UIConstants {
     static let PrivateModeLocationBackgroundColor = UIColor(red: 31 / 255, green: 31 / 255, blue: 31 / 255, alpha: 1)
     static let PrivateModeLocationBorderColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.15)
     static let PrivateModeActionButtonTintColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.8)
+    static let PrivateModeTextHighlightColor = UIColor(red: 120 / 255, green: 120 / 255, blue: 165 / 255, alpha: 1)
 
     static let ToolbarHeight: CGFloat = 44
     static let DefaultRowHeight: CGFloat = 58

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -10,6 +10,9 @@ public struct UIConstants {
 
     static let AppBackgroundColor = UIColor.blackColor()
     static let PrivateModePurple = UIColor(red: 207 / 255, green: 104 / 255, blue: 255 / 255, alpha: 1)
+    static let PrivateModeLocationBackgroundColor = UIColor(red: 31 / 255, green: 31 / 255, blue: 31 / 255, alpha: 1)
+    static let PrivateModeLocationBorderColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.15)
+    static let PrivateModeActionButtonTintColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.8)
 
     static let ToolbarHeight: CGFloat = 44
     static let DefaultRowHeight: CGFloat = 58

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -16,7 +16,7 @@ protocol AutocompleteTextFieldDelegate: class {
     func autocompleteTextFieldDidBeginEditing(autocompleteTextField: AutocompleteTextField)
 }
 
-private struct AutocompleteTextFieldUX {
+struct AutocompleteTextFieldUX {
     static let HighlightColor = UIColor(rgb: 0xccdded)
 }
 
@@ -28,6 +28,19 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private var enteredText = ""
     private var previousSuggestion = ""
     private var notifyTextChanged: (() -> ())? = nil
+
+    dynamic var highlightColor = AutocompleteTextFieldUX.HighlightColor {
+        didSet {
+            if let text = text, selectedTextRange = selectedTextRange {
+                // If the text field is currently highlighted, make sure to update the color and ignore it if it's not highlighted
+                let attributedString = NSMutableAttributedString(string: text)
+                let selectedStart = offsetFromPosition(beginningOfDocument, toPosition: selectedTextRange.start)
+                let selectedLength = offsetFromPosition(selectedTextRange.start, toPosition: selectedTextRange.end)
+                attributedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(selectedStart, selectedLength))
+                attributedText = attributedString
+            }
+        }
+    }
 
     override var text: String? {
         didSet {
@@ -60,7 +73,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         if let text = text {
             if !text.isEmpty {
                 let attributedString = NSMutableAttributedString(string: text)
-                attributedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(0, (text).characters.count))
+                attributedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(0, (text).characters.count))
                 attributedText = attributedString
 
                 enteredText = ""

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -151,7 +151,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             if suggestion.startsWith(enteredText) && (enteredText).characters.count < suggestion.characters.count {
                 let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(enteredText.characters.count))
                 let completedAndMarkedString = NSMutableAttributedString(string: suggestion)
-                completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: AutocompleteTextFieldUX.HighlightColor, range: NSMakeRange(enteredText.characters.count, endingString.characters.count))
+                completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(enteredText.characters.count, endingString.characters.count))
                 attributedText = completedAndMarkedString
                 completionActive = true
                 previousSuggestion = suggestion

--- a/Client/Frontend/Widgets/InnerStrokedView.swift
+++ b/Client/Frontend/Widgets/InnerStrokedView.swift
@@ -7,9 +7,23 @@ import UIKit
 // A transparent view with a rectangular border with rounded corners, stroked
 // with a semi-transparent white border.
 class InnerStrokedView: UIView {
-    var color = UIColor.whiteColor().colorWithAlphaComponent(0.2)
-    var strokeWidth: CGFloat = 1.0
-    var cornerRadius: CGFloat = 4
+    var color = UIColor.whiteColor().colorWithAlphaComponent(0.2) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var strokeWidth: CGFloat = 1.0 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var cornerRadius: CGFloat = 4 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Client/Frontend/Widgets/InnerStrokedView.swift
+++ b/Client/Frontend/Widgets/InnerStrokedView.swift
@@ -4,8 +4,8 @@
 
 import UIKit
 
-// A transparent view with a rectangular border with rounded corners, stroked
-// with a semi-transparent white border.
+/// A transparent view with a rectangular border with rounded corners, stroked
+/// with a semi-transparent white border.
 class InnerStrokedView: UIView {
     var color = UIColor.whiteColor().colorWithAlphaComponent(0.2) {
         didSet {

--- a/Client/Frontend/Widgets/InnerStrokedView.swift
+++ b/Client/Frontend/Widgets/InnerStrokedView.swift
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+// A transparent view with a rectangular border with rounded corners, stroked
+// with a semi-transparent white border.
+class InnerStrokedView: UIView {
+    var color = UIColor.whiteColor().colorWithAlphaComponent(0.2)
+    var strokeWidth: CGFloat = 1.0
+    var cornerRadius: CGFloat = 4
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor.clearColor()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawRect(rect: CGRect) {
+        let halfWidth = strokeWidth / 2 as CGFloat
+
+        let path = UIBezierPath(roundedRect: CGRect(x: halfWidth,
+            y: halfWidth,
+            width: rect.width - strokeWidth,
+            height: rect.height - strokeWidth),
+            cornerRadius: cornerRadius)
+        color.setStroke()
+        path.lineWidth = strokeWidth
+        path.stroke()
+    }
+}

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -26,6 +26,13 @@ class TabsButton: UIControl {
         return label
     }()
 
+    lazy var insideButton: UIView = {
+        let view = UIView()
+        view.clipsToBounds = false
+        view.userInteractionEnabled = false
+        return view
+    }()
+
     private lazy var labelBackground: UIView = {
         let background = UIView()
         background.backgroundColor = TabsButtonUX.titleBackgroundColor
@@ -47,26 +54,49 @@ class TabsButton: UIControl {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        addSubview(labelBackground)
-        addSubview(borderView)
-        addSubview(titleLabel)
+        insideButton.addSubview(labelBackground)
+        insideButton.addSubview(borderView)
+        insideButton.addSubview(titleLabel)
+        addSubview(insideButton)
     }
 
     override func updateConstraints() {
         super.updateConstraints()
         labelBackground.snp_remakeConstraints { (make) -> Void in
-            make.edges.equalTo(self).inset(insets)
+            make.edges.equalTo(insideButton)
         }
         borderView.snp_remakeConstraints { (make) -> Void in
-            make.edges.equalTo(self).inset(insets)
+            make.edges.equalTo(insideButton)
         }
         titleLabel.snp_remakeConstraints { (make) -> Void in
+            make.edges.equalTo(insideButton)
+        }
+        insideButton.snp_remakeConstraints { (make) -> Void in
             make.edges.equalTo(self).inset(insets)
         }
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func clone() -> UIView {
+        let button = TabsButton()
+
+        button.titleLabel.text = titleLabel.text
+
+        // Copy all of the styable properties over to the new TabsButton
+        button.titleLabel.font = titleLabel.font
+        button.titleLabel.textColor = titleLabel.textColor
+        button.titleLabel.layer.cornerRadius = titleLabel.layer.cornerRadius
+
+        button.labelBackground.backgroundColor = labelBackground.backgroundColor
+        button.labelBackground.layer.cornerRadius = labelBackground.layer.cornerRadius
+
+        button.borderView.strokeWidth = borderView.strokeWidth
+        button.borderView.color = borderView.color
+        button.borderView.cornerRadius = borderView.cornerRadius
+        return button
     }
 }
 

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -5,7 +5,7 @@
 import Foundation
 import SnapKit
 
-private struct DefaultUX {
+struct TabsButtonUX {
     static let titleColor: UIColor = UIColor.blackColor()
     static let titleBackgroundColor: UIColor = UIColor.whiteColor()
     static let cornerRadius: CGFloat = 2
@@ -18,9 +18,9 @@ private struct DefaultUX {
 class TabsButton: UIControl {
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = DefaultUX.titleFont
-        label.textColor = DefaultUX.titleColor
-        label.layer.cornerRadius = DefaultUX.cornerRadius
+        label.font = TabsButtonUX.titleFont
+        label.textColor = TabsButtonUX.titleColor
+        label.layer.cornerRadius = TabsButtonUX.cornerRadius
         label.textAlignment = NSTextAlignment.Center
         label.userInteractionEnabled = false
         return label
@@ -28,22 +28,22 @@ class TabsButton: UIControl {
 
     private lazy var labelBackground: UIView = {
         let background = UIView()
-        background.backgroundColor = DefaultUX.titleBackgroundColor
-        background.layer.cornerRadius = DefaultUX.cornerRadius
+        background.backgroundColor = TabsButtonUX.titleBackgroundColor
+        background.layer.cornerRadius = TabsButtonUX.cornerRadius
         background.userInteractionEnabled = false
         return background
     }()
 
     private lazy var borderView: InnerStrokedView = {
         let border = InnerStrokedView()
-        border.strokeWidth = DefaultUX.borderStrokeWidth
-        border.color = DefaultUX.borderColor
-        border.cornerRadius = DefaultUX.cornerRadius
+        border.strokeWidth = TabsButtonUX.borderStrokeWidth
+        border.color = TabsButtonUX.borderColor
+        border.cornerRadius = TabsButtonUX.cornerRadius
         border.userInteractionEnabled = false
         return border
     }()
 
-    private var buttonInsets: UIEdgeInsets = DefaultUX.titleInsets
+    private var buttonInsets: UIEdgeInsets = TabsButtonUX.titleInsets
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -6,21 +6,21 @@ import Foundation
 import SnapKit
 
 struct TabsButtonUX {
-    static let titleColor: UIColor = UIColor.blackColor()
-    static let titleBackgroundColor: UIColor = UIColor.whiteColor()
-    static let cornerRadius: CGFloat = 2
-    static let titleFont: UIFont = UIConstants.DefaultSmallFontBold
-    static let borderStrokeWidth: CGFloat = 0
-    static let borderColor: UIColor = UIColor.clearColor()
-    static let titleInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+    static let TitleColor: UIColor = UIColor.blackColor()
+    static let TitleBackgroundColor: UIColor = UIColor.whiteColor()
+    static let CornerRadius: CGFloat = 2
+    static let TitleFont: UIFont = UIConstants.DefaultSmallFontBold
+    static let BorderStrokeWidth: CGFloat = 0
+    static let BorderColor: UIColor = UIColor.clearColor()
+    static let TitleInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
 }
 
 class TabsButton: UIControl {
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = TabsButtonUX.titleFont
-        label.textColor = TabsButtonUX.titleColor
-        label.layer.cornerRadius = TabsButtonUX.cornerRadius
+        label.font = TabsButtonUX.TitleFont
+        label.textColor = TabsButtonUX.TitleColor
+        label.layer.cornerRadius = TabsButtonUX.CornerRadius
         label.textAlignment = NSTextAlignment.Center
         label.userInteractionEnabled = false
         return label
@@ -35,22 +35,22 @@ class TabsButton: UIControl {
 
     private lazy var labelBackground: UIView = {
         let background = UIView()
-        background.backgroundColor = TabsButtonUX.titleBackgroundColor
-        background.layer.cornerRadius = TabsButtonUX.cornerRadius
+        background.backgroundColor = TabsButtonUX.TitleBackgroundColor
+        background.layer.cornerRadius = TabsButtonUX.CornerRadius
         background.userInteractionEnabled = false
         return background
     }()
 
     private lazy var borderView: InnerStrokedView = {
         let border = InnerStrokedView()
-        border.strokeWidth = TabsButtonUX.borderStrokeWidth
-        border.color = TabsButtonUX.borderColor
-        border.cornerRadius = TabsButtonUX.cornerRadius
+        border.strokeWidth = TabsButtonUX.BorderStrokeWidth
+        border.color = TabsButtonUX.BorderColor
+        border.cornerRadius = TabsButtonUX.CornerRadius
         border.userInteractionEnabled = false
         return border
     }()
 
-    private var buttonInsets: UIEdgeInsets = TabsButtonUX.titleInsets
+    private var buttonInsets: UIEdgeInsets = TabsButtonUX.TitleInsets
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SnapKit
+
+private struct DefaultUX {
+    static let titleColor: UIColor = UIColor.blackColor()
+    static let titleBackgroundColor: UIColor = UIColor.whiteColor()
+    static let cornerRadius: CGFloat = 2
+    static let titleFont: UIFont = UIConstants.DefaultSmallFontBold
+    static let borderStrokeWidth: CGFloat = 0
+    static let borderColor: UIColor = UIColor.clearColor()
+    static let titleInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+}
+
+class TabsButton: UIControl {
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = DefaultUX.titleFont
+        label.textColor = DefaultUX.titleColor
+        label.layer.cornerRadius = DefaultUX.cornerRadius
+        label.textAlignment = NSTextAlignment.Center
+        label.userInteractionEnabled = false
+        return label
+    }()
+
+    private lazy var labelBackground: UIView = {
+        let background = UIView()
+        background.backgroundColor = DefaultUX.titleBackgroundColor
+        background.layer.cornerRadius = DefaultUX.cornerRadius
+        background.userInteractionEnabled = false
+        return background
+    }()
+
+    private lazy var borderView: InnerStrokedView = {
+        let border = InnerStrokedView()
+        border.strokeWidth = DefaultUX.borderStrokeWidth
+        border.color = DefaultUX.borderColor
+        border.cornerRadius = DefaultUX.cornerRadius
+        border.userInteractionEnabled = false
+        return border
+    }()
+
+    private var buttonInsets: UIEdgeInsets = DefaultUX.titleInsets
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(labelBackground)
+        addSubview(borderView)
+        addSubview(titleLabel)
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+        labelBackground.snp_remakeConstraints { (make) -> Void in
+            make.edges.equalTo(self).inset(insets)
+        }
+        borderView.snp_remakeConstraints { (make) -> Void in
+            make.edges.equalTo(self).inset(insets)
+        }
+        titleLabel.snp_remakeConstraints { (make) -> Void in
+            make.edges.equalTo(self).inset(insets)
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: UIAppearance
+extension TabsButton {
+    dynamic var borderColor: UIColor {
+        get { return borderView.color }
+        set { borderView.color = newValue }
+    }
+
+    dynamic var borderWidth: CGFloat {
+        get { return borderView.strokeWidth }
+        set { borderView.strokeWidth = newValue }
+    }
+
+    dynamic var textColor: UIColor? {
+        get { return titleLabel.textColor }
+        set { titleLabel.textColor = newValue }
+    }
+
+    dynamic var titleFont: UIFont? {
+        get { return titleLabel.font }
+        set { titleLabel.font = newValue }
+    }
+
+    dynamic var titleBackgroundColor: UIColor? {
+        get { return labelBackground.backgroundColor }
+        set { labelBackground.backgroundColor = newValue }
+    }
+
+    dynamic var insets : UIEdgeInsets {
+        get { return buttonInsets }
+        set {
+            buttonInsets = newValue
+            setNeedsUpdateConstraints()
+        }
+    }
+}


### PR DESCRIPTION
This series of patches adds the private/normal mode UI themes for the browser view controller. It includes:

* Exposes various style properties from our custom subviews (URLBarView, ToolbarTextField, etc) to be configured using the UIAppearance API.
* Adds a new TabsButton UIControl subclass that replaces our InsetButton for additional customization.
* Replaces BVC's wrapInEffect with a custom BlurWrapper UIView subclass that allows us to swap the effect in an isolated way.
* Changes some images into templated images which we toggle their tint instead of using the provided image color.