### PR TITLE
Bug 1167010 - Handle Sync server initialization.

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -55,9 +55,8 @@ public class FirefoxAccount {
         self.configuration = configuration
         self.stateCache = stateCache
         self.stateCache.checkpoint()
-        self.syncAuthState = SyncAuthState(account: self,
-            cache: KeychainCache.fromBranch("account.syncAuthState", withLabel: self.stateCache.label, factory: syncAuthStateCachefromJSON)
-)
+        self.syncAuthState = FirefoxAccountSyncAuthState(account: self,
+            cache: KeychainCache.fromBranch("account.syncAuthState", withLabel: self.stateCache.label, factory: syncAuthStateCachefromJSON))
     }
 
     public class func fromConfigurationAndJSON(configuration: FirefoxAccountConfiguration, data: JSON) -> FirefoxAccount? {

--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -92,8 +92,8 @@ public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration
     public let oauthEndpointURL = NSURL(string: "https://oauth.accounts.firefox.com/v1")!
     public let profileEndpointURL = NSURL(string: "https://profile.accounts.firefox.com/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1&exclude_signup=1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1&exclude_signup=1")!
+    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
     public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ProductionSync15Configuration()

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -16,6 +16,11 @@ public struct SyncAuthStateCache {
     let expiresAt: Timestamp
 }
 
+public protocol SyncAuthState {
+    func invalidate()
+    func token(now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: NSData)>>
+}
+
 public func syncAuthStateCachefromJSON(json: JSON) -> SyncAuthStateCache? {
     if let version = json["version"].asInt {
         if version != CurrentSyncAuthStateCacheVersion {
@@ -43,7 +48,7 @@ extension SyncAuthStateCache: JSONLiteralConvertible {
     }
 }
 
-public class SyncAuthState {
+public class FirefoxAccountSyncAuthState: SyncAuthState {
     private let account: FirefoxAccount
     private let cache: KeychainCache<SyncAuthStateCache>
 

--- a/Client-Bridging-Header.h
+++ b/Client-Bridging-Header.h
@@ -8,6 +8,7 @@
 #import "Try.h"
 
 #import "GCDWebServer.h"
+#import "GCDWebServerDataRequest.h"
 #import "GCDWebServerDataResponse.h"
 #import "ThirdParty/UIImageViewAligned/UIImageViewAligned/UIImageViewAligned.h"
 #import "Carthage/Checkouts/SDWebImage/SDWebImage/UIImageView+WebCache.h"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
 		2F642CED1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */; };
+		2F67C5261BB0CB4E00E7B73A /* MetaGlobalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */; settings = {ASSET_TAGS = (); }; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
 		2F834D161A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
 		2F834D171A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
@@ -323,8 +324,8 @@
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
-		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */; settings = {ASSET_TAGS = (); }; };
+		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		7BBFEE9A1BB409B200A305AA /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; settings = {ASSET_TAGS = (); }; };
@@ -594,10 +595,10 @@
 		E635D41E1B73F41C0078962F /* NSFileManager+NRFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */; };
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
-		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; settings = {ASSET_TAGS = (); }; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; settings = {ASSET_TAGS = (); }; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; settings = {ASSET_TAGS = (); }; };
+		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
@@ -1210,13 +1211,6 @@
 			remoteGlobalIDString = 288A2D851AB8B3260023ABC3;
 			remoteInfo = Shared;
 		};
-		E63CD1B21B31B66400A63AFF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
-			remoteInfo = Client;
-		};
 		E660BDFE1BB06522009AC090 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */;
@@ -1230,6 +1224,13 @@
 			proxyType = 2;
 			remoteGlobalIDString = CD9D05361A757D8B003CCB21;
 			remoteInfo = SWXMLHashOSXTests;
+		};
+		E63CD1B21B31B66400A63AFF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
+			remoteInfo = Client;
 		};
 		E69E4E291B9F709A00646EDB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1456,6 +1457,7 @@
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
 		2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITests.swift; sourceTree = "<group>"; };
+		2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetaGlobalTests.swift; path = SyncTests/MetaGlobalTests.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
 		2F834D111A80629A006A0B7B /* FxASignIn.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = FxASignIn.js; path = Frontend/SignIn/FxASignIn.js; sourceTree = "<group>"; };
 		2F834D131A80629A006A0B7B /* FxAContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAContentViewController.swift; path = Frontend/SignIn/FxAContentViewController.swift; sourceTree = "<group>"; };
@@ -1525,9 +1527,9 @@
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
+		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
 		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
-		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
@@ -1734,11 +1736,11 @@
 		E6231C041B90A472005ABB0D /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		E635D25D1B729DEE0078962F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E635D41A1B73F06E0078962F /* NSFileManager+NRFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+NRFileManager.h"; sourceTree = "<group>"; };
-		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
-		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
+		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
+		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
@@ -2120,6 +2122,7 @@
 				28786E541AB0F5FA009EA9EF /* DeferredTests.swift */,
 				28ECD9F31BA1F59800D829DA /* DownloadTests.swift */,
 				2F3724C41ABF3C01007607FA /* LiveStorageClientTests.swift */,
+				2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */,
 				28C0779D1A3B066000834FE5 /* RecordTests.swift */,
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
@@ -3153,6 +3156,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2F67C5281BB0D33000E7B73A /* PBXTargetDependency */,
 				28ECD9B11BA1F07000D829DA /* PBXTargetDependency */,
 				2827316B1ABC9BE700AA1954 /* PBXTargetDependency */,
 			);
@@ -3890,20 +3894,6 @@
 			remoteRef = D38B2D801A8D98380040E6B5 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		D38B2D831A8D98380040E6B5 /* SWXMLHashTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SWXMLHashTests.xctest;
-			remoteRef = D38B2D821A8D98380040E6B5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D3B5A0EA1B5459F600C15BCF /* WebImage.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = WebImage.framework;
-			remoteRef = D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		E660BDFF1BB06522009AC090 /* SWXMLHash.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -3916,6 +3906,20 @@
 			fileType = wrapper.cfbundle;
 			path = SWXMLHashOSXTests.xctest;
 			remoteRef = E660BE001BB06522009AC090 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		D38B2D831A8D98380040E6B5 /* SWXMLHashTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SWXMLHashTests.xctest;
+			remoteRef = D38B2D821A8D98380040E6B5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		D3B5A0EA1B5459F600C15BCF /* WebImage.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = WebImage.framework;
+			remoteRef = D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		E69E4E2A1B9F709A00646EDB /* Breakpad.framework */ = {
@@ -4181,6 +4185,7 @@
 				288502401AC117A500E7F670 /* SyncStateMachine.swift in Sources */,
 				28ECD9A71BA1EF3D00D829DA /* GCDWebServerResponse.m in Sources */,
 				28F657EA1ABFCA7A00A608BD /* LiveAccountTest.swift in Sources */,
+				2F67C5261BB0CB4E00E7B73A /* MetaGlobalTests.swift in Sources */,
 				2827319E1ABC9C5900AA1954 /* RecordTests.swift in Sources */,
 				28A6CE8A1AC082E200C1A2D4 /* UtilsTests.swift in Sources */,
 				28F657C01ABFC97D00A608BD /* Record.swift in Sources */,
@@ -4762,6 +4767,11 @@
 			isa = PBXTargetDependency;
 			name = "XCGLogger (iOS)";
 			targetProxy = 2F14E1371ABB88E000FF98DB /* PBXContainerItemProxy */;
+		};
+		2F67C5281BB0D33000E7B73A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2FA435FA1ABB83B4008031D1 /* Account */;
+			targetProxy = 2F67C5271BB0D33000E7B73A /* PBXContainerItemProxy */;
 		};
 		2F77F69D1ABCAEFE00484F3A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -612,13 +612,12 @@ public class BrowserProfile: Profile {
                 }
 
                 let authState = account.syncAuthState
-                let syncPrefs = profile.prefs.branch("sync")
 
-                let readyDeferred = SyncStateMachine.toReady(authState, prefs: syncPrefs)
+                let readyDeferred = SyncStateMachine(prefs: self.prefsForSync).toReady(authState)
                 let delegate = profile.getSyncDelegate()
 
                 let go = readyDeferred >>== { ready in
-                    function(delegate, syncPrefs, ready)
+                    function(delegate, self.prefsForSync, ready)
                 }
 
                 // Always unlock when we're done.

--- a/Sync/EnvelopeJSON.swift
+++ b/Sync/EnvelopeJSON.swift
@@ -54,6 +54,14 @@ public class EnvelopeJSON {
     public func toString() -> String {
         return self.json.toString()
     }
+
+    public func withModified(now: Timestamp) -> EnvelopeJSON {
+        if var d = self.json.asDictionary {
+            d["modified"] = JSON(Double(now) / 1000)
+            return EnvelopeJSON(JSON(d))
+        }
+        return EnvelopeJSON(JSON(""))
+    }
 }
 
 

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -240,6 +240,10 @@ public class Keys: Equatable {
         self.init(payload: keysRecord?.payload)
     }
 
