### PR TITLE
Bug 1207517 - Cancel the selection gesture recognizer when showing the context menu

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -137,6 +137,8 @@ addEventListener("touchstart", function (event) {
       cancel();
       webkit.messageHandlers.contextMenuMessageHandler.postMessage(data);
     }, 500);
+
+    webkit.messageHandlers.contextMenuMessageHandler.postMessage({ handled: true });
   }
 }, true);
 


### PR DESCRIPTION
Finally figured out something that works, though our context menu code is really turning into quite a hackfest. The fix is pretty small, but I think needs some explanation:

The bug is caused by `<a>` elements containing child text elements. This isn't an issue on most sites since `<a>` elements generally don't have children, but CNN and BBC wrap the text element (`<a><h2>text</h2></a>`) rather than the reverse, which is more common (`<h2><a>text</a></h2>`) (demo page [here](https://people.mozilla.org/~bnicholson/test/ios-context-selection.html)). I assume that this fires the selection delegate in this case since the target element is a non-link text node.

Now, normally, I think the default `WKWebView` context menu gesture recognizer sets a failure dependency for the selection gesture recognizer, so the selection recognizer won't trigger if the context menu is shown. However, we've set up our own dependency where our custom context menu recognizer sets a failure dependency on the built-in context menu recognizer. We never want to show the built-in context menu, so the built-in recognizer always fails as intended. But when it fails, the selection gesture recognizer then triggers because of the failure dependency mentioned above.

Ideally, the fix for this would be to simply create our own similar selection recognizer dependency with our custom context menu recognizer: if the custom context menu is shown, the selection recognizer fails. But since `WKWebView` messages are async, we don't know whether we're pressing on a context menu element until *after* `shouldBeRequiredToFailByGestureRecognizer` (which is used to create these dependencies) has already fired.

So instead, we need to figure out a way to cancel the selection recognizer on-demand. There is no `cancel` method, but the docs for `enabled` say this:

> If you change this property to false while a gesture recognizer is currently recognizing a gesture, the
> gesture recognizer transitions to a cancelled state.

So disabling and immediately re-enabling the selection recognizer should cancel the existing gesture while still listening for future ones, which is the behavior we want.