### PR TITLE
Bug 1206944 - Startup crash due to database contention

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		2894C16D1AE89FD500F1F92F /* HistoryPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2894C16B1AE89FD500F1F92F /* HistoryPayload.swift */; };
 		28A6CE8A1AC082E200C1A2D4 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */; };
 		28AA941D1B97DCA800703DC6 /* BookmarkPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AA941C1B97DCA800703DC6 /* BookmarkPayload.swift */; settings = {ASSET_TAGS = (); }; };
+		28C210C51BB3941D0017B00C /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; settings = {ASSET_TAGS = (); }; };
 		28C328021AD387E00005149C /* KeychainWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1BDF8D1A8523B000213B54 /* KeychainWrapper.swift */; };
 		28C4AB721AD42D4300D9ACE3 /* Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C4AB711AD42D4300D9ACE3 /* Clients.swift */; };
 		28C8D11D1AD4CE8900F62011 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
@@ -4305,6 +4306,7 @@
 				285F2DC21AF80B4600211843 /* SQLiteBookmarks.swift in Sources */,
 				2FA4351D1ABB6831008031D1 /* FaviconsTable.swift in Sources */,
 				2FA4352B1ABB6836008031D1 /* SwiftData.swift in Sources */,
+				28C210C51BB3941D0017B00C /* DefaultSuggestedSites.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -423,11 +423,7 @@ class BrowserViewController: UIViewController {
 
     override func viewDidAppear(animated: Bool) {
         startTrackingAccessibilityStatus()
-        // We want to load queued tabs here in case we need to execute any commands that were received while using a share extension,
-        // but no point even trying if this is the first time.
-        if !presentIntroViewController() {
-            loadQueuedTabs()
-        }
+        presentIntroViewController()
         super.viewDidAppear(animated)
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -281,7 +281,7 @@ class BrowserViewController: UIViewController {
         })
 
 
-        searchLoader = SearchLoader(history: profile.history, urlBar: urlBar)
+        searchLoader = SearchLoader(profile: profile, urlBar: urlBar)
 
         footer = UIView()
         self.view.addSubview(footer)

--- a/Client/Frontend/Browser/SearchLoader.swift
+++ b/Client/Frontend/Browser/SearchLoader.swift
@@ -20,12 +20,12 @@ typealias SearchLoader = _SearchLoader<AnyObject, AnyObject>
  * Since both of these use the same SQL query, we can perform the query once and dispatch the results.
  */
 class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController> {
-    private let history: BrowserHistory
+    private let profile: Profile
     private let urlBar: URLBarView
     private var inProgress: Cancellable? = nil
 
-    init(history: BrowserHistory, urlBar: URLBarView) {
-        self.history = history
+    init(profile: Profile, urlBar: URLBarView) {
+        self.profile = profile
         self.urlBar = urlBar
         super.init()
     }
@@ -42,7 +42,7 @@ class _SearchLoader<UnusedA, UnusedB>: Loader<Cursor<Site>, SearchViewController
                 self.inProgress = nil
             }
 
-            let deferred = self.history.getSitesByFrecencyWithLimit(100, whereURLContains: query)
+            let deferred = self.profile.history.getSitesByFrecencyWithLimit(100, whereURLContains: query)
             inProgress = deferred as? Cancellable
 
             deferred.uponQueue(dispatch_get_main_queue()) { result in

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -267,9 +267,9 @@ public class BrowserProfile: Profile {
     lazy var bookmarks: protocol<BookmarksModelFactory, ShareToDestination> = {
         // Make sure the rest of our tables are initialized before we try to read them!
         // This expression is for side-effects only.
-        let _ = self.places
-
-        return SQLiteBookmarks(db: self.db)
+        withExtendedLifetime(self.places) {
+            return SQLiteBookmarks(db: self.db)
+        }
     }()
 
     lazy var searchEngines: SearchEngines = {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -36,8 +36,12 @@ typealias EngineIdentifier = String
 typealias SyncFunction = (SyncDelegate, Prefs, Ready) -> SyncResult
 
 class ProfileFileAccessor: FileAccessor {
-    init(profile: Profile) {
-        let profileDirName = "profile.\(profile.localName())"
+    convenience init(profile: Profile) {
+        self.init(localName: profile.localName())
+    }
+
+    init(localName: String) {
+        let profileDirName = "profile.\(localName)"
 
         // Bug 1147262: First option is for device, second is for simulator.
         var rootPath: NSString
@@ -159,10 +163,13 @@ protocol Profile: class {
 
 public class BrowserProfile: Profile {
     private let name: String
+    internal let files: FileAccessor
+
     weak private var app: UIApplication?
 
     init(localName: String, app: UIApplication?) {
         self.name = localName
+        self.files = ProfileFileAccessor(localName: localName)
         self.app = app
 
         let notificationCenter = NSNotificationCenter.defaultCenter()
@@ -225,10 +232,6 @@ public class BrowserProfile: Profile {
 
     func localName() -> String {
         return name
-    }
-
-    var files: FileAccessor {
-        return ProfileFileAccessor(profile: self)
     }
 
     lazy var queue: TabQueue = {

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -34,7 +34,7 @@ public class BrowserDB {
     static let MaxVariableNumber = 999
 
     public init(filename: String, secretKey: String? = nil, files: FileAccessor) {
-        log.debug("Initializing BrowserDB.")
+        log.debug("Initializing BrowserDB: \(filename).")
         self.files = files
         self.filename = filename
         self.schemaTable = SchemaTable()

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -19,7 +19,7 @@ typealias Args = [AnyObject?]
 // Version 6 - Visit timestamps are now microseconds.
 // Version 7 - Eliminate most tables.
 public class BrowserDB {
-    private var db: SwiftData
+    private let db: SwiftData
     // XXX: Increasing this should blow away old history, since we currently don't support any upgrades.
     private let Version: Int = 7
     private let files: FileAccessor
@@ -41,7 +41,7 @@ public class BrowserDB {
         self.secretKey = secretKey
 
         let file = ((try! files.getAndEnsureDirectory()) as NSString).stringByAppendingPathComponent(filename)
-        db = SwiftData(filename: file, key: secretKey, prevKey: nil)
+        self.db = SwiftData(filename: file, key: secretKey, prevKey: nil)
 
         if AppConstants.BuildChannel == .Developer && secretKey != nil {
             log.debug("Creating db: \(file) with secret = \(secretKey)")
@@ -104,8 +104,8 @@ public class BrowserDB {
     // creation of the table in the database.
     func createOrUpdate(table: Table) -> Bool {
         log.debug("Create or update \(table.name) version \(table.version).")
+
         var success = true
-        db = SwiftData(filename: ((try! files.getAndEnsureDirectory()) as NSString).stringByAppendingPathComponent(self.filename), key: secretKey)
         let doCreate = { (connection: SQLiteDBConnection) -> () in
             switch self.createTable(connection, table: table) {
             case .Created:

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -16,9 +16,14 @@ public class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
 
     public init(db: BrowserDB) {
         self.db = db
-        db.createOrUpdate(clients)
-        db.createOrUpdate(tabs)
-        db.createOrUpdate(commands)
+
+        // There's no need to synchronously wait to update these tables --
+        // we don't pay attention to the return value -- so let's do it in
+        // the background.
+        let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
+        dispatch_async(queue) {
+            self.db.createOrUpdate(clients, tabs, commands)
+        }
     }
 
     private func doWipe(f: (conn: SQLiteDBConnection, inout err: NSError?) -> ()) -> Deferred<Maybe<()>> {


### PR DESCRIPTION
There were two problems here.

The first is that we were loading queued tabs in the background while the main thread was initing `SearchLoader` with `profile.history`, which caused DB init. (The root cause is that table init is a special snowflake.)

The fix for that is to… not do that. `SearchLoader` can access `profile.history` when it needs it, on the correct thread.

The second is that we were loading queued tabs twice, once in `BVC` when our view loads, and once in `AppDelegate` when we become active. These occur on separate threads and can thus content.

The fix for that is to remove one. I opted to keep the `AppDelegate` one, which is where we first put it. I tested both app switching and changing apps via the launchpad, and we still correctly dequeue tabs.

Handily, both of these changes should slightly improve our startup performance.