### PR TITLE
3d touch quick actions for firefox

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -814,13 +814,6 @@
 			remoteGlobalIDString = 6CA0A8071A75135D00AC539F;
 			remoteInfo = SecEncodeTransformTests;
 		};
-		2F67C5271BB0D33000E7B73A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2FA435FA1ABB83B4008031D1;
-			remoteInfo = Account;
-		};
 		2F77F69C1ABCAEFE00484F3A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 28CE83CA1A1D1D5100576538 /* FxA.xcodeproj */;
@@ -5873,6 +5866,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = Client/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MOZ_PRODUCT_NAME = FennecNightly;
 				OTHER_LDFLAGS = "-ObjC";
@@ -6020,6 +6014,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = Client/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MOZ_PRODUCT_NAME = Firefox;
 				OTHER_LDFLAGS = "-ObjC";
@@ -7241,6 +7236,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = Client/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MOZ_PRODUCT_NAME = Fennec;
 				OTHER_LDFLAGS = "-ObjC";
@@ -7268,6 +7264,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = Client/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MOZ_PRODUCT_NAME = FennecAurora;
 				OTHER_LDFLAGS = "-ObjC";

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -246,8 +246,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 self.browserViewController.openBookmarks()
                 handled = true
             case ShortcutType.ReadingList:
-                self.browserViewController.
-                    openReadingList()
+                self.browserViewController.openReadingList()
                 handled = true
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -791,6 +791,35 @@ class BrowserViewController: UIViewController {
         let tab = tabManager.addTab(NSURLRequest(URL: url))
         tabManager.selectTab(tab)
     }
+
+    
+    func openReadingList() {
+        openNewTab()
+        homePanelController?.selectedButtonIndex = 4
+    }
+
+    func openBookmarks() {
+        openNewTab()
+        homePanelController?.selectedButtonIndex = 1
+    }
+
+    func openPrivateTab() {
+        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile)
+        var tab: Browser
+        self.tabTrayController = tabTrayController
+        self.tabTrayController.changeMode(true)
+        tab = self.tabManager.addTab(isPrivate: true)
+        self.tabManager.selectTab(tab)
+    }
+
+    func openNewTab() {
+        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile)
+        var tab: Browser
+        self.tabTrayController = tabTrayController
+        self.tabTrayController.changeMode(false)
+        tab = self.tabManager.addTab()
+        self.tabManager.selectTab(tab)
+    }
 }
 
 /**

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -231,6 +231,7 @@ class TabTrayController: UIViewController {
     var addTabButton: UIButton!
     var settingsButton: UIButton!
     var collectionViewTransitionSnapshot: UIView?
+    var calledFromShortcut: Bool = false
 
     private var privateMode: Bool = false {
         didSet {
@@ -239,7 +240,9 @@ class TabTrayController: UIViewController {
                 togglePrivateMode.accessibilityValue = privateMode ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
                 emptyPrivateTabsView.hidden = !(privateMode && tabManager.privateTabs.count == 0)
                 tabDataSource.tabs = tabsToDisplay
-                collectionView.reloadData()
+                if !calledFromShortcut {
+                 collectionView.reloadData()
+                }
             }
         }
     }
@@ -428,6 +431,11 @@ class TabTrayController: UIViewController {
     @available(iOS 9, *)
     func SELdidTogglePrivateMode() {
         privateMode = !privateMode
+    }
+
+    func changeMode(toPrivate: Bool) {
+        calledFromShortcut = true
+        privateMode = toPrivate
     }
 }
 

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -100,5 +100,40 @@
 	<true/>
 	<key>Vendor</key>
 	<string>$(MOZ_VENDOR)</string>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.mozilla.ios.newtab</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>New Tab</string>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>add</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.mozilla.ios.newprivate</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>New Private Tab</string>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>smallPrivateMask</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.mozilla.ios.bookmarks</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Show Bookmarks</string>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>bookmark</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemType</key>
+			<string>org.mozilla.ios.readinglist</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Show Reading List</string>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>reader</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Quick actions such as "New Tab", "New Private Tab", "Show Bookmarks", "Show reading list" are added

![simulator screen shot sep 27 2015 6 39 49 pm](https://cloud.githubusercontent.com/assets/1550776/10155336/76c5f204-6639-11e5-92f7-43f328cf4872.png)

to run it on a simulator use https://github.com/DeskConnect/SBShortcutMenuSimulator .

Currently there are four major issues with this:
- Tab count goes wrong after some time when private tab is added through shortcut.
- When bookmarks/reading list is opened from shortcuts, home panel resets to top sites once we leave the tab and open any other tab and come back to it.
- In CrashReporterTests.swift import Client fails
- Deprecated methods in iOS 9 needs to be fixed.

I am looking for feedback and any help you guys could give me with the above four issues. 