+    public class func random() -> Keys {
+        return Keys(defaultBundle: KeyBundle.random())
+    }
+
     public func forCollection(collection: String) -> KeyBundle {
         if let bundle = collectionKeys[collection] {
             return bundle

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -253,6 +253,7 @@ public class Keys: Equatable {
 
     public func asPayload() -> KeysPayload {
         let json: JSON = JSON([
+            "id": "keys",
             "collection": "crypto",
             "default": self.defaultBundle.asPair(),
             "collections": mapValues(self.collectionKeys, f: { $0.asPair() })

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -220,14 +220,12 @@ public class Keys: Equatable {
     }
 
     public init(payload: KeysPayload?) {
-        if let payload = payload {
-            if payload.isValid() {
-                if let keys = payload.defaultKeys {
-                    self.defaultBundle = keys
-                    self.valid = true
-                    return
-                }
+        if let payload = payload where payload.isValid() {
+            if let keys = payload.defaultKeys {
+                self.defaultBundle = keys
                 self.collectionKeys = payload.collectionKeys
+                self.valid = true
+                return
             }
         }
         self.defaultBundle = KeyBundle.invalid

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -360,7 +360,7 @@ public class Scratchpad {
         prefs.setInt(1, forKey: PrefVersion)
         if let global = global {
             prefs.setLong(global.timestamp, forKey: PrefGlobalTS)
-            prefs.setString(global.value.toPayload().toString(), forKey: PrefGlobal)
+            prefs.setString(global.value.asPayload().toString(), forKey: PrefGlobal)
         } else {
             prefs.removeObjectForKey(PrefGlobal)
             prefs.removeObjectForKey(PrefGlobalTS)

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -156,12 +156,20 @@ public class Scratchpad {
             self.global = global
             if let global = global {
                 self.collectionLastFetched["meta"] = global.timestamp
+
+                // We always take the incoming meta/global's engine configuration.
+                self.engineConfiguration = global.value.engineConfiguration()
             }
             return self
         }
 
         public func clearFetchTimestamps() -> Builder {
             self.collectionLastFetched = [:]
+            return self
+        }
+
+        public func setEngineConfiguration(engineConfiguration: EngineConfiguration?) -> Builder {
+            self.engineConfiguration = engineConfiguration
             return self
         }
 
@@ -273,11 +281,6 @@ public class Scratchpad {
         self.collectionNeedsLocalReset = [String: Bool]()
         self.clientGUID = Bytes.generateGUID()
         self.clientName = DeviceInfo.defaultClientName()
-    }
-
-    // For convenience.
-    func withGlobal(m: Fetched<MetaGlobal>?) -> Scratchpad {
-        return self.evolve().setGlobal(m).build()
     }
 
     // For convenience.

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -283,7 +283,7 @@ public class Scratchpad {
 
         if let mg = prefs.stringForKey(PrefGlobal) {
             if let mgTS = prefs.unsignedLongForKey(PrefGlobalTS) {
-                if let global = MetaGlobal.fromPayload(mg) {
+                if let global = MetaGlobal.fromJSON(JSON.parse(mg)) {
                     b.setGlobal(Fetched(value: global, timestamp: mgTS))
                 } else {
                     log.error("Malformed meta/global in prefs. Ignoring.")

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -297,18 +297,6 @@ public class Scratchpad {
                    .clearFetchTimestamps()
                    .build()
     }
-
-    func applyEngineChoices(old: MetaGlobal?) -> (Scratchpad, MetaGlobal?) {
-        log.info("Applying engine choices from inbound meta/global.")
-        log.info("Old meta/global syncID: \(old?.syncID)")
-        log.info("New meta/global syncID: \(self.global?.value.syncID)")
-        log.info("HACK: ignoring engine choices.")
-
-        // TODO: detect when the sets of declined or enabled engines have changed, and update
-        //       our preferences and generate a new meta/global if necessary.
-        return (self, nil)
-    }
-
     private class func unpickleV1FromPrefs(prefs: Prefs, syncKeyBundle: KeyBundle) -> Scratchpad {
         let b = Scratchpad(b: syncKeyBundle, persistingTo: prefs).evolve()
 

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -523,13 +523,13 @@ public class Sync15StorageClient {
     }
 
     func uploadMetaGlobal(metaGlobal: MetaGlobal, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Timestamp>>> {
-        let payload = metaGlobal.toPayload()
+        let payload = metaGlobal.asPayload()
         if payload.isError {
             return Deferred(value: Maybe(failure: MalformedMetaGlobalError()))
         }
 
         // TODO finish this!
-        let record: JSON = JSON(["payload": payload, "id": "global"])
+        let record: JSON = JSON(["payload": payload.toString(), "id": "global"])
         return putResource("storage/meta/global", body: record, ifUnmodifiedSince: ifUnmodifiedSince, parser: decimalSecondsStringToTimestamp)
     }
 

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -528,6 +528,11 @@ public class Sync15StorageClient {
         return doOp(self.requestDELETE, path: path, f: f)
     }
 
+    func wipeStorage() -> Deferred<Maybe<StorageResponse<JSON>>> {
+        // In Sync 1.5 it's preferred that we delete the root, not /storage.
+        return deleteResource("", f: { $0 })
+    }
+
     func getInfoCollections() -> Deferred<Maybe<StorageResponse<InfoCollections>>> {
         return getResource("info/collections", f: InfoCollections.fromJSON)
     }
@@ -536,9 +541,12 @@ public class Sync15StorageClient {
         return getResource("storage/meta/global", f: { GlobalEnvelope($0) })
     }
 
-    func wipeStorage() -> Deferred<Maybe<StorageResponse<JSON>>> {
-        // In Sync 1.5 it's preferred that we delete the root, not /storage.
-        return deleteResource("", f: { $0 })
+    func getCryptoKeys(syncKeyBundle: KeyBundle, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Record<KeysPayload>>>> {
+        let syncKey = Keys(defaultBundle: syncKeyBundle)
+        let encoder = RecordEncoder<KeysPayload>(decode: { KeysPayload($0) }, encode: { $0 })
+        let encrypter = syncKey.encrypter("keys", encoder: encoder)
+        let client = self.clientForCollection("crypto", encrypter: encrypter)
+        return client.get("keys")
     }
 
     func uploadMetaGlobal(metaGlobal: MetaGlobal, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Timestamp>>> {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -536,6 +536,11 @@ public class Sync15StorageClient {
         return getResource("storage/meta/global", f: { GlobalEnvelope($0) })
     }
 
+    func wipeStorage() -> Deferred<Maybe<StorageResponse<JSON>>> {
+        // In Sync 1.5 it's preferred that we delete the root, not /storage.
+        return deleteResource("", f: { $0 })
+    }
+
     func uploadMetaGlobal(metaGlobal: MetaGlobal, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Timestamp>>> {
         let payload = metaGlobal.asPayload()
         if payload.isError {
@@ -547,14 +552,20 @@ public class Sync15StorageClient {
         return putResource("storage/meta/global", body: record, ifUnmodifiedSince: ifUnmodifiedSince, parser: decimalSecondsStringToTimestamp)
     }
 
-    func wipeStorage() -> Deferred<Maybe<StorageResponse<JSON>>> {
-        // In Sync 1.5 it's preferred that we delete the root, not /storage.
-        return deleteResource("", f: { $0 })
+    // The crypto/keys record is a special snowflake: it is encrypted with the Sync key bundle.  All other records are
+    // encrypted with the bulk key bundle (including possibly a per-collection bulk key) stored in crypto/keys.
+    func uploadCryptoKeys(keys: Keys, withSyncKeyBundle syncKeyBundle: KeyBundle, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Timestamp>>> {
+        let syncKey = Keys(defaultBundle: syncKeyBundle)
+        let encoder = RecordEncoder<KeysPayload>(decode: { KeysPayload($0) }, encode: { $0 })
+        let encrypter = syncKey.encrypter("keys", encoder: encoder)
+        let client = self.clientForCollection("crypto", encrypter: encrypter)
+
+        let record = Record(id: "keys", payload: keys.asPayload())
+        return client.put(record, ifUnmodifiedSince: ifUnmodifiedSince)
     }
 
-    // TODO: it would be convenient to have the storage client manage Keys,
-    // but of course we need to use a different set of keys to fetch crypto/keys
-    // itself.
+    // It would be convenient to have the storage client manage Keys, but of course we need to use a different set of
+    // keys to fetch crypto/keys itself.  See uploadCryptoKeys.
     func clientForCollection<T: CleartextPayloadJSON>(collection: String, encrypter: RecordEncrypter<T>) -> Sync15CollectionClient<T> {
         let storage = self.serverURI.URLByAppendingPathComponent("storage", isDirectory: true)
         return Sync15CollectionClient(client: self, serverURI: storage, collection: collection, encrypter: encrypter)

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -277,7 +277,13 @@ public class Sync15StorageClient {
         self.backoff = backoff
 
         // This is a potentially dangerous assumption, but failable initializers up the stack are a giant pain.
-        self.serverURI = NSURL(string: token.api_endpoint)!
+        // We want the serverURI to *not* have a trailing slash: to efficiently wipe a user's storage, we delete
+        // the user root (like /1.5/1234567) and not an "empty collection" (like /1.5/1234567/); the storage
+        // server treats the first like a DROP table and the latter like a DELETE *, and the former is more
+        // efficient than the latter.
+        self.serverURI = NSURL(string: token.api_endpoint.endsWith("/")
+            ? token.api_endpoint.substringToIndex(token.api_endpoint.endIndex.predecessor())
+            : token.api_endpoint)!
         self.authorizer = {
             (r: NSMutableURLRequest) -> NSMutableURLRequest in
             let helper = HawkHelper(id: token.id, key: token.key.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!)
@@ -450,7 +456,15 @@ public class Sync15StorageClient {
             return deferred
         }
 
-        let req = op(self.serverURI.URLByAppendingPathComponent(path))
+        // Special case "": we want /1.5/1234567 and not /1.5/1234567/.  See note about trailing slashes above.
+        let url: NSURL
+        if path == "" {
+            url = self.serverURI // No trailing slash.
+        } else {
+            url = self.serverURI.URLByAppendingPathComponent(path)
+        }
+
+        let req = op(url)
         let handler = self.errorWrap(deferred) { (_, response, result) in
             if let json: JSON = result.value as? JSON {
                 if let v = f(json) {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -537,8 +537,15 @@ public class Sync15StorageClient {
         return getResource("info/collections", f: InfoCollections.fromJSON)
     }
 
-    func getMetaGlobal() -> Deferred<Maybe<StorageResponse<GlobalEnvelope>>> {
-        return getResource("storage/meta/global", f: { GlobalEnvelope($0) })
+    func getMetaGlobal() -> Deferred<Maybe<StorageResponse<MetaGlobal>>> {
+        return getResource("storage/meta/global") { json in
+            // We have an envelope.  Parse the meta/global record embedded in the 'payload' string.
+            let envelope = EnvelopeJSON(json)
+            if envelope.isValid() {
+                return MetaGlobal.fromJSON(JSON.parse(envelope.payload))
+            }
+            return nil
+        }
     }
 
     func getCryptoKeys(syncKeyBundle: KeyBundle, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Record<KeysPayload>>>> {

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -18,6 +18,9 @@ public class EngineConfiguration: Equatable {
     }
 
     public class func fromJSON(json: JSON) -> EngineConfiguration? {
+        if json.isError {
+            return nil
+        }
         if let enabled = jsonsToStrings(json["enabled"].asArray) {
             if let declined = jsonsToStrings(json["declined"].asArray) {
                 return EngineConfiguration(enabled: enabled, declined: declined)
@@ -26,12 +29,9 @@ public class EngineConfiguration: Equatable {
         return nil
     }
 
-    public func reconcile(meta: [String: EngineMeta]) -> EngineConfiguration {
-        // TODO: when we get a changed meta/global, we need to be able
-        // to reflect its changes into our configuration.
-        // Note that sometimes we also need to make changes to the meta/global
-        // itself -- e.g., missing declined. That should be a method on MetaGlobal.
-        return self
+    public func toJSON() -> JSON {
+        let json: [String: AnyObject] = ["enabled": self.enabled, "declined": self.declined]
+        return JSON(json)
     }
 }
 

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -83,13 +83,9 @@ public struct MetaGlobal: Equatable {
     let engines: [String: EngineMeta]
     let declined: [String]
 
-    public static func fromPayload(string: String) -> MetaGlobal? {
-        return fromPayload(JSON(string: string))
-    }
-
     // TODO: is it more useful to support partial globals?
     // TODO: how do we return error states here?
-    public static func fromPayload(json: JSON) -> MetaGlobal? {
+    public static func fromJSON(json: JSON) -> MetaGlobal? {
         if json.isError {
             return nil
         }
@@ -135,19 +131,6 @@ public func ==(lhs: MetaGlobal, rhs: MetaGlobal) -> Bool {
            (lhs.storageVersion == rhs.storageVersion) &&
            optArrayEqual(lhs.declined, rhs: rhs.declined) &&
            optDictionaryEqual(lhs.engines, rhs: rhs.engines)
-}
-
-public class GlobalEnvelope: EnvelopeJSON {
-    public lazy var global: MetaGlobal? = {
-        return MetaGlobal.fromPayload(self.payload)
-    }()
-
-    public func toFetched() -> Fetched<MetaGlobal>? {
-        if let g = global {
-            return Fetched(value: g, timestamp: self.modified)
-        }
-        return nil
-    }
 }
 
 /**

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -104,13 +104,14 @@ public struct MetaGlobal: Equatable {
     }
 
     // TODO: make a whole record JSON for this.
-    public func toPayload() -> JSON {
-        return JSON([
+    public func asPayload() -> CleartextPayloadJSON {
+        let json: JSON = JSON([
             "syncID": self.syncID,
             "storageVersion": self.storageVersion,
             "engines": enginesPayload(),
             "declined": JSON(self.declined ?? [])
         ])
+        return CleartextPayloadJSON(json)
     }
 }
 

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -9,7 +9,7 @@ import Shared
 // Note that EngineConfiguration is not enough to evolve an existing meta/global:
 // a meta/global generated from this will have different syncIDs and will
 // always use this device's engine versions.
-public class EngineConfiguration {
+public class EngineConfiguration: Equatable {
     let enabled: [String]
     let declined: [String]
     public init(enabled: [String], declined: [String]) {
@@ -32,6 +32,16 @@ public class EngineConfiguration {
         // Note that sometimes we also need to make changes to the meta/global
         // itself -- e.g., missing declined. That should be a method on MetaGlobal.
         return self
+    }
+}
+
+public func ==(lhs: EngineConfiguration, rhs: EngineConfiguration) -> Bool {
+    return Set(lhs.enabled) == Set(rhs.enabled)
+}
+
+extension EngineConfiguration: CustomStringConvertible {
+    public var description: String {
+        return "EngineConfiguration(enabled: \(self.enabled.sort()), declined: \(self.declined.sort()))"
     }
 }
 
@@ -109,6 +119,14 @@ public struct MetaGlobal: Equatable {
             "declined": JSON(self.declined)
         ])
         return CleartextPayloadJSON(json)
+    }
+
+    public func withSyncID(syncID: String) -> MetaGlobal {
+        return MetaGlobal(syncID: syncID, storageVersion: self.storageVersion, engines: self.engines, declined: self.declined)
+    }
+
+    public func engineConfiguration() -> EngineConfiguration {
+        return EngineConfiguration(enabled: Array(engines.keys), declined: declined)
     }
 }
 

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -70,8 +70,8 @@ public func ==(lhs: EngineMeta, rhs: EngineMeta) -> Bool {
 public struct MetaGlobal: Equatable {
     let syncID: String
     let storageVersion: Int
-    let engines: [String: EngineMeta]?      // Is this really optional?
-    let declined: [String]?
+    let engines: [String: EngineMeta]
+    let declined: [String]
 
     public static func fromPayload(string: String) -> MetaGlobal? {
         return fromPayload(JSON(string: string))
@@ -85,22 +85,19 @@ public struct MetaGlobal: Equatable {
         }
         if let syncID = json["syncID"].asString {
             if let storageVersion = json["storageVersion"].asInt {
-                let engines = EngineMeta.mapFromJSON(json["engines"].asDictionary)
-                let declined = json["declined"].asArray
+                let engines = EngineMeta.mapFromJSON(json["engines"].asDictionary) ?? [:]
+                let declined = json["declined"].asArray ?? []
                 return MetaGlobal(syncID: syncID,
                                   storageVersion: storageVersion,
                                   engines: engines,
-                                  declined: jsonsToStrings(declined))
+                                  declined: jsonsToStrings(declined) ?? [])
             }
         }
         return nil
     }
 
     public func enginesPayload() -> JSON {
-        if let engines = engines {
-            return JSON(mapValues(engines, f: { $0.toJSON() }))
-        }
-        return JSON([:])
+        return JSON(mapValues(engines, f: { $0.toJSON() }))
     }
 
     // TODO: make a whole record JSON for this.
@@ -109,7 +106,7 @@ public struct MetaGlobal: Equatable {
             "syncID": self.syncID,
             "storageVersion": self.storageVersion,
             "engines": enginesPayload(),
-            "declined": JSON(self.declined ?? [])
+            "declined": JSON(self.declined)
         ])
         return CleartextPayloadJSON(json)
     }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -135,7 +135,8 @@ public enum SyncStateLabel: String {
     case InitialWithExpiredTokenAndInfo = "initialWithExpiredTokenAndInfo"
     case InitialWithLiveToken = "initialWithLiveToken"
     case InitialWithLiveTokenAndInfo = "initialWithLiveTokenAndInfo"
-    case ResolveMetaGlobal = "resolveMetaGlobal"
+    case ResolveMetaGlobalVersion = "resolveMetaGlobalVersion"
+    case ResolveMetaGlobalContent = "resolveMetaGlobalContent"
     case NewMetaGlobal = "newMetaGlobal"
     case HasMetaGlobal = "hasMetaGlobal"
     case NeedsFreshCryptoKeys = "needsFreshCryptoKeys"
@@ -157,7 +158,8 @@ public enum SyncStateLabel: String {
         InitialWithExpiredTokenAndInfo,
         InitialWithLiveToken,
         InitialWithLiveTokenAndInfo,
-        ResolveMetaGlobal,
+        ResolveMetaGlobalVersion,
+        ResolveMetaGlobalContent,
         NewMetaGlobal,
         HasMetaGlobal,
         NeedsFreshCryptoKeys,
@@ -517,21 +519,20 @@ public class InitialWithLiveToken: BaseSyncState {
  * Or it might be different. In this case the previous m/g and our local user preferences
  * are compared to the new, resulting in some actions and a final state.
  *
- * This state is similar in purpose to GlobalSession.processMetaGlobal in Android Sync.
- * TODO
+ * This states are similar in purpose to GlobalSession.processMetaGlobal in Android Sync.
  */
 
-public class ResolveMetaGlobal: BaseSyncStateWithInfo {
+public class ResolveMetaGlobalVersion: BaseSyncStateWithInfo {
     let fetched: Fetched<MetaGlobal>
 
     init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
         self.fetched = fetched
         super.init(client: client, scratchpad: scratchpad, token: token, info: info)
     }
-    public override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobal }
+    public override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalVersion }
 
-    class func fromState(state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobal {
-        return ResolveMetaGlobal(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+    class func fromState(state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalVersion {
+        return ResolveMetaGlobalVersion(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
     override public func advance() -> Deferred<Maybe<SyncState>> {
@@ -549,7 +550,25 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
             return deferMaybe(RemoteUpgradeRequired(previousState: self))
         }
 
-        // Second: check global syncID and contents.
+        return deferMaybe(ResolveMetaGlobalContent.fromState(self, fetched: self.fetched))
+    }
+}
+
+public class ResolveMetaGlobalContent: BaseSyncStateWithInfo {
+    let fetched: Fetched<MetaGlobal>
+
+    init(fetched: Fetched<MetaGlobal>, client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections) {
+        self.fetched = fetched
+        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+    }
+    public override var label: SyncStateLabel { return SyncStateLabel.ResolveMetaGlobalContent }
+
+    class func fromState(state: BaseSyncStateWithInfo, fetched: Fetched<MetaGlobal>) -> ResolveMetaGlobalContent {
+        return ResolveMetaGlobalContent(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
+    }
+
+    override public func advance() -> Deferred<Maybe<SyncState>> {
+        // Check global syncID and contents.
         if let previous = self.scratchpad.global?.value {
             // Do checks that only apply when we're coming from a previous meta/global.
             if previous.syncID != fetched.value.syncID {
@@ -656,7 +675,7 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
                 // We use the server's timestamp, rather than the record's modified field.
                 // Either can be made to work, but the latter has suffered from bugs: see Bug 1210625.
                 let fetched = Fetched(value: resp.value, timestamp: resp.metadata.timestampMilliseconds)
-                return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
+                return deferMaybe(ResolveMetaGlobalVersion.fromState(self, fetched: fetched))
             }
 
             if let _ = result.failureValue as? NotFound<NSHTTPURLResponse> {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -106,9 +106,11 @@ public enum SyncStateLabel: String {
     case ResolveMetaGlobal = "resolveMetaGlobal"
     case NewMetaGlobal = "newMetaGlobal"
     case HasMetaGlobal = "hasMetaGlobal"
+    case NeedsFreshCryptoKeys = "needsFreshCryptoKeys"
+    case HasFreshCryptoKeys = "hasFreshCryptoKeys"
+    case Ready = "ready"
     case FreshStartRequired = "freshStartRequired"                                  // Go around again... once only, perhaps.
     case ServerConfigurationRequired = "serverConfigurationRequired"
-    case Ready = "ready"
 
     case ChangedServer = "changedServer"
     case MissingMetaGlobal = "missingMetaGlobal"
@@ -126,6 +128,8 @@ public enum SyncStateLabel: String {
         ResolveMetaGlobal,
         NewMetaGlobal,
         HasMetaGlobal,
+        NeedsFreshCryptoKeys,
+        HasFreshCryptoKeys,
         Ready,
 
         FreshStartRequired,
@@ -670,60 +674,58 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
     }
 
     override public func advance() -> Deferred<Maybe<SyncState>> {
-        // Fetch crypto/keys, unless it's present in the cache already.
-
+        // Check if crypto/keys is fresh in the cache already.
         if let keys = self.scratchpad.keys where keys.value.valid {
             if let cryptoModified = self.info.modified("crypto") {
                 // Both of these are server timestamps. If the record we stored has the
                 // same modified time as the server collection, and we're fetching from the
                 // same server, then the record must be identical, and we can use it directly.
-                // If the server timestamp is newer, there might be new keys.
-                // If the server timestamp is older, something horribly wrong has occurred.
                 if cryptoModified == keys.timestamp {
                     log.debug("Using cached collection keys for ready state.")
-                    let ready = Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, info: self.info, keys: keys.value)
-                    return Deferred(value: Maybe(success: ready))
+                    return deferMaybe(HasFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, collectionKeys: keys.value))
                 }
 
-                log.warning("Cached keys with timestamp \(keys.timestamp) disagree with server modified \(cryptoModified).")
+                if cryptoModified < keys.timestamp {
+                    // If the server timestamp is older, something horribly wrong has occurred.
+                    log.warning("Cached keys with timestamp \(keys.timestamp) newer than server modified \(cryptoModified). This should never happen! Dropping stale cached keys.")
+                    self.scratchpad = self.scratchpad.evolve().setKeys(nil).build().checkpoint()
+                }
 
+                // The server timestamp is newer, so there might be new keys.
                 // Re-fetch keys and check to see if the actual contents differ.
                 // If the keys are the same, we can ignore this change. If they differ,
                 // we need to re-sync any collection whose keys just changed.
-                // TODO TODO TODO: do that work.
-                log.error("Unable to handle key evolution. Sorry.")
-                return Deferred(value: Maybe(failure: InvalidKeysError(keys.value)))
+                log.info("Cached keys with timestamp \(keys.timestamp) older than server modified \(cryptoModified). Fetching fresh keys.")
+                return deferMaybe(NeedsFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, staleCollectionKeys: keys.value))
             } else {
                 // No known modified time for crypto/. That likely means the server has no keys.
                 // Drop our cached value and fall through; we'll try to fetch, fail, and
                 // go through the usual failure flow.
                 log.warning("Local keys found timestamped \(keys.timestamp), but no crypto collection on server. Dropping cached keys.")
                 self.scratchpad = self.scratchpad.evolve().setKeys(nil).build().checkpoint()
-
-                // TODO: we need to do a full sync when we have new keys.
             }
         }
 
-        //
-        // N.B., we assume that if the server has a meta/global, we don't have a cached crypto/keys,
-        // and the server doesn't have crypto/keys, that the server was wiped.
-        //
-        // This assumption is basically so that we don't get trapped in a cycle of seeing this situation,
-        // blanking the server, trying to upload meta/global, getting interrupted, and so on.
-        //
-        // I think this is pretty safe. TODO: verify this assumption by reading a-s and desktop code.
-        //
-        // TODO: detect when the keys have changed, and scream and run away if so.
-        // TODO: upload keys if necessary, then go to Restart.
-        let syncKey = Keys(defaultBundle: self.scratchpad.syncKeyBundle)
-        let encoder = RecordEncoder<KeysPayload>(decode: { KeysPayload($0) }, encode: { $0 })
-        let encrypter = syncKey.encrypter("keys", encoder: encoder)
-        let client = self.client.clientForCollection("crypto", encrypter: encrypter)
+        return deferMaybe(NeedsFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, staleCollectionKeys: nil))
+    }
+}
 
-        // TODO: this assumes that there are keys on the server. Check first, and if there aren't,
-        // go ahead and go to an upload state without having to fail.
-        return client.get("keys").bind {
-            result in
+public class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
+    public override var label: SyncStateLabel { return SyncStateLabel.NeedsFreshCryptoKeys }
+    let staleCollectionKeys: Keys?
+
+    class func fromState(state: BaseSyncStateWithInfo, scratchpad: Scratchpad, staleCollectionKeys: Keys?) -> NeedsFreshCryptoKeys {
+        return NeedsFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: staleCollectionKeys)
+    }
+
+    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys?) {
+        self.staleCollectionKeys = keys
+        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+    }
+
+    override public func advance() -> Deferred<Maybe<SyncState>> {
+        // Fetch crypto/keys.
+        return self.client.getCryptoKeys(self.scratchpad.syncKeyBundle, ifUnmodifiedSince: nil).bind { result in
             if let resp = result.successValue {
                 let collectionKeys = Keys(payload: resp.value.payload)
                 if (!collectionKeys.valid) {
@@ -735,10 +737,11 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
                 // other records in that collection, even if there are we don't care about them.
                 let fetched = Fetched(value: collectionKeys, timestamp: resp.value.modified)
                 let s = self.scratchpad.evolve().setKeys(fetched).build().checkpoint()
-                let ready = Ready(client: self.client, scratchpad: s, token: self.token, info: self.info, keys: collectionKeys)
 
-                log.info("Arrived in Ready state.")
-                return deferMaybe(ready)
+                if let staleCollectionKeys = self.staleCollectionKeys {
+                    // We have work to do.  We need to reset all the local collections that are no longer fresh.
+                }
+                return deferMaybe(HasFreshCryptoKeys.fromState(self, scratchpad: s, collectionKeys: collectionKeys))
             }
 
             if let _ = result.failureValue as? NotFound<NSHTTPURLResponse> {
@@ -749,6 +752,24 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
             // Otherwise, we have a failure state.
             return deferMaybe(processFailure(result.failureValue))
         }
+    }
+}
+
+public class HasFreshCryptoKeys: BaseSyncStateWithInfo {
+    public override var label: SyncStateLabel { return SyncStateLabel.HasFreshCryptoKeys }
+    let collectionKeys: Keys
+
+    class func fromState(state: BaseSyncStateWithInfo, scratchpad: Scratchpad, collectionKeys: Keys) -> HasFreshCryptoKeys {
+        return HasFreshCryptoKeys(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info, keys: collectionKeys)
+    }
+
+    public init(client: Sync15StorageClient, scratchpad: Scratchpad, token: TokenServerToken, info: InfoCollections, keys: Keys) {
+        self.collectionKeys = keys
+        super.init(client: client, scratchpad: scratchpad, token: token, info: info)
+    }
+
+    override public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(Ready(client: self.client, scratchpad: self.scratchpad, token: self.token, info: self.info, keys: self.collectionKeys))
     }
 }
 

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -17,6 +17,11 @@ private func getDefaultEngines() -> [String: EngineMeta] {
     return mapValues(DefaultEngines, f: { EngineMeta(version: $0, syncID: Bytes.generateGUID()) })
 }
 
+// TODO: this needs EnginePreferences.
+private func createMetaGlobal(previous: MetaGlobal?, scratchpad: Scratchpad) -> MetaGlobal {
+    return MetaGlobal(syncID: Bytes.generateGUID(), storageVersion: StorageVersionCurrent, engines: getDefaultEngines(), declined: DefaultDeclined)
+}
+
 public typealias TokenSource = () -> Deferred<Maybe<TokenServerToken>>
 public typealias ReadyDeferred = Deferred<Maybe<Ready>>
 
@@ -28,41 +33,60 @@ public typealias ReadyDeferred = Deferred<Maybe<Ready>>
 // some state from the last.
 // The resultant 'Ready' will be able to provide a suitably initialized storage client.
 public class SyncStateMachine {
-    private class func scratchpadPrefs(prefs: Prefs) -> Prefs {
-        return prefs.branch("scratchpad")
-    }
+    // The keys are used as a set, to prevent cycles in the state machine.
+    var stateLabelsSeen = [SyncStateLabel: Bool]()
 
-    public class func getInfoCollections(authState: SyncAuthState, prefs: Prefs) -> Deferred<Maybe<InfoCollections>> {
-        log.debug("Fetching info/collections in state machine.")
-        let token = authState.token(NSDate.now(), canBeExpired: true)
-        return chainDeferred(token, f: { (token, kB) in
-            // TODO: the token might not be expired! Check and selectively advance.
-            log.debug("Got token from auth state. Advancing to InitialWithExpiredToken.")
-            let state = InitialWithExpiredToken(scratchpad: Scratchpad(b: KeyBundle.fromKB(kB), persistingTo: self.scratchpadPrefs(prefs)), token: token)
-            return state.getInfoCollections()
-        })
+    let scratchpadPrefs: Prefs
+
+    public init(prefs: Prefs) {
+        self.scratchpadPrefs = prefs.branch("scratchpad")
     }
 
     public class func clearStateFromPrefs(prefs: Prefs) {
         log.debug("Clearing all Sync prefs.")
-        Scratchpad.clearFromPrefs(self.scratchpadPrefs(prefs))
+        Scratchpad.clearFromPrefs(prefs.branch("scratchpad")) // XXX this is convoluted.
         prefs.clearAll()
     }
 
-    public class func toReady(authState: SyncAuthState, prefs: Prefs) -> ReadyDeferred {
+    private func advanceFromState(state: SyncState) -> ReadyDeferred {
+        log.info("advanceFromState: \(state.label)")
+        if let ready = state as? Ready {
+            // Sweet, we made it!
+            return deferMaybe(ready)
+        }
+
+        // Cycles are not necessarily a problem, but seeing the same (recoverable) error condition is a problem.
+        let labelAlreadySeen = self.stateLabelsSeen.updateValue(true, forKey: state.label) != nil
+        if state is RecoverableSyncState && labelAlreadySeen {
+            return deferMaybe(StateMachineCycleError())
+        }
+
+        return state.advance().bind { (result: Maybe<SyncState>) -> Deferred<Maybe<Ready>> in
+            if let nextState: SyncState = result.successValue {
+                return self.advanceFromState(nextState)
+            }
+            return deferMaybe(result.failureValue ?? UnknownError())
+        }
+    }
+
+    public func toReady(authState: SyncAuthState) -> ReadyDeferred {
         let token = authState.token(NSDate.now(), canBeExpired: false)
         return chainDeferred(token, f: { (token, kB) in
             log.debug("Got token from auth state. Server is \(token.api_endpoint).")
-            let scratchpadPrefs = self.scratchpadPrefs(prefs)
-            let prior = Scratchpad.restoreFromPrefs(scratchpadPrefs, syncKeyBundle: KeyBundle.fromKB(kB))
+            let prior = Scratchpad.restoreFromPrefs(self.scratchpadPrefs, syncKeyBundle: KeyBundle.fromKB(kB))
             if prior == nil {
                 log.info("No persisted Sync state. Starting over.")
             }
-            let scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKB(kB), persistingTo: scratchpadPrefs)
+            let scratchpad = prior ?? Scratchpad(b: KeyBundle.fromKB(kB), persistingTo: self.scratchpadPrefs)
 
             log.info("Advancing to InitialWithLiveToken.")
             let state = InitialWithLiveToken(scratchpad: scratchpad, token: token)
-            return advanceSyncState(state)
+
+            // Start with fresh visibility data.
+            self.stateLabelsSeen = [:]
+            self.stateLabelSequence = []
+
+            return self.advanceFromState(state)
         })
     }
 }
@@ -78,6 +102,7 @@ public enum SyncStateLabel: String {
     case NewMetaGlobal = "newMetaGlobal"
     case HasMetaGlobal = "hasMetaGlobal"
     case FreshStartRequired = "freshStartRequired"                                  // Go around again... once only, perhaps.
+    case ServerConfigurationRequired = "serverConfigurationRequired"
     case Ready = "ready"
 
     case ChangedServer = "changedServer"
@@ -94,8 +119,10 @@ public enum SyncStateLabel: String {
         ResolveMetaGlobal,
         NewMetaGlobal,
         HasMetaGlobal,
-        FreshStartRequired,
         Ready,
+
+        FreshStartRequired,
+        ServerConfigurationRequired,
 
         ChangedServer,
         MissingMetaGlobal,
@@ -129,6 +156,8 @@ public enum SyncStateLabel: String {
  */
 public protocol SyncState {
     var label: SyncStateLabel { get }
+
+    func advance() -> Deferred<Maybe<SyncState>>
 }
 
 /*
@@ -170,6 +199,10 @@ public class BaseSyncState: SyncState {
         self.client = client
         log.info("Inited \(self.label.rawValue)")
     }
+
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(StubStateError())
+    }
 }
 
 public class BaseSyncStateWithInfo: BaseSyncState {
@@ -194,6 +227,12 @@ public protocol SyncError: MaybeErrorType {}
 public class UnknownError: SyncError {
     public var description: String {
         return "Unknown error."
+    }
+}
+
+public class StateMachineCycleError: SyncError {
+    public var description: String {
+        return "The Sync state machine encountered a cycle. This is a coding error."
     }
 }
 
@@ -239,13 +278,13 @@ public class InvalidKeysError: SyncError {
     }
 }
 
-/*
- * Error states. These are errors that can be recovered from by taking actions.
- */
+/**
+ * Error states. These are errors that can be recovered from by taking actions.  We use RecoverableSyncState as a
+ * sentinel: if we see the same recoverable state twice, we bail out and complain that we've seen a cycle.  (Seeing
+ * some states -- principally initial states -- twice is fine.
+*/
 
-public protocol RecoverableSyncState: SyncState, SyncError {
-    // All error states must be able to advance to a usable state.
-    func recover() -> ReadyDeferred
+public protocol RecoverableSyncState: SyncState {
 }
 
 /**
@@ -257,10 +296,6 @@ public protocol RecoverableSyncState: SyncState, SyncError {
 public class ChangedServerError: RecoverableSyncState {
     public var label: SyncStateLabel { return SyncStateLabel.ChangedServer }
 
-    public var description: String {
-        return "Token destination changed to \(self.newToken.api_endpoint)/\(self.newToken.uid)."
-    }
-
     let newToken: TokenServerToken
     let newScratchpad: Scratchpad
 
@@ -269,10 +304,10 @@ public class ChangedServerError: RecoverableSyncState {
         self.newScratchpad = Scratchpad(b: scratchpad.syncKeyBundle, persistingTo: scratchpad.prefs)
     }
 
-    public func recover() -> ReadyDeferred {
+    public func advance() -> Deferred<Maybe<SyncState>> {
         // TODO: mutate local storage to allow for a fresh start.
         let state = InitialWithLiveToken(scratchpad: newScratchpad.checkpoint(), token: newToken)
-        return advanceSyncState(state)
+        return deferMaybe(state)
     }
 }
 
@@ -282,10 +317,6 @@ public class ChangedServerError: RecoverableSyncState {
 public class SyncIDChangedError: RecoverableSyncState {
     public var label: SyncStateLabel { return SyncStateLabel.SyncIDChanged }
 
-    public var description: String {
-        return "Global sync ID changed."
-    }
-
     private let previousState: BaseSyncStateWithInfo
     private let newMetaGlobal: Fetched<MetaGlobal>
 
@@ -294,24 +325,42 @@ public class SyncIDChangedError: RecoverableSyncState {
         self.newMetaGlobal = newMetaGlobal
     }
 
-    public func recover() -> ReadyDeferred {
+    public func advance() -> Deferred<Maybe<SyncState>> {
         // TODO: mutate local storage to allow for a fresh start.
         let s = self.previousState.scratchpad.evolve().setGlobal(self.newMetaGlobal).setKeys(nil).build().checkpoint()
         let state = HasMetaGlobal(client: self.previousState.client, scratchpad: s, token: self.previousState.token, info: self.previousState.info)
-        return advanceSyncState(state)
+        return deferMaybe(state)
     }
 }
 
 /**
- * Recovery: wipe the server (perhaps unnecessarily) and start fresh, uploading a
- * new meta/global and a new crypto/keys.
+ * Recovery: configure the server.
+ */
+public class ServerConfigurationRequiredError: RecoverableSyncState {
+    public var label: SyncStateLabel { return SyncStateLabel.ServerConfigurationRequired }
+
+    private let previousState: BaseSyncStateWithInfo
+
+    public init(previousState: BaseSyncStateWithInfo) {
+        self.previousState = previousState
+    }
+
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        let client = self.previousState.client
+        let s = self.previousState.scratchpad.evolve().setGlobal(nil).setKeys(nil).build().checkpoint()
+        // Upload a new meta/global ...
+        return client.uploadMetaGlobal(createMetaGlobal(nil, scratchpad: s), ifUnmodifiedSince: nil)
+            // ... and a new crypto/keys.
+            >>> { return client.uploadCryptoKeys(Keys.random(), withSyncKeyBundle: s.syncKeyBundle, ifUnmodifiedSince: nil) }
+            >>> { return deferMaybe(InitialWithLiveToken(client: client, scratchpad: s, token: self.previousState.token)) }
+    }
+}
+
+/**
+ * Recovery: wipe the server (perhaps unnecessarily) and proceed to configure the server.
  */
 public class FreshStartRequiredError: RecoverableSyncState {
     public var label: SyncStateLabel { return SyncStateLabel.FreshStartRequired }
-
-    public var description: String {
-        return "Fresh start required."
-    }
 
     private let previousState: BaseSyncStateWithInfo
 
@@ -324,102 +373,44 @@ public class FreshStartRequiredError: RecoverableSyncState {
         return MetaGlobal(syncID: Bytes.generateGUID(), storageVersion: StorageVersionCurrent, engines: getDefaultEngines(), declined: DefaultDeclined)
     }
 
-    public func recover() -> ReadyDeferred {
+    public func advance() -> Deferred<Maybe<SyncState>> {
         let client = self.previousState.client
         return client.wipeStorage()
-            >>> {
-                let s = self.previousState.scratchpad.evolve().setGlobal(nil).setKeys(nil).build().checkpoint()
-                // Upload a new meta/global ...
-                return client.uploadMetaGlobal(FreshStartRequiredError.createMetaGlobal(nil, scratchpad: s), ifUnmodifiedSince: nil)
-                    // ... and a new crypto/keys.
-                    >>> { return client.uploadCryptoKeys(Keys.random(), withSyncKeyBundle: s.syncKeyBundle, ifUnmodifiedSince: nil) }
-                    >>> { return advanceSyncState(InitialWithLiveToken(client: client, scratchpad: s, token: self.previousState.token)) }
-        }
+            >>> { return deferMaybe(ServerConfigurationRequiredError(previousState: self.previousState)) }
     }
 }
 
 public class MissingMetaGlobalError: RecoverableSyncState {
     public var label: SyncStateLabel { return SyncStateLabel.MissingMetaGlobal }
 
-    public var description: String {
-        return "Missing meta/global."
-    }
-
     private let previousState: BaseSyncStateWithInfo
 
     public init(previousState: BaseSyncStateWithInfo) {
         self.previousState = previousState
     }
 
-    public func recover() -> ReadyDeferred {
-        return FreshStartRequiredError(previousState: self.previousState).recover()
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
     }
 }
 
 public class MissingCryptoKeysError: RecoverableSyncState {
     public var label: SyncStateLabel { return SyncStateLabel.MissingCryptoKeys }
 
-    public var description: String {
-        return "Missing crypto/keys."
-    }
-
     private let previousState: BaseSyncStateWithInfo
 
     public init(previousState: BaseSyncStateWithInfo) {
         self.previousState = previousState
     }
 
-    public func recover() -> ReadyDeferred {
-        return FreshStartRequiredError(previousState: self.previousState).recover()
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
     }
 }
 
 /*
  * Non-error states.
  */
-
-public class InitialWithExpiredToken: BaseSyncState {
-    public override var label: SyncStateLabel { return SyncStateLabel.InitialWithExpiredToken }
-
-    // This looks totally redundant, but try taking it out, I dare you.
-    public override init(scratchpad: Scratchpad, token: TokenServerToken) {
-        super.init(scratchpad: scratchpad, token: token)
-    }
-
-    func advanceWithInfo(info: InfoCollections) -> InitialWithExpiredTokenAndInfo {
-        return InitialWithExpiredTokenAndInfo(scratchpad: self.scratchpad, token: self.token, info: info)
-    }
-
-    public func advanceIfNeeded(previous: InfoCollections?, collections: [String]?) -> Deferred<Maybe<InitialWithExpiredTokenAndInfo?>> {
-        return chain(getInfoCollections(), f: { info in
-            // Unchanged or no previous state? Short-circuit.
-            if let previous = previous {
-                if info.same(previous, collections: collections) {
-                    return nil
-                }
-            }
-
-            // Changed? Move to the next state with the fetched info.
-            return self.advanceWithInfo(info)
-        })
-    }
-}
-
-public class InitialWithExpiredTokenAndInfo: BaseSyncStateWithInfo {
-    public override var label: SyncStateLabel { return SyncStateLabel.InitialWithExpiredTokenAndInfo }
-
-    public func advanceWithToken(liveTokenSource: TokenSource) -> Deferred<Maybe<InitialWithLiveTokenAndInfo>> {
-        return chainResult(liveTokenSource(), f: { token in
-            if self.token.sameDestination(token) {
-                return Maybe(success: InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: token, info: self.info))
-            }
-
-            // Otherwise, we're screwed: we need to start over.
-            // Pass in the new token, of course.
-            return Maybe(failure: ChangedServerError(scratchpad: self.scratchpad, token: token))
-        })
-    }
-}
 
 public class InitialWithLiveToken: BaseSyncState {
     public override var label: SyncStateLabel { return SyncStateLabel.InitialWithLiveToken }
@@ -434,11 +425,11 @@ public class InitialWithLiveToken: BaseSyncState {
         super.init(client: client, scratchpad: scratchpad, token: token)
     }
 
-    func advanceWithInfo(info: InfoCollections) -> InitialWithLiveTokenAndInfo {
+    func advanceWithInfo(info: InfoCollections) -> SyncState {
         return InitialWithLiveTokenAndInfo(scratchpad: self.scratchpad, token: self.token, info: info)
     }
 
-    public func advance() -> Deferred<Maybe<InitialWithLiveTokenAndInfo>> {
+    override public func advance() -> Deferred<Maybe<SyncState>> {
         return chain(getInfoCollections(), f: self.advanceWithInfo)
     }
 }
@@ -473,7 +464,7 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
         return ResolveMetaGlobal(fetched: fetched, client: state.client, scratchpad: state.scratchpad, token: state.token, info: state.info)
     }
 
-    func advance() -> ReadyDeferred {
+    override public func advance() -> Deferred<Maybe<SyncState>> {
         // TODO: detect when an individual collection syncID has changed, and make sure that
         //       collection is reset.
 
@@ -482,13 +473,13 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
         if v > StorageVersionCurrent {
             // New storage version?  Uh-oh.  No recovery possible here.
             log.info("Client upgrade required for storage version \(v)")
-            return Deferred(value: Maybe(failure: UpgradeRequiredError(target: v)))
+            return deferMaybe(UpgradeRequiredError(target: v))
         }
 
         if v < StorageVersionCurrent {
             // Old storage version?  Uh-oh.  Wipe and upload both meta/global and crypto/keys.
             log.info("Server storage version \(v) is outdated.")
-            return MissingMetaGlobalError(previousState: self).recover()
+            return deferMaybe(MissingMetaGlobalError(previousState: self))
         }
 
         // Second: check syncID and contents.
@@ -518,12 +509,12 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
      * meta/global if we must, and then moves to HasMetaGlobal and on to Ready.
      * TODO: reset all local collections.
      */
-    private func resetStateWithGlobal(fetched: Fetched<MetaGlobal>) -> ReadyDeferred {
+    private func resetStateWithGlobal(fetched: Fetched<MetaGlobal>) -> Deferred<Maybe<SyncState>> {
         let fresh = self.scratchpad.freshStartWithGlobal(fetched)
         return applyEngineChoicesAndAdvance(fresh)
     }
 
-    private func applyEngineChoicesAndAdvance(newScratchpad: Scratchpad) -> ReadyDeferred {
+    private func applyEngineChoicesAndAdvance(newScratchpad: Scratchpad) -> Deferred<Maybe<SyncState>> {
         // When we adopt a new meta global, we might update our local enabled/declined
         // engine lists (which are stored in the scratchpad itself), or need to add
         // some to meta/global. This call asks the scratchpad to return a possibly new
@@ -539,49 +530,45 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
             let upload = self.client.uploadMetaGlobal(toUpload, ifUnmodifiedSince: fetched.timestamp)
             return chainDeferred(upload, f: { resp in
                 let postUpload = withEnginesApplied.checkpoint()    // TODO: add the timestamp!
-                return HasMetaGlobal.fromState(self, scratchpad: postUpload).advance()
+                return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: postUpload))
             })
         }
 
         // If the meta/global was quietly applied, great; roll on with what we were given.
-        return HasMetaGlobal.fromState(self, scratchpad: withEnginesApplied.checkpoint()).advance()
+        let s = withEnginesApplied.checkpoint()
+        return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: s))
     }
+}
+
+private func processFailure(failure: MaybeErrorType?) -> MaybeErrorType {
+    if let failure = failure as? ServerInBackoffError {
+        log.warning("Server in backoff. Bailing out. \(failure.description)")
+        return failure
+    }
+
+    // TODO: backoff etc. for all of these.
+    if let failure = failure as? ServerError<NSHTTPURLResponse> {
+        // Be passive.
+        log.error("Server error. Bailing out. \(failure.description)")
+        return failure
+    }
+
+    if let failure = failure as? BadRequestError<NSHTTPURLResponse> {
+        // Uh oh.
+        log.error("Bad request. Bailing out. \(failure.description)")
+        return failure
+    }
+
+    log.error("Unexpected failure. \(failure?.description)")
+    return failure ?? UnknownError()
 }
 
 public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
     public override var label: SyncStateLabel { return SyncStateLabel.InitialWithLiveTokenAndInfo }
 
-    private func processFailure(failure: MaybeErrorType?) -> MaybeErrorType {
-        if let failure = failure as? ServerInBackoffError {
-            return failure
-        }
-
-        // TODO: backoff etc. for all of these.
-        if let failure = failure as? ServerError<StorageResponse<GlobalEnvelope>> {
-            // Be passive.
-            return failure
-        }
-
-        if let failure = failure as? BadRequestError<StorageResponse<GlobalEnvelope>> {
-            // Uh oh.
-            log.error("Bad request. Bailing out. \(failure.description)")
-            return failure
-        }
-
-        if let _ = failure as? NotFound<NSHTTPURLResponse> {
-            // OK, this is easy.
-            // This state is responsible for creating the new m/g, uploading it, and
-            // restarting with a clean scratchpad.
-            return MissingMetaGlobalError(previousState: self)
-        }
-
-        log.error("Unexpected failure. \(failure?.description)")
-        return failure ?? UnknownError()
-    }
-
     // This method basically hops over HasMetaGlobal, because it's not a state
     // that we expect consumers to know about.
-    func advance() -> ReadyDeferred {
+    override public func advance() -> Deferred<Maybe<SyncState>> {
         // Either m/g and c/k are in our local cache, and they're up-to-date with i/c,
         // or we need to fetch them.
         // Cached and not changed in i/c? Use that.
@@ -599,7 +586,7 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
                     // Strictly speaking we can avoid fetching if this condition is not true,
                     // but if meta/ is modified for a different reason -- store timestamps
                     // for the last collection fetch. This will do for now.
-                    return HasMetaGlobal.fromState(self).advance()
+                    return deferMaybe(HasMetaGlobal.fromState(self))
                 }
             }
         }
@@ -611,19 +598,23 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
                     // We bump the meta/ timestamp because, though in theory there might be
                     // other records in that collection, even if there are we don't care about them.
                     self.scratchpad.collectionLastFetched["meta"] = resp.metadata.lastModifiedMilliseconds
-                    return ResolveMetaGlobal.fromState(self, fetched: fetched).advance()
+                    return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
                 }
 
                 // This should not occur.
-                log.error("Unexpectedly no meta/global despite a successful fetch.")
+                log.error("Unexpectedly no meta/global despite a successful fetch!")
+                return deferMaybe(UnknownError())
             }
 
-            // Otherwise, we have a failure state.
-            let failure = self.processFailure(result.failureValue)
-            guard let recoverable = failure as? RecoverableSyncState else {
-                return Deferred(value: Maybe(failure: failure))
+            if let _ = result.failureValue as? NotFound<NSHTTPURLResponse> {
+                // OK, this is easy.
+                // This state is responsible for creating the new m/g, uploading it, and
+                // restarting with a clean scratchpad.
+                return deferMaybe(FreshStartRequiredError(previousState: self))
             }
-            return recoverable.recover()
+
+            // Otherwise, we have a failure state.  Die on the sword!
+            return deferMaybe(processFailure(result.failureValue))
         }
     }
 }
@@ -639,29 +630,7 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
         return HasMetaGlobal(client: state.client, scratchpad: scratchpad, token: state.token, info: state.info)
     }
 
-    private func processFailure(failure: MaybeErrorType?) -> MaybeErrorType {
-        if let _ = failure as? NotFound<NSHTTPURLResponse> {
-            // No crypto/keys?  Uh-oh.  Wipe and upload both meta/global and crypto/keys.
-            return MissingMetaGlobalError(previousState: self)
-        }
-
-        // TODO: backoff etc. for all of these.
-        if let failure = failure as? ServerError<StorageResponse<KeysPayload>> {
-            // Be passive.
-            return failure
-        }
-
-        if let failure = failure as? BadRequestError<StorageResponse<KeysPayload>> {
-            // Uh oh.
-            log.error("Bad request. Bailing out. \(failure.description)")
-            return failure
-        }
-
-        log.error("Unexpected failure. \(failure?.description)")
-        return failure ?? UnknownError()
-    }
-
-    func advance() -> ReadyDeferred {
+    override public func advance() -> Deferred<Maybe<SyncState>> {
         // Fetch crypto/keys, unless it's present in the cache already.
 
         if let keys = self.scratchpad.keys where keys.value.valid {
@@ -730,16 +699,16 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
                 let ready = Ready(client: self.client, scratchpad: s, token: self.token, info: self.info, keys: collectionKeys)
 
                 log.info("Arrived in Ready state.")
-                return Deferred(value: Maybe(success: ready))
+                return deferMaybe(ready)
             }
 
-            // Much of this logic is shared with the meta/global fetch.
-            // Otherwise, we have a failure state.
-            let failure = self.processFailure(result.failureValue)
-            guard let recoverable = failure as? RecoverableSyncState else {
-                return Deferred(value: Maybe(failure: failure))
+            if let _ = result.failureValue as? NotFound<NSHTTPURLResponse> {
+                // No crypto/keys?  We can handle this.  Wipe and upload both meta/global and crypto/keys.
+                return deferMaybe(MissingCryptoKeysError(previousState: self))
             }
-            return recoverable.recover()
+
+            // Otherwise, we have a failure state.
+            return deferMaybe(processFailure(result.failureValue))
         }
     }
 }
@@ -752,17 +721,4 @@ public class Ready: BaseSyncStateWithInfo {
         self.collectionKeys = keys
         super.init(client: client, scratchpad: scratchpad, token: token, info: info)
     }
-}
-
-
-/*
- * Because a strongly typed state machine is incompatible with protocols,
- * we use function dispatch to ape a protocol.
- */
-func advanceSyncState(s: InitialWithLiveToken) -> ReadyDeferred {
-    return chainDeferred(s.advance(), f: { $0.advance() })
-}
-
-func advanceSyncState(s: HasMetaGlobal) -> ReadyDeferred {
-    return s.advance()
 }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -35,6 +35,7 @@ public typealias ReadyDeferred = Deferred<Maybe<Ready>>
 public class SyncStateMachine {
     // The keys are used as a set, to prevent cycles in the state machine.
     var stateLabelsSeen = [SyncStateLabel: Bool]()
+    var stateLabelSequence = [SyncStateLabel]()
 
     let scratchpadPrefs: Prefs
 
@@ -50,13 +51,17 @@ public class SyncStateMachine {
 
     private func advanceFromState(state: SyncState) -> ReadyDeferred {
         log.info("advanceFromState: \(state.label)")
+
+        // Record visibility before taking any action.
+        let labelAlreadySeen = self.stateLabelsSeen.updateValue(true, forKey: state.label) != nil
+        stateLabelSequence.append(state.label)
+
         if let ready = state as? Ready {
             // Sweet, we made it!
             return deferMaybe(ready)
         }
 
         // Cycles are not necessarily a problem, but seeing the same (recoverable) error condition is a problem.
-        let labelAlreadySeen = self.stateLabelsSeen.updateValue(true, forKey: state.label) != nil
         if state is RecoverableSyncState && labelAlreadySeen {
             return deferMaybe(StateMachineCycleError())
         }
@@ -110,6 +115,8 @@ public enum SyncStateLabel: String {
     case MissingCryptoKeys = "missingCryptoKeys"
     case MalformedCryptoKeys = "malformedCryptoKeys"
     case SyncIDChanged = "syncIDChanged"
+    case RemoteUpgradeRequired = "remoteUpgradeRequired"
+    case ClientUpgradeRequired = "clientUpgradeRequired"
 
     static let allValues: [SyncStateLabel] = [
         InitialWithExpiredToken,
@@ -129,6 +136,8 @@ public enum SyncStateLabel: String {
         MissingCryptoKeys,
         MalformedCryptoKeys,
         SyncIDChanged,
+        RemoteUpgradeRequired,
+        ClientUpgradeRequired,
     ]
 }
 
@@ -254,7 +263,7 @@ public class StubStateError: SyncError {
     }
 }
 
-public class UpgradeRequiredError: SyncError {
+public class ClientUpgradeRequiredError: SyncError {
     let targetStorageVersion: Int
 
     public init(target: Int) {
@@ -262,7 +271,7 @@ public class UpgradeRequiredError: SyncError {
     }
 
     public var description: String {
-        return "Upgrade required to work with storage version \(self.targetStorageVersion)."
+        return "Client upgrade required to work with storage version \(self.targetStorageVersion)."
     }
 }
 
@@ -408,6 +417,36 @@ public class MissingCryptoKeysError: RecoverableSyncState {
     }
 }
 
+public class RemoteUpgradeRequired: RecoverableSyncState {
+    public var label: SyncStateLabel { return SyncStateLabel.RemoteUpgradeRequired }
+
+    private let previousState: BaseSyncStateWithInfo
+
+    public init(previousState: BaseSyncStateWithInfo) {
+        self.previousState = previousState
+    }
+
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(FreshStartRequiredError(previousState: self.previousState))
+    }
+}
+
+public class ClientUpgradeRequired: RecoverableSyncState {
+    public var label: SyncStateLabel { return SyncStateLabel.ClientUpgradeRequired }
+
+    private let previousState: BaseSyncStateWithInfo
+    let targetStorageVersion: Int
+
+    public init(previousState: BaseSyncStateWithInfo, target: Int) {
+        self.previousState = previousState
+        self.targetStorageVersion = target
+    }
+
+    public func advance() -> Deferred<Maybe<SyncState>> {
+        return deferMaybe(ClientUpgradeRequiredError(target: self.targetStorageVersion))
+    }
+}
+
 /*
  * Non-error states.
  */
@@ -473,13 +512,13 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
         if v > StorageVersionCurrent {
             // New storage version?  Uh-oh.  No recovery possible here.
             log.info("Client upgrade required for storage version \(v)")
-            return deferMaybe(UpgradeRequiredError(target: v))
+            return deferMaybe(ClientUpgradeRequired(previousState: self, target: v))
         }
 
         if v < StorageVersionCurrent {
             // Old storage version?  Uh-oh.  Wipe and upload both meta/global and crypto/keys.
             log.info("Server storage version \(v) is outdated.")
-            return deferMaybe(MissingMetaGlobalError(previousState: self))
+            return deferMaybe(RemoteUpgradeRequired(previousState: self))
         }
 
         // Second: check syncID and contents.
@@ -610,7 +649,7 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
                 // OK, this is easy.
                 // This state is responsible for creating the new m/g, uploading it, and
                 // restarting with a clean scratchpad.
-                return deferMaybe(FreshStartRequiredError(previousState: self))
+                return deferMaybe(MissingMetaGlobalError(previousState: self))
             }
 
             // Otherwise, we have a failure state.  Die on the sword!

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -628,31 +628,35 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
         // has been the case in the past, with the Sync 1.1 migration indicator.
         if let global = self.scratchpad.global {
             if let metaModified = self.info.modified("meta") {
-                // The record timestamp *should* be no more recent than the current collection.
-                // We don't check that (indeed, we don't even store it!).
-                // We also check the last fetch timestamp for the record, and that can be
+                // We check the last time we fetched the record, and that can be
                 // later than the collection timestamp. All we care about here is if the
                 // server might have a newer record.
                 if global.timestamp >= metaModified {
-                    log.info("Using cached meta/global.")
+                    log.debug("Cached meta/global fetched at \(global.timestamp), newer than server modified \(metaModified). Using cached meta/global.")
                     // Strictly speaking we can avoid fetching if this condition is not true,
                     // but if meta/ is modified for a different reason -- store timestamps
                     // for the last collection fetch. This will do for now.
                     return deferMaybe(HasMetaGlobal.fromState(self))
                 }
+                log.info("Cached meta/global fetched at \(global.timestamp) older than server modified \(metaModified). Fetching fresh meta/global.")
+            } else {
+                // No known modified time for meta/. That means the server has no meta/global.
+                // Drop our cached value and fall through; we'll try to fetch, fail, and
+                // go through the usual failure flow.
+                log.warning("Local meta/global fetched at \(global.timestamp) found, but no meta collection on server. Dropping cached meta/global.")
+                self.scratchpad = self.scratchpad.evolve().setGlobal(nil).setKeys(nil).build().checkpoint()
             }
+        } else {
+            log.debug("No cached meta/global found. Fetching fresh meta/global.")
         }
 
         // Fetch.
         return self.client.getMetaGlobal().bind { result in
             if let resp = result.successValue {
-                if let fetched = resp.value.toFetched() {
-                    return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
-                }
-
-                // This should not occur.
-                log.error("Unexpectedly no meta/global despite a successful fetch!")
-                return deferMaybe(UnknownError())
+                // We use the server's timestamp, rather than the record's modified field.
+                // Either can be made to work, but the latter has suffered from bugs: see Bug 1210625.
+                let fetched = Fetched(value: resp.value, timestamp: resp.metadata.timestampMilliseconds)
+                return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
             }
 
             if let _ = result.failureValue as? NotFound<NSHTTPURLResponse> {
@@ -739,8 +743,6 @@ public class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
                     return Deferred(value: Maybe(failure: InvalidKeysError(collectionKeys)))
                 }
 
-                // setKeys bumps the crypto/ timestamp because, though in theory there might be
-                // other records in that collection, even if there are we don't care about them.
                 let fetched = Fetched(value: collectionKeys, timestamp: resp.value.modified)
                 let s = self.scratchpad.evolve().setKeys(fetched).build().checkpoint()
                 return deferMaybe(HasFreshCryptoKeys.fromState(self, scratchpad: s, collectionKeys: collectionKeys))

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -647,9 +647,6 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
         return self.client.getMetaGlobal().bind { result in
             if let resp = result.successValue {
                 if let fetched = resp.value.toFetched() {
-                    // We bump the meta/ timestamp because, though in theory there might be
-                    // other records in that collection, even if there are we don't care about them.
-                    self.scratchpad.collectionLastFetched["meta"] = resp.metadata.lastModifiedMilliseconds
                     return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
                 }
 

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -687,33 +687,28 @@ public class HasMetaGlobal: BaseSyncStateWithInfo {
         // Check if crypto/keys is fresh in the cache already.
         if let keys = self.scratchpad.keys where keys.value.valid {
             if let cryptoModified = self.info.modified("crypto") {
-                // Both of these are server timestamps. If the record we stored has the
-                // same modified time as the server collection, and we're fetching from the
-                // same server, then the record must be identical, and we can use it directly.
-                if cryptoModified == keys.timestamp {
-                    log.debug("Using cached collection keys for ready state.")
+                // Both of these are server timestamps. If the record we stored was fetched after the last time the record was modified, as represented by the "crypto" entry in info/collections, and we're fetching from the
+                // same server, then the record must be identical, and we can use it directly.  If are ever additional records in the crypto collection, this will fetch keys too frequently.  In that case, we should use X-I-U-S and expect some 304 responses.
+                if keys.timestamp >= cryptoModified {
+                    log.debug("Cached keys fetched at \(keys.timestamp), newer than server modified \(cryptoModified). Using cached keys.")
                     return deferMaybe(HasFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, collectionKeys: keys.value))
-                }
-
-                if cryptoModified < keys.timestamp {
-                    // If the server timestamp is older, something horribly wrong has occurred.
-                    log.warning("Cached keys with timestamp \(keys.timestamp) newer than server modified \(cryptoModified). This should never happen! Dropping stale cached keys.")
-                    self.scratchpad = self.scratchpad.evolve().setKeys(nil).build().checkpoint()
                 }
 
                 // The server timestamp is newer, so there might be new keys.
                 // Re-fetch keys and check to see if the actual contents differ.
                 // If the keys are the same, we can ignore this change. If they differ,
                 // we need to re-sync any collection whose keys just changed.
-                log.info("Cached keys with timestamp \(keys.timestamp) older than server modified \(cryptoModified). Fetching fresh keys.")
+                log.info("Cached keys fetched at \(keys.timestamp) older than server modified \(cryptoModified). Fetching fresh keys.")
                 return deferMaybe(NeedsFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, staleCollectionKeys: keys.value))
             } else {
                 // No known modified time for crypto/. That likely means the server has no keys.
                 // Drop our cached value and fall through; we'll try to fetch, fail, and
                 // go through the usual failure flow.
-                log.warning("Local keys found timestamped \(keys.timestamp), but no crypto collection on server. Dropping cached keys.")
+                log.warning("Local keys fetched at \(keys.timestamp) found, but no crypto collection on server. Dropping cached keys.")
                 self.scratchpad = self.scratchpad.evolve().setKeys(nil).build().checkpoint()
             }
+        } else {
+            log.debug("No cached keys found. Fetching fresh keys.")
         }
 
         return deferMaybe(NeedsFreshCryptoKeys.fromState(self, scratchpad: self.scratchpad, staleCollectionKeys: nil))
@@ -743,7 +738,7 @@ public class NeedsFreshCryptoKeys: BaseSyncStateWithInfo {
                     return Deferred(value: Maybe(failure: InvalidKeysError(collectionKeys)))
                 }
 
-                let fetched = Fetched(value: collectionKeys, timestamp: resp.value.modified)
+                let fetched = Fetched(value: collectionKeys, timestamp: resp.metadata.timestampMilliseconds)
                 let s = self.scratchpad.evolve().setKeys(fetched).build().checkpoint()
                 return deferMaybe(HasFreshCryptoKeys.fromState(self, scratchpad: s, collectionKeys: collectionKeys))
             }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -535,9 +535,6 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
     }
 
     override public func advance() -> Deferred<Maybe<SyncState>> {
-        // TODO: detect when an individual collection syncID has changed, and make sure that
-        //       collection is reset.
-
         // First: check storage version.
         let v = fetched.value.storageVersion
         if v > StorageVersionCurrent {
@@ -552,60 +549,45 @@ public class ResolveMetaGlobal: BaseSyncStateWithInfo {
             return deferMaybe(RemoteUpgradeRequired(previousState: self))
         }
 
-        // Second: check syncID and contents.
+        // Second: check global syncID and contents.
         if let previous = self.scratchpad.global?.value {
             // Do checks that only apply when we're coming from a previous meta/global.
             if previous.syncID != fetched.value.syncID {
-                // Global syncID changed. Reset for every collection, and also throw away any cached keys.
-                return resetStateWithGlobal(fetched)
+                log.info("Remote global sync ID has changed. Dropping keys and resetting all local collections.")
+                let s = self.scratchpad.freshStartWithGlobal(fetched).checkpoint()
+                return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: s))
             }
 
-            // TODO: Check individual collections, resetting them as necessary if their syncID has changed!
-            // For now, we just adopt the new meta/global, adjust our engines to match, and move on.
-            // This means that if a per-engine syncID changes, *we won't do the right thing*.
-            let withFetchedGlobal = self.scratchpad.evolve().setGlobal(fetched).build()
-            return applyEngineChoicesAndAdvance(withFetchedGlobal)
+            let b = self.scratchpad.evolve()
+                .setGlobal(fetched) // We always adopt the upstream meta/global record.
+
+            let previousEngines = Set(previous.engines.keys)
+            let remoteEngines = Set(fetched.value.engines.keys)
+
+            for engine in previousEngines.subtract(remoteEngines) {
+                log.info("Remote meta/global disabled previously enabled engine \(engine). No action needed.")
+            }
+
+            for engine in remoteEngines.subtract(previousEngines) {
+                log.info("Remote meta/global enabled previously disabled engine \(engine). Resetting local.")
+                b.collectionNeedsLocalReset.updateValue(true, forKey: engine)
+            }
+
+            for engine in remoteEngines.intersect(previousEngines) {
+                let remoteEngine = fetched.value.engines[engine]!
+                let previousEngine = previous.engines[engine]!
+                if previousEngine.syncID != remoteEngine.syncID {
+                    log.info("Remote sync ID for \(engine) has changed. Resetting local.")
+                    b.collectionNeedsLocalReset.updateValue(true, forKey: engine)
+                }
+            }
+
+            let s = b.build().checkpoint()
+            return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: s))
         }
 
-        // No previous meta/global. We know we need to do a fresh start sync.
-        // This function will do the right thing if there's no previous meta/global.
-        return resetStateWithGlobal(fetched)
-    }
-
-    /**
-     * In some cases we downloaded a new meta/global, and we recognize that we need
-     * a blank slate. This method makes one from our scratchpad, applies any necessary
-     * changes to engine elections from the downloaded meta/global, uploads a changed
-     * meta/global if we must, and then moves to HasMetaGlobal and on to Ready.
-     * TODO: reset all local collections.
-     */
-    private func resetStateWithGlobal(fetched: Fetched<MetaGlobal>) -> Deferred<Maybe<SyncState>> {
-        let fresh = self.scratchpad.freshStartWithGlobal(fetched)
-        return applyEngineChoicesAndAdvance(fresh)
-    }
-
-    private func applyEngineChoicesAndAdvance(newScratchpad: Scratchpad) -> Deferred<Maybe<SyncState>> {
-        // When we adopt a new meta global, we might update our local enabled/declined
-        // engine lists (which are stored in the scratchpad itself), or need to add
-        // some to meta/global. This call asks the scratchpad to return a possibly new
-        // scratchpad, and optionally a meta/global to upload.
-        // If this upload fails, we abort, of course.
-        let previousMetaGlobal = self.scratchpad.global?.value
-        let (withEnginesApplied, toUpload) = newScratchpad.applyEngineChoices(previousMetaGlobal)
-
-        if let toUpload = toUpload {
-            // Upload the new meta/global.
-            // The provided scratchpad *does not reflect this new meta/global*: you need to
-            // get the timestamp from the upload!
-            let upload = self.client.uploadMetaGlobal(toUpload, ifUnmodifiedSince: fetched.timestamp)
-            return chainDeferred(upload, f: { resp in
-                let postUpload = withEnginesApplied.checkpoint()    // TODO: add the timestamp!
-                return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: postUpload))
-            })
-        }
-
-        // If the meta/global was quietly applied, great; roll on with what we were given.
-        let s = withEnginesApplied.checkpoint()
+        // No previous meta/global. Adopt the new meta/global.
+        let s = self.scratchpad.freshStartWithGlobal(fetched).checkpoint()
         return deferMaybe(HasMetaGlobal.fromState(self, scratchpad: s))
     }
 }

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -161,10 +161,10 @@ public class BaseSingleCollectionSynchronizer: SingleCollectionSynchronizer {
             return .Backoff(remainingSeconds: Int(remaining))
         }
 
-        if let _ = self.scratchpad.global?.value {
+        if let metaGlobal = self.scratchpad.global?.value {
             // There's no need to check the global storage format here; the state machine will already have
             // done so.
-            if let engineMeta = self.scratchpad.global?.value.engines?[collection] {
+            if let engineMeta = metaGlobal.engines[collection] {
                 if engineMeta.version > self.storageVersion {
                     return .EngineFormatOutdated(needs: engineMeta.version)
                 }

--- a/SyncTests/DownloadTests.swift
+++ b/SyncTests/DownloadTests.swift
@@ -65,20 +65,4 @@ class DownloadTests: XCTestCase {
         }
         waitForExpectationsWithTimeout(10, handler: nil)
     }
-
-    func makeValidEnvelope(guid: GUID, modified: Timestamp) -> EnvelopeJSON {
-        let clientBody: [String: AnyObject] = [
-            "name": "Foobar",
-            "commands": [],
-            "type": "mobile",
-        ]
-        let clientBodyString = JSON(clientBody).toString(false)
-        let clientRecord: [String : AnyObject] = [
-            "id": guid,
-            "collection": "clients",
-            "payload": clientBodyString,
-            "modified": Double(modified) / 1000,
-        ]
-        return EnvelopeJSON(JSON(clientRecord).toString(false))
-    }
 }

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -130,7 +130,7 @@ class LiveStorageClientTests : LiveAccountTest {
             if let ready = result.successValue {
                 XCTAssertTrue(ready.collectionKeys.defaultBundle.encKey.length == 32)
                 XCTAssertTrue(ready.scratchpad.global != nil)
-                if let clients = ready.scratchpad.global?.value.engines?["clients"] {
+                if let clients = ready.scratchpad.global?.value.engines["clients"] {
                     XCTAssertTrue(clients.syncID.characters.count == 12)
                 }
             }

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -124,7 +124,7 @@ class LiveStorageClientTests : LiveAccountTest {
         let expectation = expectationWithDescription("Waiting on value.")
         let authState = self.getAuthState(NSDate.now())
 
-        let d = chainDeferred(authState, f: { SyncStateMachine.toReady($0, prefs: MockProfilePrefs()) })
+        let d = chainDeferred(authState, f: { SyncStateMachine(prefs: MockProfilePrefs()).toReady($0) })
 
         d.upon { result in
             if let ready = result.successValue {

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -70,10 +70,6 @@ class MetaGlobalTests: XCTestCase {
         server.storeRecords([envelope], inCollection: "crypto")
     }
 
-    func assertStateLabelsSeen(stateLabelsSeen: [String]) {
-        XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, stateLabelsSeen)
-    }
-
     func assertFreshStart(ready: Ready?, after: Timestamp) {
         XCTAssertNotNil(ready)
         guard let ready = ready else {
@@ -99,7 +95,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
             XCTAssertNotNil(result.failureValue as? ClientUpgradeRequiredError)
             XCTAssertNil(result.successValue)
             expectation.fulfill()
@@ -117,7 +113,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -134,7 +131,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -153,7 +151,7 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Account
+import Foundation
+import Shared
+import Storage
+@testable import Sync
+import XCGLogger
+import XCTest
+
+private let log = Logger.syncLogger
+
+class MockSyncAuthState: SyncAuthState {
+    let serverRoot: String
+    let kB: NSData
+
+    init(serverRoot: String, kB: NSData) {
+        self.serverRoot = serverRoot
+        self.kB = kB
+    }
+
+    func invalidate() {
+    }
+
+    func token(now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: NSData)>> {
+        let token = TokenServerToken(id: "id", key: "key", api_endpoint: serverRoot, uid: UInt64(0),
+            durationInSeconds: UInt64(5 * 60), remoteTimestamp: Timestamp(now - 1))
+        return deferMaybe((token, self.kB))
+    }
+}
+
+class MetaGlobalTests: XCTestCase {
+    var server: MockSyncServer!
+    var serverRoot: String!
+    var kB: NSData!
+
+    override func setUp() {
+        kB = NSData.randomOfLength(32)!
+        server = MockSyncServer(username: "1234567")
+        server.start()
+        serverRoot = server.baseURL
+    }
+
+    func now() -> Timestamp {
+        return Timestamp(1000 * NSDate().timeIntervalSince1970)
+    }
+
+    func storeMetaGlobal(metaGlobal: MetaGlobal) {
+        let envelope = EnvelopeJSON(JSON([
+            "id": "global",
+            "collection": "meta",
+            "payload": metaGlobal.asPayload().toString(),
+            "modified": Double(NSDate().timeIntervalSince1970)]))
+        server.storeRecords([envelope], inCollection: "meta")
+    }
+
+    func storeKeys(keys: Keys) {
+        let keyBundle = KeyBundle.fromKB(kB)
+        let keys = Keys(defaultBundle: keyBundle)
+        let record = Record(id: "keys", payload: keys.asPayload())
+        let envelope = EnvelopeJSON(keyBundle.serializer({ $0 })(record)!)
+        server.storeRecords([envelope], inCollection: "crypto")
+    }
+
+    func ready() -> ReadyDeferred {
+        let syncPrefs = MockProfilePrefs()
+        let authState: SyncAuthState = MockSyncAuthState(serverRoot: serverRoot, kB: kB)
+        return SyncStateMachine.toReady(authState, prefs: syncPrefs)
+    }
+
+    func assertFreshStart(ready: Ready?, after: Timestamp) {
+        XCTAssertNotNil(ready)
+        guard let ready = ready else {
+            return
+        }
+        // We should have wiped.
+        // We should have uploaded new meta/global and crypto/keys.
+        XCTAssertGreaterThan(server.collections["meta"]?["global"]?.modified ?? 0, after)
+        XCTAssertGreaterThan(server.collections["crypto"]?["keys"]?.modified ?? 0, after)
+        // And we should have downloaded meta/global and crypto/keys.
+        XCTAssertNotNil(ready.scratchpad.global)
+        XCTAssertNotNil(ready.scratchpad.keys)
+        // Basic verifications.
+        XCTAssertEqual(ready.collectionKeys.defaultBundle.encKey.length, 32)
+        if let clients = ready.scratchpad.global?.value.engines?["clients"] {
+            XCTAssertTrue(clients.syncID.characters.count == 12)
+        }
+    }
+
+    func testMetaGlobalVersionTooNew() {
+        // There's no recovery from a meta/global version "in the future": just bail out with an UpgradeRequiredError.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 6, engines: [String: EngineMeta](), declined: nil))
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            XCTAssertNotNil(result.failureValue as? UpgradeRequiredError)
+            XCTAssertNil(result.successValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+    
+
+    func testMetaGlobalVersionTooOld() {
+        // To recover from a meta/global version "in the past", fresh start.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 4, engines: [String: EngineMeta](), declined: nil))
+
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testMetaGlobalMissing() {
+        // To recover from a missing meta/global, fresh start.
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testCryptoKeysMissing() {
+        // To recover from a missing crypto/keys, fresh start.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: nil))
+
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+}

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -81,6 +81,15 @@ class MetaGlobalTests: XCTestCase {
         // And we should have downloaded meta/global and crypto/keys.
         XCTAssertNotNil(ready.scratchpad.global)
         XCTAssertNotNil(ready.scratchpad.keys)
+
+        // We should have the default engine configuration.
+        XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+        guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+            return
+        }
+        XCTAssertEqual(engineConfiguration.enabled.sort(), ["addons", "bookmarks", "clients", "forms", "history", "passwords", "prefs", "tabs"])
+        XCTAssertEqual(engineConfiguration.declined, [])
+
         // Basic verifications.
         XCTAssertEqual(ready.collectionKeys.defaultBundle.encKey.length, 32)
         if let clients = ready.scratchpad.global?.value.engines["clients"] {
@@ -145,7 +154,7 @@ class MetaGlobalTests: XCTestCase {
 
     func testCryptoKeysMissing() {
         // To recover from a missing crypto/keys, fresh start.
-        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: []))
+        storeMetaGlobal(createMetaGlobal(nil))
 
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
@@ -311,6 +320,77 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             thirdExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testEngineConfigurations() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+        let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5,
+            engines: ["bookmarks": EngineMeta(version: 1, syncID: "bookmarks"), "unknownEngine1": EngineMeta(version: 2, syncID: "engineId1")],
+            declined: ["clients, forms", "unknownEngine2"])
+        let cryptoKeys = Keys.random()
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectedEngineConfiguration = EngineConfiguration(enabled: ["bookmarks", "unknownEngine1"], declined: ["clients", "forms", "unknownEngine2"])
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // We should have saved the engine configuration.
+            XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+            guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+                return
+            }
+            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        // Wipe meta/global.
+        server.collections["meta"]?.removeAll()
+
+        // Now, run through the state machine again.  We should produce and upload a meta/global reflecting our engine configuration.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // The downloaded meta/global should reflect our local engine configuration.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), expectedEngineConfiguration)
+
+            // We should have the same cached engine configuration.
+            XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+            guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+                return
+            }
+            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -103,7 +103,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "clientUpgradeRequired"])
             XCTAssertNotNil(result.failureValue as? ClientUpgradeRequiredError)
             XCTAssertNil(result.successValue)
             expectation.fulfill()
@@ -121,8 +121,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "remoteUpgradeRequired",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -140,7 +140,7 @@ class MetaGlobalTests: XCTestCase {
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -159,7 +159,7 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -180,7 +180,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -240,7 +240,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -343,7 +343,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -371,7 +371,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.  We should produce and upload a meta/global reflecting our engine configuration.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -410,7 +410,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -441,7 +441,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -482,7 +482,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let thirdExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -327,16 +327,19 @@ class MetaGlobalTests: XCTestCase {
         }
     }
 
-    func testEngineConfigurations() {
-        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+    private func createUnusualMetaGlobal() -> MetaGlobal {
         let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5,
             engines: ["bookmarks": EngineMeta(version: 1, syncID: "bookmarks"), "unknownEngine1": EngineMeta(version: 2, syncID: "engineId1")],
-            declined: ["clients, forms", "unknownEngine2"])
+            declined: ["clients", "forms", "unknownEngine2"])
+        return metaGlobal
+    }
+
+    func testEngineConfigurations() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+        let metaGlobal = createUnusualMetaGlobal()
         let cryptoKeys = Keys.random()
         storeMetaGlobal(metaGlobal)
         storeCryptoKeys(cryptoKeys)
-
-        let expectedEngineConfiguration = EngineConfiguration(enabled: ["bookmarks", "unknownEngine1"], declined: ["clients", "forms", "unknownEngine2"])
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
@@ -351,7 +354,7 @@ class MetaGlobalTests: XCTestCase {
             guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
                 return
             }
-            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+            XCTAssertEqual(engineConfiguration, metaGlobal.engineConfiguration())
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -379,18 +382,129 @@ class MetaGlobalTests: XCTestCase {
             guard let global = ready.scratchpad.global?.value else {
                 return
             }
-            XCTAssertEqual(global.engineConfiguration(), expectedEngineConfiguration)
+            XCTAssertEqual(global.engineConfiguration(), metaGlobal.engineConfiguration())
 
             // We should have the same cached engine configuration.
             XCTAssertNotNil(ready.scratchpad.engineConfiguration)
             guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
                 return
             }
-            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+            XCTAssertEqual(engineConfiguration, metaGlobal.engineConfiguration())
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testMetaGlobalModified() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        let metaGlobal = createUnusualMetaGlobal()
+        let cryptoKeys = Keys.random()
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // And we should have downloaded meta/global and crypto/keys.
+            XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
+            XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "forms", "history", "passwords", "tabs"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterFirstSync = now()
+
+        // Store a meta/global with a new global syncID.
+        let newMetaGlobal = metaGlobal.withSyncID("newID")
+        storeMetaGlobal(newMetaGlobal)
+
+        // Now, run through the state machine again.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have downloaded a fresh meta/global ...
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.global?.timestamp ?? Timestamp.min, afterFirstSync)
+            // ... and we should have downloaded a fresh crypto/keys -- but its timestamp is identical to the old one!
+            // Therefore, the "needsFreshCryptoKeys" stage above is our test that we re-downloaded crypto/keys.
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "forms", "history", "passwords", "tabs"])
+
+            // And our engine configuration should be unchanged.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), metaGlobal.engineConfiguration())
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        // Now store a meta/global with a changed engine syncID, a new engine, and a new declined entry.
+        var engines = newMetaGlobal.engines
+        engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "bookmarks")
+        engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "forms")
+        var declined = newMetaGlobal.declined.filter({ $0 != "forms" })
+        declined.append("passwords")
+        let secondMetaGlobal = MetaGlobal(syncID: newMetaGlobal.syncID, storageVersion: 5, engines: engines, declined: declined)
+        storeMetaGlobal(secondMetaGlobal)
+
+        // Now, run through the state machine again.
+        let thirdExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have downloaded a fresh meta/global ...
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.global?.timestamp ?? Timestamp.min, afterFirstSync)
+            // ... and we should have downloaded a fresh crypto/keys -- but its timestamp is identical to the old one!
+            // Therefore, the "needsFreshCryptoKeys" stage above is our test that we re-downloaded crypto/keys.
+
+            // We should have marked the changed engine and the newly enabled engine for local reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "forms"])
+
+            // And our engine configuration should reflect the new meta/global on the server.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), secondMetaGlobal.engineConfiguration())
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            thirdExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -169,9 +169,6 @@ class MetaGlobalTests: XCTestCase {
         storeMetaGlobal(metaGlobal)
         storeCryptoKeys(cryptoKeys)
 
-        var metaGlobalTimestamp: Timestamp!
-        var cryptoKeysTimestamp: Timestamp!
-
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
@@ -179,12 +176,13 @@ class MetaGlobalTests: XCTestCase {
             guard let ready = result.successValue else {
                 return
             }
-            metaGlobalTimestamp = ready.scratchpad.global!.timestamp
-            cryptoKeysTimestamp = ready.scratchpad.keys!.timestamp
 
             // And we should have downloaded meta/global and crypto/keys.
             XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
             XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "forms", "history", "passwords", "tabs"])
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -195,6 +193,8 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
+        let afterFirstSync = now()
+
         // Now, run through the state machine again.  Nothing's changed remotely, so we should advance quickly.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
@@ -204,12 +204,113 @@ class MetaGlobalTests: XCTestCase {
                 return
             }
             // And we should have not downloaded a fresh meta/global or crypto/keys.
-            XCTAssertEqual(ready.scratchpad.global?.timestamp, metaGlobalTimestamp)
-            XCTAssertEqual(ready.scratchpad.keys?.timestamp, cryptoKeysTimestamp)
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterFirstSync)
+            XCTAssertLessThan(ready.scratchpad.keys?.timestamp ?? Timestamp.max, afterFirstSync)
+
+            // We should not have marked any local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), [])
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testUpdatedCryptoKeys() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: [])
+        let cryptoKeys = Keys.random()
+        cryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "bookmarks")
+        cryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "clients")
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // And we should have downloaded meta/global and crypto/keys.
+            XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
+            XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "forms", "history", "passwords", "tabs"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterFirstSync = now()
+
+        // Store a fresh crypto/keys, with the same default key, one identical collection key, and one changed collection key.
+        let freshCryptoKeys = Keys.init(defaultBundle: cryptoKeys.defaultBundle)
+        freshCryptoKeys.collectionKeys.updateValue(cryptoKeys.forCollection("bookmarks"), forKey: "bookmarks")
+        freshCryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "clients")
+        storeCryptoKeys(freshCryptoKeys)
+
+        // Now, run through the state machine again.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have not downloaded a fresh meta/global ...
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterFirstSync)
+            // ... but we should have downloaded a fresh crypto/keys.
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.keys?.timestamp ?? Timestamp.min, afterFirstSync)
+
+            // We should have marked only the local engine with a changed key for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["clients"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterSecondSync = now()
+
+        // Now store a random crypto/keys, with a different default key (and no bulk keys).
+        let randomCryptoKeys = Keys.random()
+        storeCryptoKeys(randomCryptoKeys)
+
+        // Now, run through the state machine again.
+        let thirdExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have not downloaded a fresh meta/global ...
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterSecondSync)
+            // ... but we should have downloaded a fresh crypto/keys.
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.keys?.timestamp ?? Timestamp.min, afterSecondSync)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "forms", "history", "passwords", "tabs"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            thirdExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -67,7 +67,7 @@ class MetaGlobalTests: XCTestCase {
     func ready() -> ReadyDeferred {
         let syncPrefs = MockProfilePrefs()
         let authState: SyncAuthState = MockSyncAuthState(serverRoot: serverRoot, kB: kB)
-        return SyncStateMachine.toReady(authState, prefs: syncPrefs)
+        return SyncStateMachine(prefs: syncPrefs).toReady(authState)
     }
 
     func assertFreshStart(ready: Ready?, after: Timestamp) {
@@ -104,7 +104,6 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
-    
 
     func testMetaGlobalVersionTooOld() {
         // To recover from a meta/global version "in the past", fresh start.

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -247,10 +247,10 @@ class MockSyncServer {
     }
 
     func start() {
-        let basePath = "/1.5/\(self.username)/"
-        let storagePath = "\(basePath)storage/"
+        let basePath = "/1.5/\(self.username)"
+        let storagePath = "\(basePath)/storage/"
 
-        let infoCollectionsPath = "\(basePath)info/collections"
+        let infoCollectionsPath = "\(basePath)/info/collections"
         server.addHandlerForMethod("GET", path: infoCollectionsPath, requestClass: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse! in
             var ic = [String: NSNumber]()
             for (collection, map) in self.collections {
@@ -267,7 +267,7 @@ class MockSyncServer {
         }
 
         let matchPut: GCDWebServerMatchBlock = { method, url, headers, path, query -> GCDWebServerRequest! in
-            guard method == "PUT" && path.startsWith(basePath) else {
+            guard method == "PUT" && path.startsWith(storagePath) else {
                 return nil
             }
             return GCDWebServerDataRequest(method: method, url: url, headers: headers, path: path, query: query)

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -172,6 +172,21 @@ class MockSyncServer {
         return (items, nil)
     }
 
+    private func recordResponse(record: EnvelopeJSON) -> GCDWebServerResponse {
+        let body = JSON(record.asJSON()).toString()
+        let bodyData = body.utf8EncodedData
+        let response = GCDWebServerDataResponse(data: bodyData, contentType: "application/json")
+
+        // Compute the correct set of headers: timestamps, etc.
+        let xLastModified = millisecondsToDecimalSeconds(record.modified)
+        response.setValue("\(xLastModified)", forAdditionalHeader: "X-Last-Modified")
+
+        let xWeaveTimestamp = millisecondsToDecimalSeconds(NSDate.now())
+        response.setValue("\(xWeaveTimestamp)", forAdditionalHeader: "X-Weave-Timestamp")
+
+        return response
+    }
+
     func start() {
         let basePath = "/1.5/\(self.username)/"
         let storagePath = "\(basePath)storage/"
@@ -208,8 +223,13 @@ class MockSyncServer {
             }
 
             // 2. Grab the matching set of records. Prune based on TTL, exclude with X-I-U-S, etc.
-            if spec.id != nil {
-                return GCDWebServerDataResponse(statusCode: 500)
+            if let id = spec.id {
+                guard let collection = self.collections[spec.collection], record = collection[id] else {
+                    // Unable to find the requested collection/id.
+                    return GCDWebServerDataResponse(statusCode: 404)
+                }
+
+                return self.recordResponse(record)
             }
 
             guard let (items, offset) = self.recordsMatchingSpec(spec) else {

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -147,8 +147,11 @@ class MockSyncServer {
     }
 
     func storeRecords(records: [EnvelopeJSON], inCollection collection: String) {
+        let now = Timestamp(1000 * NSDate.now())
         var out = self.collections[collection] ?? [:]
-        records.forEach { out[$0.id] = $0 }
+        records.forEach {
+            out[$0.id] = $0.withModified(now)
+        }
         self.collections[collection] = out
     }
 

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -257,7 +257,10 @@ class MockSyncServer {
         server.addHandlerForMethod("GET", path: infoCollectionsPath, requestClass: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse! in
             var ic = [String: NSNumber]()
             for (collection, map) in self.collections {
-                ic[collection] = NSNumber(double: Double(map.values.reduce(Timestamp(0)) { max($0, $1.modified) }) / 1000)
+                if !map.isEmpty {
+                    let timestamp = map.values.reduce(0) { max($0, $1.modified) }
+                    ic[collection] = NSNumber(double: Double(timestamp) / 1000)
+                }
             }
             let body = JSON(ic).toString()
             let bodyData = body.utf8EncodedData

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -147,7 +147,7 @@ class MockSyncServer {
     }
 
     func storeRecords(records: [EnvelopeJSON], inCollection collection: String) {
-        let now = Timestamp(1000 * NSDate.now())
+        let now = Timestamp(NSDate.now())
         var out = self.collections[collection] ?? [:]
         records.forEach {
             out[$0.id] = $0.withModified(now)

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -131,10 +131,10 @@ class RecordTests: XCTestCase {
             "\"username\":\"5817483\"," +
             "\"modified\":1.32046073744E9}"
 
-        let record = GlobalEnvelope(fullRecord)
+        let record = EnvelopeJSON(fullRecord)
         XCTAssertTrue(record.isValid())
 
-        let global = MetaGlobal.fromPayload(JSON.parse(record.payload))
+        let global = MetaGlobal.fromJSON(JSON.parse(record.payload))
         XCTAssertTrue(global != nil)
 
         if let global = global {

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -148,7 +148,7 @@ class RecordTests: XCTestCase {
             let syncID = forms!.syncID
             XCTAssertEqual("GXF29AFprnvc", syncID)
 
-            let payload: JSON = global.toPayload()
+            let payload: JSON = global.asPayload()
             XCTAssertEqual("GXF29AFprnvc", payload["engines"]["forms"]["syncID"].asString!)
             XCTAssertEqual(1, payload["engines"]["forms"]["version"].asInt!)
             XCTAssertEqual("bookmarks", payload["declined"].asArray![0].asString!)

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -138,13 +138,11 @@ class RecordTests: XCTestCase {
         XCTAssertTrue(global != nil)
 
         if let global = global {
-            XCTAssertTrue(global.declined != nil)
-            XCTAssertTrue(global.engines != nil)
-            XCTAssertEqual(["bookmarks"], global.declined!)
+            XCTAssertEqual(["bookmarks"], global.declined)
             XCTAssertEqual(5, global.storageVersion)
             let modified = record.modified
             XCTAssertTrue(1320460737440 == modified)
-            let forms = global.engines!["forms"]
+            let forms = global.engines["forms"]
             let syncID = forms!.syncID
             XCTAssertEqual("GXF29AFprnvc", syncID)
 

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -11,7 +11,6 @@ func compareScratchpads(lhs: Scratchpad, rhs: Scratchpad) {
     // This one is set in the constructor!
     XCTAssertEqual(lhs.syncKeyBundle, rhs.syncKeyBundle)
 
-    XCTAssertEqual(lhs.collectionLastFetched, rhs.collectionLastFetched)
     XCTAssertEqual(lhs.clientName, rhs.clientName)
     XCTAssertEqual(lhs.clientGUID, rhs.clientGUID)
     if let lkeys = lhs.keys {

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -26,6 +26,8 @@ func compareScratchpads(lhs: Scratchpad, rhs: Scratchpad) {
     }
 
     XCTAssertTrue(lhs.global == rhs.global)
+
+    XCTAssertEqual(lhs.engineConfiguration, rhs.engineConfiguration)
 }
 
 func roundtrip(s: Scratchpad) -> (Scratchpad, rhs: Scratchpad) {
@@ -40,6 +42,10 @@ class StateTests: XCTestCase {
         return Fetched(value: g, timestamp: NSDate.now())
     }
 
+    func getEngineConfiguration() -> EngineConfiguration {
+        return EngineConfiguration(enabled: ["bookmarks", "clients"], declined: ["tabs"])
+    }
+
     func baseScratchpad() -> Scratchpad {
         let syncKeyBundle = KeyBundle.fromKB(Bytes.generateRandomBytes(32))
         let keys = Fetched(value: Keys(defaultBundle: syncKeyBundle), timestamp: 1001)
@@ -49,5 +55,6 @@ class StateTests: XCTestCase {
     func testPickling() {
         compareScratchpads(roundtrip(baseScratchpad()))
         compareScratchpads(roundtrip(baseScratchpad().evolve().setGlobal(getGlobal()).build()))
+        compareScratchpads(roundtrip(baseScratchpad().evolve().setEngineConfiguration(getEngineConfiguration()).build()))
     }
 }

--- a/SyncTests/SyncTests-Bridging-Header.h
+++ b/SyncTests/SyncTests-Bridging-Header.h
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import "GCDWebServer.h"
+#import "GCDWebServerDataRequest.h"
 #import "GCDWebServerDataResponse.h"
 
 #endif

--- a/UITests/UITests-Bridging-Header.h
+++ b/UITests/UITests-Bridging-Header.h
@@ -10,6 +10,7 @@
 #import <KIF/UIApplication-KIFAdditions.h>
 #import <KIF/UIAccessibilityElement-KIFAdditions.h>
 #import "GCDWebServer.h"
+#import "GCDWebServerDataRequest.h"
 #import "GCDWebServerDataResponse.h"
 
 #endif


### PR DESCRIPTION
@rnewman okay, sorry this is a dog's breakfast, but please start looking at it.  The patch sequence loops back on itself more than usual, since the logic and desired outcome took me some time to arrive at.  Right now, I'm too tired of this code to clean it up and make it more linear.  Next week, I'll split the `MockSyncServer` changes out, and write tests for that functionality; and I'm sure the tests themselves can be made less redundant.

Known issues:
* I haven't tested node re-assignment yet.  I think it "just works", but we'll need to test it.
* I haven't done X-I-U-S=0 for fresh start yet.  We'll have a new `RaceAvoidanceRequired` terminal state after we handle the 412 results.
* I haven't handled uploading a modified `meta/global` at all.  I think we can avoid it entirely, like we discussed.  Do you concur?
* I could be convinced that tracking `meta/global` and `crypto/keys` 'modified' stamp is better than the fetch X-Weave-Timestamp.  Better for X-I-U-S, for sure.