### PR TITLE
Fixes 1196258 - Restore "Create an account" on Remote Tabs Panel empty state

### DIFF
--- a/Client/Frontend/Home/RemoteTabsPanel.swift
+++ b/Client/Frontend/Home/RemoteTabsPanel.swift
@@ -33,9 +33,6 @@ private struct RemoteTabsPanelUX {
     static let EmptyStateSignInButtonWidth = 200
     static let EmptyStateCreateAccountButtonFont = UIFont.systemFontOfSize(12)
 
-    // Temporary placeholder for strings removed in Bug 1193456.
-    private let CreateAccountString = NSLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j")
-
     // Backup and active strings added in Bug 1205294.
     static let EmptyStateInstructionsSyncTabsPasswordsBookmarksString = NSLocalizedString("Sync your tabs, bookmarks, passwords and more.", comment: "See http://mzl.la/1Qtkf0j")
 
@@ -412,6 +409,7 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         super.init(style: .Default, reuseIdentifier: RemoteTabsErrorCell.Identifier)
 
         self.homePanel = homePanel
+        let createAnAccountButton = UIButton(type: .System)
         let imageView = UIImageView()
 
         imageView.image = UIImage(named: "emptySync")
@@ -439,6 +437,11 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
         signInButton.addTarget(self, action: "SELsignIn", forControlEvents: UIControlEvents.TouchUpInside)
         contentView.addSubview(signInButton)
 
+        createAnAccountButton.setTitle(NSLocalizedString("Create an account", comment: "See http://mzl.la/1Qtkf0j"), forState: .Normal)
+        createAnAccountButton.titleLabel?.font = RemoteTabsPanelUX.EmptyStateCreateAccountButtonFont
+        createAnAccountButton.addTarget(self, action: "SELcreateAnAccount", forControlEvents: UIControlEvents.TouchUpInside)
+        contentView.addSubview(createAnAccountButton)
+
         imageView.snp_makeConstraints { (make) -> Void in
             make.centerX.equalTo(instructionsLabel)
 
@@ -453,6 +456,12 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
             make.top.equalTo(imageView.snp_bottom).offset(RemoteTabsPanelUX.EmptyStateTopPaddingInBetweenItems)
             make.centerX.equalTo(imageView)
         }
+
+
+        createAnAccountButton.snp_makeConstraints { (make) -> Void in
+            make.centerX.equalTo(signInButton)
+            make.top.equalTo(signInButton.snp_bottom).offset(RemoteTabsPanelUX.EmptyStateTopPaddingInBetweenItems)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -462,6 +471,12 @@ class RemoteTabsNotLoggedInCell: UITableViewCell {
     @objc private func SELsignIn() {
         if let homePanel = self.homePanel {
             homePanel.homePanelDelegate?.homePanelDidRequestToSignIn(homePanel)
+        }
+    }
+
+    @objc private func SELcreateAnAccount() {
+        if let homePanel = self.homePanel {
+            homePanel.homePanelDelegate?.homePanelDidRequestToCreateAccount(homePanel)
         }
     }
 


### PR DESCRIPTION
This patch brings back the "Create an account" button on the empty state of the Remote Tabs Home Panel.

It basically is https://github.com/mozilla/firefox-ios/pull/911 reversed with Swift 2.0 fixes.