### PR TITLE
Bug 1205685 - handle AVAudioEngineConfigurationChangeNotification

### DIFF
--- a/Client/Frontend/Widgets/AuralProgressBar.swift
+++ b/Client/Frontend/Widgets/AuralProgressBar.swift
@@ -39,23 +39,47 @@ class AuralProgressBar {
             tickPlayer = AVAudioPlayerNode()
             tickPlayer.pan = -Float(AuralProgressBarUX.TickProgressPanSpread)
             engine.attachNode(tickPlayer)
-            engine.connect(tickPlayer, to: engine.mainMixerNode, format: nil)
 
             progressPlayer = AVAudioPlayerNode()
             progressPlayer.pan = +Float(AuralProgressBarUX.TickProgressPanSpread)
             engine.attachNode(progressPlayer)
-            engine.connect(progressPlayer, to: engine.mainMixerNode, format: nil)
+
+            connectPlayerNodes()
+
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("audioEngineConfigurationDidChange:"), name: AVAudioEngineConfigurationChangeNotification, object: nil)
+        }
+
+        deinit {
+            NSNotificationCenter.defaultCenter().removeObserver(self, name: AVAudioEngineConfigurationChangeNotification, object: nil)
+        }
+
+        func connectPlayerNodes() {
+            let mainMixer = engine.mainMixerNode
+            engine.connect(tickPlayer, to: mainMixer, format: mainMixer.outputFormatForBus(0))
+            engine.connect(progressPlayer, to: mainMixer, format: tickBuffer.format)
+        }
+
+        func disconnectPlayerNodes() {
+            engine.disconnectNodeOutput(tickPlayer)
+            engine.disconnectNodeOutput(progressPlayer)
+        }
+
+        @objc func audioEngineConfigurationDidChange(notification: NSNotification) {
+            disconnectPlayerNodes()
+            connectPlayerNodes()
+
+            if !engine.running {
+                do { try engine.start() } catch _ { }
+            }
         }
 
         func start() {
             do {
                 try engine.start()
-            } catch _ {
-            }
+            } catch _ { }
             tickPlayer.play()
             progressPlayer.play()
-            tickPlayer.scheduleBuffer(tickBuffer, atTime: nil, options: AVAudioPlayerNodeBufferOptions.Loops) { () -> Void in
-            }
+            tickPlayer.scheduleBuffer(tickBuffer, atTime: nil, options: AVAudioPlayerNodeBufferOptions.Loops) { }
         }
 
         func stop() {
@@ -68,8 +92,7 @@ class AuralProgressBar {
             // using exp2 and log2 instead of exp and log as "log" clashes with XCGLogger.log
             let pitch = AuralProgressBarUX.ProgressStartFrequency * exp2(log2(AuralProgressBarUX.ProgressEndFrequency/AuralProgressBarUX.ProgressStartFrequency) * progress)
             let buffer = UI.tone(progressPlayer.outputFormatForBus(0), pitch: pitch, volume: AuralProgressBarUX.ProgressVolume, duration: AuralProgressBarUX.ProgressDuration)
-            progressPlayer.scheduleBuffer(buffer, atTime: nil, options: .Interrupts) { () -> Void in
-            }
+            progressPlayer.scheduleBuffer(buffer, atTime: nil, options: .Interrupts) { }
         }
 
         class func tone(format: AVAudioFormat, pitch: Double, volume: Double, duration: Double, period: Double? = nil) -> AVAudioPCMBuffer {


### PR DESCRIPTION
Listen for AVAudioEngineConfigurationChangeNotification and detach & reattach mainMixerNodes when called.
This was a blind fix as I was unable to replicate the original issue and so _hope_ that this has resolved it correctly. Any confirmation from someone who has been able to experience it appreciated.

https://bugzilla.mozilla.org/show_bug.cgi?id=1205685