### PR TITLE
Bug 1212093 - Correctly send newer param on subsequent batch fetches.

### DIFF
--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -285,8 +285,12 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
 
             // If there are records, advance to just before the timestamp of the last.
             // If our next fetch with X-Weave-Next-Offset fails, at least we'll start here.
+            //
+            // Without Bug 1212189 we get records in the wrong order, and this approach doesn't work.
+            // Commented out until then.
             if let newBase = response.value.last?.modified {
-                self.baseTimestamp = newBase - 1
+                // TODO
+                // self.baseTimestamp = newBase - 1
             }
 
             log.debug("Got success response with \(response.metadata.records) records.")

--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -201,6 +201,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         }
     }
 
+    // Set after each batch, from record timestamps.
     var baseTimestamp: Timestamp {
         get {
             return self.prefs.timestampForKey("baseTimestamp") ?? 0
@@ -210,6 +211,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         }
     }
 
+    // Only set at the end of a batch, from headers.
     var lastModified: Timestamp {
         get {
             return self.prefs.timestampForKey("lastModified") ?? 0
@@ -251,7 +253,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         if let (offset, since) = self.nextFetchParameters {
             return (offset, since)
         }
-        return (nil, self.baseTimestamp)
+        return (nil, max(self.lastModified, self.baseTimestamp))
     }
 
     func downloadNextBatchWithLimit(limit: Int, infoModified: Timestamp) -> Deferred<Maybe<DownloadEndState>> {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -642,12 +642,11 @@ public class Sync15CollectionClient<T: CleartextPayloadJSON> {
 
         var params: [NSURLQueryItem] = [
             NSURLQueryItem(name: "full", value: "1"),
+            NSURLQueryItem(name: "newer", value: millisecondsToDecimalSeconds(since)),
         ]
 
         if let offset = offset {
             params.append(NSURLQueryItem(name: "offset", value: offset))
-        } else {
-            params.append(NSURLQueryItem(name: "newer", value: millisecondsToDecimalSeconds(since)))
         }
 
         if let limit = limit {


### PR DESCRIPTION
This partly undoes Bug 1211744 (67044d8cee7eb650cd11e1d52dff36e66c89d63d), following what I learned from talking to @rfk this afternoon.

@ncalexan and/or @fluffyemily, please take a look.