### PR TITLE
Bug 1167010

### DIFF
--- a/Account/FirefoxAccountConfiguration.swift
+++ b/Account/FirefoxAccountConfiguration.swift
@@ -92,8 +92,8 @@ public struct ProductionFirefoxAccountConfiguration: FirefoxAccountConfiguration
     public let oauthEndpointURL = NSURL(string: "https://oauth.accounts.firefox.com/v1")!
     public let profileEndpointURL = NSURL(string: "https://profile.accounts.firefox.com/v1")!
 
-    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1&exclude_signup=1")!
-    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1&exclude_signup=1")!
+    public let signInURL = NSURL(string: "https://accounts.firefox.com/signin?service=sync&context=fx_ios_v1")!
+    public let settingsURL = NSURL(string: "https://accounts.firefox.com/settings?context=fx_ios_v1")!
     public let forceAuthURL = NSURL(string: "https://accounts.firefox.com/force_auth?service=sync&context=fx_ios_v1")!
 
     public let sync15Configuration: Sync15Configuration = ProductionSync15Configuration()

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -228,12 +228,13 @@
 		2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */; };
 		2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */; };
 		2F642CED1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */; };
+		2F67C5261BB0CB4E00E7B73A /* MetaGlobalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */; settings = {ASSET_TAGS = (); }; };
 		2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */; };
 		2F834D161A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
 		2F834D171A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
 		2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F834D131A80629A006A0B7B /* FxAContentViewController.swift */; };
-		2F834D1B1A80629A006A0B7B /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F834D131A80629A006A0B7B /* FxAContentViewController.swift */; };
 		2F8C76571BC32F3C00D5E4E0 /* MockSyncServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */; settings = {ASSET_TAGS = (); }; };
+		2F834D1B1A80629A006A0B7B /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F834D131A80629A006A0B7B /* FxAContentViewController.swift */; };
 		2FA435111ABB6829008031D1 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE23F1ABB531100877008 /* Bookmarks.swift */; };
 		2FA435131ABB6829008031D1 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2411ABB531100877008 /* Cursor.swift */; };
 		2FA435141ABB6829008031D1 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2421ABB531100877008 /* Favicons.swift */; };
@@ -327,9 +328,9 @@
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
-		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */; settings = {ASSET_TAGS = (); }; };
 		7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */; settings = {ASSET_TAGS = (); }; };
+		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		7BBFEE9A1BB409B200A305AA /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; settings = {ASSET_TAGS = (); }; };
@@ -501,7 +502,6 @@
 		E4A961341AC051360069AD6F /* ReadabilityBrowserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */; };
 		E4A961361AC052DE0069AD6F /* ReadabilityBrowserHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */; };
 		E4A961381AC06FA50069AD6F /* ReaderViewLoading.html in Resources */ = {isa = PBXBuildFile; fileRef = E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */; };
-		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		E4B3344D1BBF2393004E2BFF /* ADJActivityHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334231BBF2393004E2BFF /* ADJActivityHandler.m */; settings = {ASSET_TAGS = (); }; };
 		E4B3344E1BBF2393004E2BFF /* ADJActivityKind.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334251BBF2393004E2BFF /* ADJActivityKind.m */; settings = {ASSET_TAGS = (); }; };
 		E4B3344F1BBF2393004E2BFF /* ADJActivityPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334271BBF2393004E2BFF /* ADJActivityPackage.m */; settings = {ASSET_TAGS = (); }; };
@@ -526,6 +526,7 @@
 		E4B334881BBF23F3004E2BFF /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
 		E4B3348A1BBF23F9004E2BFF /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334891BBF23F9004E2BFF /* AdSupport.framework */; };
 		E4B3348C1BC01D8F004E2BFF /* AdjustIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3348B1BC01D8F004E2BFF /* AdjustIntegration.swift */; settings = {ASSET_TAGS = (); }; };
+		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */; };
 		E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */; };
 		E4B7B7611A793CF20022C5E0 /* CharisSILB.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */; };
@@ -623,10 +624,10 @@
 		E635D41E1B73F41C0078962F /* NSFileManager+NRFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */; };
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
-		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; settings = {ASSET_TAGS = (); }; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; settings = {ASSET_TAGS = (); }; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; settings = {ASSET_TAGS = (); }; };
+		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
@@ -1461,10 +1462,11 @@
 		2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsTableViewController.swift; sourceTree = "<group>"; };
 		2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginePicker.swift; sourceTree = "<group>"; };
 		2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITests.swift; sourceTree = "<group>"; };
+		2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetaGlobalTests.swift; path = SyncTests/MetaGlobalTests.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
+		2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockSyncServerTests.swift; path = SyncTests/MockSyncServerTests.swift; sourceTree = "<group>"; };
 		2F834D111A80629A006A0B7B /* FxASignIn.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = FxASignIn.js; path = Frontend/SignIn/FxASignIn.js; sourceTree = "<group>"; };
 		2F834D131A80629A006A0B7B /* FxAContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAContentViewController.swift; path = Frontend/SignIn/FxAContentViewController.swift; sourceTree = "<group>"; };
-		2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockSyncServerTests.swift; path = SyncTests/MockSyncServerTests.swift; sourceTree = "<group>"; };
 		2FA435FB1ABB83B4008031D1 /* Account.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Account.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA435FE1ABB83B4008031D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2FA436051ABB83B4008031D1 /* AccountTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AccountTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1531,10 +1533,10 @@
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
-		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
-		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
 		7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChevronView.swift; sourceTree = "<group>"; };
 		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
+		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
+		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
@@ -1656,8 +1658,6 @@
 		E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeUtils.swift; sourceTree = "<group>"; };
 		E4A961171AC041C40069AD6F /* ReadabilityService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityService.swift; sourceTree = "<group>"; };
 		E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityBrowserHelper.swift; sourceTree = "<group>"; };
-		E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ReadabilityBrowserHelper.js; sourceTree = "<group>"; };
-		E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ReaderViewLoading.html; sourceTree = "<group>"; };
 		E4B334221BBF2393004E2BFF /* ADJActivityHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADJActivityHandler.h; sourceTree = "<group>"; };
 		E4B334231BBF2393004E2BFF /* ADJActivityHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADJActivityHandler.m; sourceTree = "<group>"; };
 		E4B334241BBF2393004E2BFF /* ADJActivityKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADJActivityKind.h; sourceTree = "<group>"; };
@@ -1703,6 +1703,8 @@
 		E4B334871BBF23F3004E2BFF /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		E4B334891BBF23F9004E2BFF /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E4B3348B1BC01D8F004E2BFF /* AdjustIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustIntegration.swift; sourceTree = "<group>"; };
+		E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ReadabilityBrowserHelper.js; sourceTree = "<group>"; };
+		E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ReaderViewLoading.html; sourceTree = "<group>"; };
 		E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeCache.swift; sourceTree = "<group>"; };
 		E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeHandlers.swift; sourceTree = "<group>"; };
 		E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILB.ttf; sourceTree = "<group>"; };
@@ -1786,11 +1788,11 @@
 		E6231C041B90A472005ABB0D /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		E635D25D1B729DEE0078962F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E635D41A1B73F06E0078962F /* NSFileManager+NRFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+NRFileManager.h"; sourceTree = "<group>"; };
-		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
-		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
+		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
+		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
@@ -2170,17 +2172,18 @@
 				28C077971A3B064000834FE5 /* CryptoTests.swift */,
 				28786E541AB0F5FA009EA9EF /* DeferredTests.swift */,
 				28ECD9F31BA1F59800D829DA /* DownloadTests.swift */,
-				2855611E1AEFFA1C00D5ED5B /* HistorySynchronizerTests.swift */,
 				2F3724C41ABF3C01007607FA /* LiveStorageClientTests.swift */,
-				28ECD9791BA1EA2200D829DA /* MockSyncServer.swift */,
-				2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */,
+				2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */,
 				28C0779D1A3B066000834FE5 /* RecordTests.swift */,
+				2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */,
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
 				2F3724C51ABF3C01007607FA /* StorageClientTests.swift */,
 				28F596A01ACA13CA0071DDCC /* InfoTests.swift */,
 				2827316F1ABC9BE700AA1954 /* Supporting Files */,
 				50027345B49B967409DDA348 /* StateTests.swift */,
+				28ECD9791BA1EA2200D829DA /* MockSyncServer.swift */,
+				2855611E1AEFFA1C00D5ED5B /* HistorySynchronizerTests.swift */,
 			);
 			name = SyncTests;
 			sourceTree = "<group>";
@@ -2652,47 +2655,6 @@
 			name = SWTableViewCell;
 			sourceTree = "<group>";
 		};
-		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				287DA9D51AE06D220055AC35 /* Extensions */,
-				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
-				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
-				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
-				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
-				2FCAE2401ABB531100877008 /* Bytes.swift */,
-				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
-				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
-				287DAA1E1AE06E5D0055AC35 /* DeviceInfo.swift */,
-				0B71FFF41B4C49E50046AF87 /* FaviconFetcher.swift */,
-				283306E81AB3BB87008999AC /* Functions.swift */,
-				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
-				2F0624D41AE58C7800FA022C /* KeychainCache.swift */,
-				D339C2821AD354B400C087BD /* Loader.swift */,
-				E635D25D1B729DEE0078962F /* Logger.swift */,
-				285D3B321B4332C00035FD22 /* NotificationConstants.swift */,
-				282731A11ABC9D2600AA1954 /* Prefs.swift */,
-				E69966981B72674B0036F797 /* RollingFileLogger.swift */,
-				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
-				B729F0691B75CBEF00745F7A /* UserAgent.swift */,
-				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
-				E4252A0D1AF01AE40028C684 /* Swizzling.m */,
-				E4C358531AF1440B00299F7E /* Swizzling.h */,
-				E46C51C11B41ADD800EB349F /* Try.h */,
-				E46C51C21B41ADD800EB349F /* Try.m */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
-		E49943F31AE6879C00BF9DE4 /* Intro */ = {
-			isa = PBXGroup;
-			children = (
-				E49943F41AE6879C00BF9DE4 /* IntroViewController.swift */,
-				E49943F61AE69EDD00BF9DE4 /* Intro.xcassets */,
-			);
-			path = Intro;
-			sourceTree = "<group>";
-		};
 		E4B334211BBF2393004E2BFF /* Adjust */ = {
 			isa = PBXGroup;
 			children = (
@@ -2749,6 +2711,47 @@
 				E4B334301BBF2393004E2BFF /* UIDevice+ADJAdditions.m */,
 			);
 			path = ADJAdditions;
+			sourceTree = "<group>";
+		};
+		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				287DA9D51AE06D220055AC35 /* Extensions */,
+				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
+				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
+				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
+				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
+				2FCAE2401ABB531100877008 /* Bytes.swift */,
+				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
+				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
+				287DAA1E1AE06E5D0055AC35 /* DeviceInfo.swift */,
+				0B71FFF41B4C49E50046AF87 /* FaviconFetcher.swift */,
+				283306E81AB3BB87008999AC /* Functions.swift */,
+				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
+				2F0624D41AE58C7800FA022C /* KeychainCache.swift */,
+				D339C2821AD354B400C087BD /* Loader.swift */,
+				E635D25D1B729DEE0078962F /* Logger.swift */,
+				285D3B321B4332C00035FD22 /* NotificationConstants.swift */,
+				282731A11ABC9D2600AA1954 /* Prefs.swift */,
+				E69966981B72674B0036F797 /* RollingFileLogger.swift */,
+				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
+				B729F0691B75CBEF00745F7A /* UserAgent.swift */,
+				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
+				E4252A0D1AF01AE40028C684 /* Swizzling.m */,
+				E4C358531AF1440B00299F7E /* Swizzling.h */,
+				E46C51C11B41ADD800EB349F /* Try.h */,
+				E46C51C21B41ADD800EB349F /* Try.m */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		E49943F31AE6879C00BF9DE4 /* Intro */ = {
+			isa = PBXGroup;
+			children = (
+				E49943F41AE6879C00BF9DE4 /* IntroViewController.swift */,
+				E49943F61AE69EDD00BF9DE4 /* Intro.xcassets */,
+			);
+			path = Intro;
 			sourceTree = "<group>";
 		};
 		E4BA8AA01B4B15EF00BC2E95 /* ViewLater */ = {
@@ -3262,6 +3265,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2F67C5281BB0D33000E7B73A /* PBXTargetDependency */,
 				28ECD9B11BA1F07000D829DA /* PBXTargetDependency */,
 				2827316B1ABC9BE700AA1954 /* PBXTargetDependency */,
 			);
@@ -4275,6 +4279,7 @@
 				2F8C76571BC32F3C00D5E4E0 /* MockSyncServerTests.swift in Sources */,
 				28ECD9A71BA1EF3D00D829DA /* GCDWebServerResponse.m in Sources */,
 				28F657EA1ABFCA7A00A608BD /* LiveAccountTest.swift in Sources */,
+				2F67C5261BB0CB4E00E7B73A /* MetaGlobalTests.swift in Sources */,
 				2827319E1ABC9C5900AA1954 /* RecordTests.swift in Sources */,
 				28A6CE8A1AC082E200C1A2D4 /* UtilsTests.swift in Sources */,
 				28F657C01ABFC97D00A608BD /* Record.swift in Sources */,
@@ -4880,6 +4885,11 @@
 			isa = PBXTargetDependency;
 			name = "XCGLogger (iOS)";
 			targetProxy = 2F14E1371ABB88E000FF98DB /* PBXContainerItemProxy */;
+		};
+		2F67C5281BB0D33000E7B73A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2FA435FA1ABB83B4008031D1 /* Account */;
+			targetProxy = 2F67C5271BB0D33000E7B73A;
 		};
 		2F77F69D1ABCAEFE00484F3A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -233,8 +233,8 @@
 		2F834D161A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
 		2F834D171A80629A006A0B7B /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 2F834D111A80629A006A0B7B /* FxASignIn.js */; };
 		2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F834D131A80629A006A0B7B /* FxAContentViewController.swift */; };
-		2F8C76571BC32F3C00D5E4E0 /* MockSyncServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		2F834D1B1A80629A006A0B7B /* FxAContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F834D131A80629A006A0B7B /* FxAContentViewController.swift */; };
+		2F8C76571BC32F3C00D5E4E0 /* MockSyncServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		2FA435111ABB6829008031D1 /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE23F1ABB531100877008 /* Bookmarks.swift */; };
 		2FA435131ABB6829008031D1 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2411ABB531100877008 /* Cursor.swift */; };
 		2FA435141ABB6829008031D1 /* Favicons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2421ABB531100877008 /* Favicons.swift */; };
@@ -270,6 +270,7 @@
 		2FA436421ABB8448008031D1 /* TokenServerClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA4363C1ABB8448008031D1 /* TokenServerClientTests.swift */; };
 		2FC244B31A855E05007CE41D /* FxA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; };
 		2FC244B81A855E0D007CE41D /* FxA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; };
+		2FC87C3D1BC46677001BAE77 /* LoginsSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ED02251B262B5E003948B2 /* LoginsSynchronizer.swift */; settings = {ASSET_TAGS = (); }; };
 		2FCAE2251ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE2311ABB51F800877008 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		2FCAE2321ABB51F800877008 /* Storage.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -328,9 +329,9 @@
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
+		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */; settings = {ASSET_TAGS = (); }; };
 		7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */; settings = {ASSET_TAGS = (); }; };
-		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; settings = {ASSET_TAGS = (); }; };
 		7BBFEE9A1BB409B200A305AA /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; settings = {ASSET_TAGS = (); }; };
@@ -502,6 +503,7 @@
 		E4A961341AC051360069AD6F /* ReadabilityBrowserHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */; };
 		E4A961361AC052DE0069AD6F /* ReadabilityBrowserHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */; };
 		E4A961381AC06FA50069AD6F /* ReaderViewLoading.html in Resources */ = {isa = PBXBuildFile; fileRef = E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */; };
+		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		E4B3344D1BBF2393004E2BFF /* ADJActivityHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334231BBF2393004E2BFF /* ADJActivityHandler.m */; settings = {ASSET_TAGS = (); }; };
 		E4B3344E1BBF2393004E2BFF /* ADJActivityKind.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334251BBF2393004E2BFF /* ADJActivityKind.m */; settings = {ASSET_TAGS = (); }; };
 		E4B3344F1BBF2393004E2BFF /* ADJActivityPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B334271BBF2393004E2BFF /* ADJActivityPackage.m */; settings = {ASSET_TAGS = (); }; };
@@ -526,7 +528,6 @@
 		E4B334881BBF23F3004E2BFF /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334871BBF23F3004E2BFF /* iAd.framework */; };
 		E4B3348A1BBF23F9004E2BFF /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4B334891BBF23F9004E2BFF /* AdSupport.framework */; };
 		E4B3348C1BC01D8F004E2BFF /* AdjustIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3348B1BC01D8F004E2BFF /* AdjustIntegration.swift */; settings = {ASSET_TAGS = (); }; };
-		E4AAE2B91A956304006F8740 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		E4B423BE1AB9FE6A007E66C8 /* ReaderModeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */; };
 		E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */; };
 		E4B7B7611A793CF20022C5E0 /* CharisSILB.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */; };
@@ -624,10 +625,10 @@
 		E635D41E1B73F41C0078962F /* NSFileManager+NRFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */; };
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
+		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; settings = {ASSET_TAGS = (); }; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; settings = {ASSET_TAGS = (); }; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; settings = {ASSET_TAGS = (); }; };
-		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */; };
@@ -920,6 +921,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 28F951FA19D0F9FA00DCE892;
 			remoteInfo = FxA;
+		};
+		2FC87C3C1BC45E67001BAE77 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2FA435FA1ABB83B4008031D1;
+			remoteInfo = Account;
 		};
 		2FCAE2261ABB51F800877008 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1464,9 +1472,9 @@
 		2F642CEC1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITests.swift; sourceTree = "<group>"; };
 		2F67C5251BB0CB4E00E7B73A /* MetaGlobalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetaGlobalTests.swift; path = SyncTests/MetaGlobalTests.swift; sourceTree = "<group>"; };
 		2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEnginesTests.swift; sourceTree = "<group>"; };
-		2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockSyncServerTests.swift; path = SyncTests/MockSyncServerTests.swift; sourceTree = "<group>"; };
 		2F834D111A80629A006A0B7B /* FxASignIn.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = FxASignIn.js; path = Frontend/SignIn/FxASignIn.js; sourceTree = "<group>"; };
 		2F834D131A80629A006A0B7B /* FxAContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAContentViewController.swift; path = Frontend/SignIn/FxAContentViewController.swift; sourceTree = "<group>"; };
+		2F8C76561BC32F3C00D5E4E0 /* MockSyncServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockSyncServerTests.swift; path = SyncTests/MockSyncServerTests.swift; sourceTree = "<group>"; };
 		2FA435FB1ABB83B4008031D1 /* Account.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Account.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA435FE1ABB83B4008031D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2FA436051ABB83B4008031D1 /* AccountTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AccountTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1533,10 +1541,10 @@
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
-		7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChevronView.swift; sourceTree = "<group>"; };
-		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
 		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
+		7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChevronView.swift; sourceTree = "<group>"; };
+		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
 		7BF5A1C91B4160EA00EA9DD8 /* SyncCommandsTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncCommandsTable.swift; sourceTree = "<group>"; };
@@ -1658,6 +1666,8 @@
 		E4A960051ABB9C450069AD6F /* ReaderModeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeUtils.swift; sourceTree = "<group>"; };
 		E4A961171AC041C40069AD6F /* ReadabilityService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityService.swift; sourceTree = "<group>"; };
 		E4A961331AC051360069AD6F /* ReadabilityBrowserHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadabilityBrowserHelper.swift; sourceTree = "<group>"; };
+		E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ReadabilityBrowserHelper.js; sourceTree = "<group>"; };
+		E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ReaderViewLoading.html; sourceTree = "<group>"; };
 		E4B334221BBF2393004E2BFF /* ADJActivityHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADJActivityHandler.h; sourceTree = "<group>"; };
 		E4B334231BBF2393004E2BFF /* ADJActivityHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADJActivityHandler.m; sourceTree = "<group>"; };
 		E4B334241BBF2393004E2BFF /* ADJActivityKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADJActivityKind.h; sourceTree = "<group>"; };
@@ -1703,8 +1713,6 @@
 		E4B334871BBF23F3004E2BFF /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		E4B334891BBF23F9004E2BFF /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E4B3348B1BC01D8F004E2BFF /* AdjustIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustIntegration.swift; sourceTree = "<group>"; };
-		E4A961351AC052DE0069AD6F /* ReadabilityBrowserHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ReadabilityBrowserHelper.js; sourceTree = "<group>"; };
-		E4A961371AC06FA50069AD6F /* ReaderViewLoading.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = ReaderViewLoading.html; sourceTree = "<group>"; };
 		E4B423BD1AB9FE6A007E66C8 /* ReaderModeCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeCache.swift; sourceTree = "<group>"; };
 		E4B423DC1ABA0318007E66C8 /* ReaderModeHandlers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModeHandlers.swift; sourceTree = "<group>"; };
 		E4B7B73A1A793CF20022C5E0 /* CharisSILB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = CharisSILB.ttf; sourceTree = "<group>"; };
@@ -1788,11 +1796,11 @@
 		E6231C041B90A472005ABB0D /* libxml2.2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.2.tbd; path = usr/lib/libxml2.2.tbd; sourceTree = SDKROOT; };
 		E635D25D1B729DEE0078962F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E635D41A1B73F06E0078962F /* NSFileManager+NRFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager+NRFileManager.h"; sourceTree = "<group>"; };
+		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
+		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
-		E635D41B1B73F06E0078962F /* NSFileManager+NRFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager+NRFileManager.m"; sourceTree = "<group>"; };
-		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E698FFD91B4AADF40001F623 /* BrowserScrollController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserScrollController.swift; sourceTree = "<group>"; };
@@ -2655,6 +2663,47 @@
 			name = SWTableViewCell;
 			sourceTree = "<group>";
 		};
+		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				287DA9D51AE06D220055AC35 /* Extensions */,
+				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
+				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
+				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
+				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
+				2FCAE2401ABB531100877008 /* Bytes.swift */,
+				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
+				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
+				287DAA1E1AE06E5D0055AC35 /* DeviceInfo.swift */,
+				0B71FFF41B4C49E50046AF87 /* FaviconFetcher.swift */,
+				283306E81AB3BB87008999AC /* Functions.swift */,
+				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
+				2F0624D41AE58C7800FA022C /* KeychainCache.swift */,
+				D339C2821AD354B400C087BD /* Loader.swift */,
+				E635D25D1B729DEE0078962F /* Logger.swift */,
+				285D3B321B4332C00035FD22 /* NotificationConstants.swift */,
+				282731A11ABC9D2600AA1954 /* Prefs.swift */,
+				E69966981B72674B0036F797 /* RollingFileLogger.swift */,
+				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
+				B729F0691B75CBEF00745F7A /* UserAgent.swift */,
+				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
+				E4252A0D1AF01AE40028C684 /* Swizzling.m */,
+				E4C358531AF1440B00299F7E /* Swizzling.h */,
+				E46C51C11B41ADD800EB349F /* Try.h */,
+				E46C51C21B41ADD800EB349F /* Try.m */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		E49943F31AE6879C00BF9DE4 /* Intro */ = {
+			isa = PBXGroup;
+			children = (
+				E49943F41AE6879C00BF9DE4 /* IntroViewController.swift */,
+				E49943F61AE69EDD00BF9DE4 /* Intro.xcassets */,
+			);
+			path = Intro;
+			sourceTree = "<group>";
+		};
 		E4B334211BBF2393004E2BFF /* Adjust */ = {
 			isa = PBXGroup;
 			children = (
@@ -2711,47 +2760,6 @@
 				E4B334301BBF2393004E2BFF /* UIDevice+ADJAdditions.m */,
 			);
 			path = ADJAdditions;
-			sourceTree = "<group>";
-		};
-		E42CCDFF1A24C4E300B794D3 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				287DA9D51AE06D220055AC35 /* Extensions */,
-				0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */,
-				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
-				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
-				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
-				2FCAE2401ABB531100877008 /* Bytes.swift */,
-				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
-				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
-				287DAA1E1AE06E5D0055AC35 /* DeviceInfo.swift */,
-				0B71FFF41B4C49E50046AF87 /* FaviconFetcher.swift */,
-				283306E81AB3BB87008999AC /* Functions.swift */,
-				D39999A81AA01D65005AED21 /* KeyboardHelper.swift */,
-				2F0624D41AE58C7800FA022C /* KeychainCache.swift */,
-				D339C2821AD354B400C087BD /* Loader.swift */,
-				E635D25D1B729DEE0078962F /* Logger.swift */,
-				285D3B321B4332C00035FD22 /* NotificationConstants.swift */,
-				282731A11ABC9D2600AA1954 /* Prefs.swift */,
-				E69966981B72674B0036F797 /* RollingFileLogger.swift */,
-				2F3444561AB22A4B00FD9731 /* TimeConstants.swift */,
-				B729F0691B75CBEF00745F7A /* UserAgent.swift */,
-				D3ACB4381AD33EBA00748D50 /* WeakList.swift */,
-				E4252A0D1AF01AE40028C684 /* Swizzling.m */,
-				E4C358531AF1440B00299F7E /* Swizzling.h */,
-				E46C51C11B41ADD800EB349F /* Try.h */,
-				E46C51C21B41ADD800EB349F /* Try.m */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
-		E49943F31AE6879C00BF9DE4 /* Intro */ = {
-			isa = PBXGroup;
-			children = (
-				E49943F41AE6879C00BF9DE4 /* IntroViewController.swift */,
-				E49943F61AE69EDD00BF9DE4 /* Intro.xcassets */,
-			);
-			path = Intro;
 			sourceTree = "<group>";
 		};
 		E4BA8AA01B4B15EF00BC2E95 /* ViewLater */ = {
@@ -4291,6 +4299,7 @@
 				28ECD9A41BA1EF3D00D829DA /* GCDWebServerConnection.m in Sources */,
 				28ECD9A91BA1EF5100D829DA /* GCDWebServerFileRequest.m in Sources */,
 				2894C16D1AE89FD500F1F92F /* HistoryPayload.swift in Sources */,
+				2FC87C3D1BC46677001BAE77 /* LoginsSynchronizer.swift in Sources */,
 				28ECD9AD1BA1EF5100D829DA /* GCDWebServerErrorResponse.m in Sources */,
 				288501F91AC0F62200E7F670 /* RequestExtensions.swift in Sources */,
 				5002717C41BC7C50F67F1CAD /* StateTests.swift in Sources */,
@@ -4889,7 +4898,7 @@
 		2F67C5281BB0D33000E7B73A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2FA435FA1ABB83B4008031D1 /* Account */;
-			targetProxy = 2F67C5271BB0D33000E7B73A;
+			targetProxy = 2FC87C3C1BC45E67001BAE77 /* PBXContainerItemProxy */;
 		};
 		2F77F69D1ABCAEFE00484F3A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -636,13 +636,12 @@ public class BrowserProfile: Profile {
                 }
 
                 let authState = account.syncAuthState
-                let syncPrefs = profile.prefs.branch("sync")
 
-                let readyDeferred = SyncStateMachine.toReady(authState, prefs: syncPrefs)
+                let readyDeferred = SyncStateMachine(prefs: self.prefsForSync).toReady(authState)
                 let delegate = profile.getSyncDelegate()
 
                 let go = readyDeferred >>== { ready in
-                    function(delegate, syncPrefs, ready)
+                    function(delegate, self.prefsForSync, ready)
                 }
 
                 // Always unlock when we're done.

--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -8,7 +8,7 @@ import Storage
 import XCGLogger
 
 private let log = Logger.syncLogger
-private let BookmarksStorageVersion = 2
+let BookmarksStorageVersion = 2
 
 /**
  * This is like a synchronizer, but it downloads records bit by bit, eventually

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -9,7 +9,7 @@ import Account
 
 private let KeyLength = 32
 
-public class KeyBundle: Equatable {
+public class KeyBundle: Hashable {
     let encKey: NSData
     let hmacKey: NSData
 
@@ -201,6 +201,10 @@ public class KeyBundle: Equatable {
 
     public func asPair() -> [String] {
         return [self.encKey.base64EncodedString, self.hmacKey.base64EncodedString]
+    }
+
+    public var hashValue: Int {
+        return "\(self.encKey.base64EncodedString) \(self.hmacKey.base64EncodedString)".hashValue
     }
 }
 

--- a/Sync/KeyBundle.swift
+++ b/Sync/KeyBundle.swift
@@ -220,14 +220,12 @@ public class Keys: Equatable {
     }
 
     public init(payload: KeysPayload?) {
-        if let payload = payload {
-            if payload.isValid() {
-                if let keys = payload.defaultKeys {
-                    self.defaultBundle = keys
-                    self.valid = true
-                    return
-                }
+        if let payload = payload where payload.isValid() {
+            if let keys = payload.defaultKeys {
+                self.defaultBundle = keys
                 self.collectionKeys = payload.collectionKeys
+                self.valid = true
+                return
             }
         }
         self.defaultBundle = KeyBundle.invalid

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -36,6 +36,10 @@ public enum LocalCommand: CustomStringConvertible, Hashable {
     // timestamp and possibly re-upload.
     case ResetEngine(engine: String)
 
+    // We've seen a change in meta/global: an engine has come or gone.
+    case EnableEngine(engine: String)
+    case DisableEngine(engine: String)
+
     public func toJSON() -> JSON {
         switch (self) {
         case let .ResetAllEngines(except):
@@ -43,6 +47,12 @@ public enum LocalCommand: CustomStringConvertible, Hashable {
 
         case let .ResetEngine(engine):
             return JSON(["type": "ResetEngine", "engine": engine])
+
+        case let .EnableEngine(engine):
+            return JSON(["type": "EnableEngine", "engine": engine])
+
+        case let .DisableEngine(engine):
+            return JSON(["type": "DisableEngine", "engine": engine])
         }
     }
 
@@ -62,6 +72,16 @@ public enum LocalCommand: CustomStringConvertible, Hashable {
         case "ResetEngine":
             if let engine = json["engine"].asString {
                 return .ResetEngine(engine: engine)
+            }
+            return nil
+        case "EnableEngine":
+            if let engine = json["engine"].asString {
+                return .EnableEngine(engine: engine)
+            }
+            return nil
+        case "DisableEngine":
+            if let engine = json["engine"].asString {
+                return .DisableEngine(engine: engine)
             }
             return nil
         default:
@@ -84,6 +104,12 @@ public func ==(lhs: LocalCommand, rhs: LocalCommand) -> Bool {
         return exceptL == exceptR
 
     case (let .ResetEngine(engineL), let .ResetEngine(engineR)):
+        return engineL == engineR
+
+    case (let .EnableEngine(engineL), let .EnableEngine(engineR)):
+        return engineL == engineR
+
+    case (let .DisableEngine(engineL), let .DisableEngine(engineR)):
         return engineL == engineR
 
     default:

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -381,18 +381,6 @@ public class Scratchpad {
                    .clearFetchTimestamps()
                    .build()
     }
-
-    func applyEngineChoices(old: MetaGlobal?) -> (Scratchpad, MetaGlobal?) {
-        log.info("Applying engine choices from inbound meta/global.")
-        log.info("Old meta/global syncID: \(old?.syncID)")
-        log.info("New meta/global syncID: \(self.global?.value.syncID)")
-        log.info("HACK: ignoring engine choices.")
-
-        // TODO: detect when the sets of declined or enabled engines have changed, and update
-        //       our preferences and generate a new meta/global if necessary.
-        return (self, nil)
-    }
-
     private class func unpickleV1FromPrefs(prefs: Prefs, syncKeyBundle: KeyBundle) -> Scratchpad {
         let b = Scratchpad(b: syncKeyBundle, persistingTo: prefs).evolve()
 

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -366,7 +366,7 @@ public class Scratchpad {
 
         if let mg = prefs.stringForKey(PrefGlobal) {
             if let mgTS = prefs.unsignedLongForKey(PrefGlobalTS) {
-                if let global = MetaGlobal.fromPayload(mg) {
+                if let global = MetaGlobal.fromJSON(JSON.parse(mg)) {
                     b.setGlobal(Fetched(value: global, timestamp: mgTS))
                 } else {
                     log.error("Malformed meta/global in prefs. Ignoring.")

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -188,6 +188,50 @@ public class Scratchpad {
             self.clientName = p.clientName
         }
 
+        public func clearLocalCommands() -> Builder {
+            self.localCommands.removeAll()
+            return self
+        }
+
+        public func addLocalCommandsFromKeys(keys: Fetched<Keys>?) -> Builder {
+            // Getting new keys can force local collection resets.
+            if let freshKeys = keys?.value, staleKeys = self.keys?.value where staleKeys.valid {
+                // New keys, and we have valid old keys.
+                if freshKeys.defaultBundle != staleKeys.defaultBundle {
+                    // Default bundle has changed.  Reset everything but collections that have unchanged bulk keys.
+                    var except: Set<String> = Set()
+                    // Symmetric difference, like an animal.  Swift doesn't allow Hashable tuples; don't fight it.
+                    for (collection, keyBundle) in staleKeys.collectionKeys {
+                        if keyBundle == freshKeys.forCollection(collection) {
+                            except.insert(collection)
+                        }
+                    }
+                    for (collection, keyBundle) in freshKeys.collectionKeys {
+                        if keyBundle == staleKeys.forCollection(collection) {
+                            except.insert(collection)
+                        }
+                    }
+                    self.localCommands.insert(.ResetAllEngines(except: except))
+                } else {
+                    // Default bundle is the same.  Reset collections that have changed bulk keys.
+                    for (collection, keyBundle) in staleKeys.collectionKeys {
+                        if keyBundle != freshKeys.forCollection(collection) {
+                            self.localCommands.insert(.ResetEngine(engine: collection))
+                        }
+                    }
+                    for (collection, keyBundle) in freshKeys.collectionKeys {
+                        if keyBundle != staleKeys.forCollection(collection) {
+                            self.localCommands.insert(.ResetEngine(engine: collection))
+                        }
+                    }
+                }
+            } else {
+                // Removing keys, or new keys and either we didn't have old keys or they weren't valid.  Everybody gets a reset!
+                self.localCommands.insert(LocalCommand.ResetAllEngines(except: []))
+            }
+            return self
+        }
+
         public func setKeys(keys: Fetched<Keys>?) -> Builder {
             self.keys = keys
             if let keys = keys {
@@ -328,6 +372,7 @@ public class Scratchpad {
         // TODO: I *think* a new keyLabel is unnecessary.
         return self.evolve()
                    .setGlobal(global)
+                   .addLocalCommandsFromKeys(nil)
                    .setKeys(nil)
                    .clearFetchTimestamps()
                    .build()

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -25,6 +25,72 @@ public func ==<T: Equatable>(lhs: Fetched<T>, rhs: Fetched<T>) -> Bool {
            lhs.value == rhs.value
 }
 
+public enum LocalCommand: CustomStringConvertible, Hashable {
+    // We've seen something (a blank server, a changed global sync ID, a
+    // crypto/keys with a different meta/global) that requires us to reset all
+    // local engine timestamps (save the ones listed) and possibly re-upload.
+    case ResetAllEngines(except: Set<String>)
+
+    // We've seen something (a changed engine sync ID, a crypto/keys with a
+    // different per-engine bulk key) that requires us to reset our local engine
+    // timestamp and possibly re-upload.
+    case ResetEngine(engine: String)
+
+    public func toJSON() -> JSON {
+        switch (self) {
+        case let .ResetAllEngines(except):
+            return JSON(["type": "ResetAllEngines", "except": Array(except).sort()])
+
+        case let .ResetEngine(engine):
+            return JSON(["type": "ResetEngine", "engine": engine])
+        }
+    }
+
+    public static func fromJSON(json: JSON) -> LocalCommand? {
+        if json.isError {
+            return nil
+        }
+        guard let type = json["type"].asString else {
+            return nil
+        }
+        switch type {
+        case "ResetAllEngines":
+            if let except = json["except"].asArray where except.every({$0.isString}) {
+                return .ResetAllEngines(except: Set(except.map({$0.asString!})))
+            }
+            return nil
+        case "ResetEngine":
+            if let engine = json["engine"].asString {
+                return .ResetEngine(engine: engine)
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    public var description: String {
+        return self.toJSON().toString()
+    }
+
+    public var hashValue: Int {
+        return self.description.hashValue
+    }
+}
+
+public func ==(lhs: LocalCommand, rhs: LocalCommand) -> Bool {
+    switch (lhs, rhs) {
+    case (let .ResetAllEngines(exceptL), let .ResetAllEngines(exceptR)):
+        return exceptL == exceptR
+
+    case (let .ResetEngine(engineL), let .ResetEngine(engineR)):
+        return engineL == engineR
+
+    default:
+        return false
+    }
+}
+
 /*
  * Persistence pref names.
  * Note that syncKeyBundle isn't persisted by us.
@@ -39,6 +105,7 @@ private let PrefGlobalTS = "globalTS"
 private let PrefKeyLabel = "keyLabel"
 private let PrefKeysTS = "keysTS"
 private let PrefLastFetched = "lastFetched"
+private let PrefLocalCommands = "localCommands"
 private let PrefClientName = "clientName"
 private let PrefClientGUID = "clientGUID"
 
@@ -83,6 +150,7 @@ class PrefsBackoffStorage: BackoffStorage {
  * 2. Metadata like timestamps, both for cached records and for server fetches.
  * 3. User preferences -- engine enablement.
  * 4. Client record state.
+ * 5. Local commands that have yet to be processed.
  *
  * Note that the scratchpad itself is immutable, but is a class passed by reference.
  * Its mutable fields can be mutated, but you can't accidentally e.g., switch out
@@ -98,6 +166,7 @@ public class Scratchpad {
         private var keys: Fetched<Keys>?
         private var keyLabel: String
         var collectionLastFetched: [String: Timestamp]
+        var localCommands: Set<LocalCommand>
         var engineConfiguration: EngineConfiguration?
         var clientGUID: String
         var clientName: String
@@ -113,6 +182,7 @@ public class Scratchpad {
             self.keyLabel = p.keyLabel
 
             self.collectionLastFetched = p.collectionLastFetched
+            self.localCommands = p.localCommands
             self.engineConfiguration = p.engineConfiguration
             self.clientGUID = p.clientGUID
             self.clientName = p.clientName
@@ -146,6 +216,7 @@ public class Scratchpad {
                     k: self.keys,
                     keyLabel: self.keyLabel,
                     fetches: self.collectionLastFetched,
+                    localCommands: self.localCommands,
                     engines: self.engineConfiguration,
                     clientGUID: self.clientGUID,
                     clientName: self.clientName,
@@ -195,6 +266,9 @@ public class Scratchpad {
     // Collection timestamps.
     var collectionLastFetched: [String: Timestamp]
 
+    // Local commands.
+    var localCommands: Set<LocalCommand>
+
     // Enablement states.
     let engineConfiguration: EngineConfiguration?
 
@@ -210,6 +284,7 @@ public class Scratchpad {
          k: Fetched<Keys>?,
          keyLabel: String,
          fetches: [String: Timestamp],
+         localCommands: Set<LocalCommand>,
          engines: EngineConfiguration?,
          clientGUID: String,
          clientName: String,
@@ -223,6 +298,7 @@ public class Scratchpad {
         self.global = m
         self.engineConfiguration = engines
         self.collectionLastFetched = fetches
+        self.localCommands = localCommands
         self.clientGUID = clientGUID
         self.clientName = clientName
     }
@@ -238,6 +314,7 @@ public class Scratchpad {
         self.global = nil
         self.engineConfiguration = nil
         self.collectionLastFetched = [String: Timestamp]()
+        self.localCommands = Set()
         self.clientGUID = Bytes.generateGUID()
         self.clientName = DeviceInfo.defaultClientName()
     }
@@ -316,6 +393,11 @@ public class Scratchpad {
             return DeviceInfo.defaultClientName()
         }()
 
+
+        if let localCommands: [String] = prefs.stringArrayForKey(PrefLocalCommands) {
+            b.localCommands = Set(optFilter(localCommands.map({LocalCommand.fromJSON(JSON.parse($0))})))
+        }
+
         // TODO: engineConfiguration
         return b.build()
     }
@@ -390,6 +472,9 @@ public class Scratchpad {
         // Thanks, Swift.
         let dict = mapValues(collectionLastFetched, f: { NSNumber(unsignedLongLong: $0) }) as NSDictionary
         prefs.setObject(dict, forKey: PrefLastFetched)
+
+        let localCommands: [String] = Array(self.localCommands).map({$0.toJSON().toString()})
+        prefs.setObject(localCommands, forKey: PrefLocalCommands)
 
         return self
     }

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -166,7 +166,6 @@ public class Scratchpad {
         private var global: Fetched<MetaGlobal>?
         private var keys: Fetched<Keys>?
         private var keyLabel: String
-        var collectionLastFetched: [String: Timestamp]
         var localCommands: Set<LocalCommand>
         var engineConfiguration: EngineConfiguration?
         var clientGUID: String
@@ -181,8 +180,6 @@ public class Scratchpad {
 
             self.keys = p.keys
             self.keyLabel = p.keyLabel
-
-            self.collectionLastFetched = p.collectionLastFetched
             self.localCommands = p.localCommands
             self.engineConfiguration = p.engineConfiguration
             self.clientGUID = p.clientGUID
@@ -235,25 +232,15 @@ public class Scratchpad {
 
         public func setKeys(keys: Fetched<Keys>?) -> Builder {
             self.keys = keys
-            if let keys = keys {
-                self.collectionLastFetched["crypto"] = keys.timestamp
-            }
             return self
         }
 
         public func setGlobal(global: Fetched<MetaGlobal>?) -> Builder {
             self.global = global
             if let global = global {
-                self.collectionLastFetched["meta"] = global.timestamp
-
                 // We always take the incoming meta/global's engine configuration.
                 self.engineConfiguration = global.value.engineConfiguration()
             }
-            return self
-        }
-
-        public func clearFetchTimestamps() -> Builder {
-            self.collectionLastFetched = [:]
             return self
         }
 
@@ -268,7 +255,6 @@ public class Scratchpad {
                     m: self.global,
                     k: self.keys,
                     keyLabel: self.keyLabel,
-                    fetches: self.collectionLastFetched,
                     localCommands: self.localCommands,
                     engines: self.engineConfiguration,
                     clientGUID: self.clientGUID,
@@ -316,9 +302,6 @@ public class Scratchpad {
     let keys: Fetched<Keys>?
     let keyLabel: String
 
-    // Collection timestamps.
-    var collectionLastFetched: [String: Timestamp]
-
     // Local commands.
     var localCommands: Set<LocalCommand>
 
@@ -336,7 +319,6 @@ public class Scratchpad {
          m: Fetched<MetaGlobal>?,
          k: Fetched<Keys>?,
          keyLabel: String,
-         fetches: [String: Timestamp],
          localCommands: Set<LocalCommand>,
          engines: EngineConfiguration?,
          clientGUID: String,
@@ -350,7 +332,6 @@ public class Scratchpad {
         self.keyLabel = keyLabel
         self.global = m
         self.engineConfiguration = engines
-        self.collectionLastFetched = fetches
         self.localCommands = localCommands
         self.clientGUID = clientGUID
         self.clientName = clientName
@@ -366,7 +347,6 @@ public class Scratchpad {
         self.keyLabel = Bytes.generateGUID()
         self.global = nil
         self.engineConfiguration = nil
-        self.collectionLastFetched = [String: Timestamp]()
         self.localCommands = Set()
         self.clientGUID = Bytes.generateGUID()
         self.clientName = DeviceInfo.defaultClientName()
@@ -378,16 +358,11 @@ public class Scratchpad {
                    .setGlobal(global)
                    .addLocalCommandsFromKeys(nil)
                    .setKeys(nil)
-                   .clearFetchTimestamps()
                    .build()
     }
+
     private class func unpickleV1FromPrefs(prefs: Prefs, syncKeyBundle: KeyBundle) -> Scratchpad {
         let b = Scratchpad(b: syncKeyBundle, persistingTo: prefs).evolve()
-
-        // Do this first so that the meta/global and crypto/keys unpickling can overwrite the timestamps.
-        if let lastFetched: [String: AnyObject] = prefs.dictionaryForKey(PrefLastFetched) {
-            b.collectionLastFetched = optFilter(mapValues(lastFetched, f: { ($0 as? NSNumber)?.unsignedLongLongValue }))
-        }
 
         if let mg = prefs.stringForKey(PrefGlobal) {
             if let mgTS = prefs.unsignedLongForKey(PrefGlobalTS) {
@@ -509,10 +484,6 @@ public class Scratchpad {
 
         prefs.setString(clientName, forKey: PrefClientName)
         prefs.setString(clientGUID, forKey: PrefClientGUID)
-
-        // Thanks, Swift.
-        let dict = mapValues(collectionLastFetched, f: { NSNumber(unsignedLongLong: $0) }) as NSDictionary
-        prefs.setObject(dict, forKey: PrefLastFetched)
 
         let localCommands: [String] = Array(self.localCommands).map({$0.toJSON().toString()})
         prefs.setObject(localCommands, forKey: PrefLocalCommands)

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -244,12 +244,20 @@ public class Scratchpad {
             self.global = global
             if let global = global {
                 self.collectionLastFetched["meta"] = global.timestamp
+
+                // We always take the incoming meta/global's engine configuration.
+                self.engineConfiguration = global.value.engineConfiguration()
             }
             return self
         }
 
         public func clearFetchTimestamps() -> Builder {
             self.collectionLastFetched = [:]
+            return self
+        }
+
+        public func setEngineConfiguration(engineConfiguration: EngineConfiguration?) -> Builder {
+            self.engineConfiguration = engineConfiguration
             return self
         }
 
@@ -361,11 +369,6 @@ public class Scratchpad {
         self.localCommands = Set()
         self.clientGUID = Bytes.generateGUID()
         self.clientName = DeviceInfo.defaultClientName()
-    }
-
-    // For convenience.
-    func withGlobal(m: Fetched<MetaGlobal>?) -> Scratchpad {
-        return self.evolve().setGlobal(m).build()
     }
 
     func freshStartWithGlobal(global: Fetched<MetaGlobal>) -> Scratchpad {

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -533,8 +533,15 @@ public class Sync15StorageClient {
         return getResource("info/collections", f: InfoCollections.fromJSON)
     }
 
-    func getMetaGlobal() -> Deferred<Maybe<StorageResponse<GlobalEnvelope>>> {
-        return getResource("storage/meta/global", f: { GlobalEnvelope($0) })
+    func getMetaGlobal() -> Deferred<Maybe<StorageResponse<MetaGlobal>>> {
+        return getResource("storage/meta/global") { json in
+            // We have an envelope.  Parse the meta/global record embedded in the 'payload' string.
+            let envelope = EnvelopeJSON(json)
+            if envelope.isValid() {
+                return MetaGlobal.fromJSON(JSON.parse(envelope.payload))
+            }
+            return nil
+        }
     }
 
     func getCryptoKeys(syncKeyBundle: KeyBundle, ifUnmodifiedSince: Timestamp?) -> Deferred<Maybe<StorageResponse<Record<KeysPayload>>>> {

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -9,7 +9,7 @@ import Shared
 // Note that EngineConfiguration is not enough to evolve an existing meta/global:
 // a meta/global generated from this will have different syncIDs and will
 // always use this device's engine versions.
-public class EngineConfiguration {
+public class EngineConfiguration: Equatable {
     let enabled: [String]
     let declined: [String]
     public init(enabled: [String], declined: [String]) {
@@ -32,6 +32,16 @@ public class EngineConfiguration {
         // Note that sometimes we also need to make changes to the meta/global
         // itself -- e.g., missing declined. That should be a method on MetaGlobal.
         return self
+    }
+}
+
+public func ==(lhs: EngineConfiguration, rhs: EngineConfiguration) -> Bool {
+    return Set(lhs.enabled) == Set(rhs.enabled)
+}
+
+extension EngineConfiguration: CustomStringConvertible {
+    public var description: String {
+        return "EngineConfiguration(enabled: \(self.enabled.sort()), declined: \(self.declined.sort()))"
     }
 }
 
@@ -112,6 +122,14 @@ public struct MetaGlobal: Equatable {
             "declined": JSON(self.declined ?? [])
         ])
         return CleartextPayloadJSON(json)
+    }
+
+    public func withSyncID(syncID: String) -> MetaGlobal {
+        return MetaGlobal(syncID: syncID, storageVersion: self.storageVersion, engines: self.engines, declined: self.declined)
+    }
+
+    public func engineConfiguration() -> EngineConfiguration {
+        return EngineConfiguration(enabled: Array(engines.keys), declined: declined)
     }
 }
 

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -18,6 +18,9 @@ public class EngineConfiguration: Equatable {
     }
 
     public class func fromJSON(json: JSON) -> EngineConfiguration? {
+        if json.isError {
+            return nil
+        }
         if let enabled = jsonsToStrings(json["enabled"].asArray) {
             if let declined = jsonsToStrings(json["declined"].asArray) {
                 return EngineConfiguration(enabled: enabled, declined: declined)
@@ -26,12 +29,9 @@ public class EngineConfiguration: Equatable {
         return nil
     }
 
-    public func reconcile(meta: [String: EngineMeta]) -> EngineConfiguration {
-        // TODO: when we get a changed meta/global, we need to be able
-        // to reflect its changes into our configuration.
-        // Note that sometimes we also need to make changes to the meta/global
-        // itself -- e.g., missing declined. That should be a method on MetaGlobal.
-        return self
+    public func toJSON() -> JSON {
+        let json: [String: AnyObject] = ["enabled": self.enabled, "declined": self.declined]
+        return JSON(json)
     }
 }
 

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -83,13 +83,9 @@ public struct MetaGlobal: Equatable {
     let engines: [String: EngineMeta]
     let declined: [String]
 
-    public static func fromPayload(string: String) -> MetaGlobal? {
-        return fromPayload(JSON(string: string))
-    }
-
     // TODO: is it more useful to support partial globals?
     // TODO: how do we return error states here?
-    public static func fromPayload(json: JSON) -> MetaGlobal? {
+    public static func fromJSON(json: JSON) -> MetaGlobal? {
         if json.isError {
             return nil
         }
@@ -135,19 +131,6 @@ public func ==(lhs: MetaGlobal, rhs: MetaGlobal) -> Bool {
            (lhs.storageVersion == rhs.storageVersion) &&
            optArrayEqual(lhs.declined, rhs: rhs.declined) &&
            optDictionaryEqual(lhs.engines, rhs: rhs.engines)
-}
-
-public class GlobalEnvelope: EnvelopeJSON {
-    public lazy var global: MetaGlobal? = {
-        return MetaGlobal.fromPayload(self.payload)
-    }()
-
-    public func toFetched() -> Fetched<MetaGlobal>? {
-        if let g = global {
-            return Fetched(value: g, timestamp: self.modified)
-        }
-        return nil
-    }
 }
 
 /**

--- a/Sync/SyncMeta.swift
+++ b/Sync/SyncMeta.swift
@@ -80,8 +80,8 @@ public func ==(lhs: EngineMeta, rhs: EngineMeta) -> Bool {
 public struct MetaGlobal: Equatable {
     let syncID: String
     let storageVersion: Int
-    let engines: [String: EngineMeta]?      // Is this really optional?
-    let declined: [String]?
+    let engines: [String: EngineMeta]
+    let declined: [String]
 
     public static func fromPayload(string: String) -> MetaGlobal? {
         return fromPayload(JSON(string: string))
@@ -95,22 +95,19 @@ public struct MetaGlobal: Equatable {
         }
         if let syncID = json["syncID"].asString {
             if let storageVersion = json["storageVersion"].asInt {
-                let engines = EngineMeta.mapFromJSON(json["engines"].asDictionary)
-                let declined = json["declined"].asArray
+                let engines = EngineMeta.mapFromJSON(json["engines"].asDictionary) ?? [:]
+                let declined = json["declined"].asArray ?? []
                 return MetaGlobal(syncID: syncID,
                                   storageVersion: storageVersion,
                                   engines: engines,
-                                  declined: jsonsToStrings(declined))
+                                  declined: jsonsToStrings(declined) ?? [])
             }
         }
         return nil
     }
 
     public func enginesPayload() -> JSON {
-        if let engines = engines {
-            return JSON(mapValues(engines, f: { $0.toJSON() }))
-        }
-        return JSON([:])
+        return JSON(mapValues(engines, f: { $0.toJSON() }))
     }
 
     // TODO: make a whole record JSON for this.
@@ -119,7 +116,7 @@ public struct MetaGlobal: Equatable {
             "syncID": self.syncID,
             "storageVersion": self.storageVersion,
             "engines": enginesPayload(),
-            "declined": JSON(self.declined ?? [])
+            "declined": JSON(self.declined)
         ])
         return CleartextPayloadJSON(json)
     }

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -655,9 +655,6 @@ public class InitialWithLiveTokenAndInfo: BaseSyncStateWithInfo {
         return self.client.getMetaGlobal().bind { result in
             if let resp = result.successValue {
                 if let fetched = resp.value.toFetched() {
-                    // We bump the meta/ timestamp because, though in theory there might be
-                    // other records in that collection, even if there are we don't care about them.
-                    self.scratchpad.collectionLastFetched["meta"] = resp.metadata.lastModifiedMilliseconds
                     return deferMaybe(ResolveMetaGlobal.fromState(self, fetched: fetched))
                 }
 

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -10,7 +10,33 @@ import XCGLogger
 private let log = Logger.syncLogger
 
 private let StorageVersionCurrent = 5
-private let DefaultEngines: [String: Int] = ["tabs": 1]
+
+// Names of collections for which a synchronizer is implemented locally.
+private let LocalEngines: [String] = [
+    "bookmarks",
+    "clients",
+    "history",
+    "passwords",
+    "tabs",
+]
+
+// Names of collections which will appear in a default meta/global produced locally.
+// Map collection name to engine version.  See http://docs.services.mozilla.com/sync/objectformats.html.
+private let DefaultEngines: [String: Int] = [
+    "bookmarks": BookmarksStorageVersion,
+    "clients": ClientsStorageVersion,
+    "history": HistoryStorageVersion,
+    "passwords": PasswordsStorageVersion,
+    "tabs": TabsStorageVersion,
+    // We opt-in to syncing collections we don't know about, since no client offers to sync non-enabled,
+    // non-declined engines yet.  See Bug 969669.
+    "forms": 1,
+    "addons": 1,
+    "prefs": 2,
+]
+
+// Names of collections which will appear as declined in a default
+// meta/global produced locally.
 private let DefaultDeclined: [String] = [String]()
 
 private func getDefaultEngines() -> [String: EngineMeta] {

--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -593,11 +593,12 @@ public class ResolveMetaGlobalContent: BaseSyncStateWithInfo {
 
             for engine in previousEngines.subtract(remoteEngines) {
                 log.info("Remote meta/global disabled previously enabled engine \(engine). No action needed.")
+                b.localCommands.insert(.DisableEngine(engine: engine))
             }
 
             for engine in remoteEngines.subtract(previousEngines) {
                 log.info("Remote meta/global enabled previously disabled engine \(engine). Resetting local.")
-                b.localCommands.insert(.ResetEngine(engine: engine))
+                b.localCommands.insert(.EnableEngine(engine: engine))
             }
 
             for engine in remoteEngines.intersect(previousEngines) {
@@ -819,9 +820,37 @@ public class Ready: BaseSyncStateWithInfo {
                 needReset.unionInPlace(Set(LocalEngines).subtract(except))
             case let .ResetEngine(engine):
                 needReset.insert(engine)
+            case .EnableEngine, .DisableEngine:
+                break
             }
         }
         return Array(needReset).sort()
+    }
+
+    public func enginesEnabled() -> [String] {
+        var engines: Set<String> = Set()
+        for command in self.scratchpad.localCommands {
+            switch command {
+            case let .EnableEngine(engine):
+                engines.insert(engine)
+            default:
+                break
+            }
+        }
+        return Array(engines).sort()
+    }
+
+    public func enginesDisabled() -> [String] {
+        var engines: Set<String> = Set()
+        for command in self.scratchpad.localCommands {
+            switch command {
+            case let .DisableEngine(engine):
+                engines.insert(engine)
+            default:
+                break
+            }
+        }
+        return Array(engines).sort()
     }
 
     public func clearLocalCommands() {

--- a/Sync/Synchronizers/ClientsSynchronizer.swift
+++ b/Sync/Synchronizers/ClientsSynchronizer.swift
@@ -8,7 +8,7 @@ import Storage
 import XCGLogger
 
 private let log = Logger.syncLogger
-private let ClientsStorageVersion = 1
+let ClientsStorageVersion = 1
 
 // TODO
 public protocol Command {

--- a/Sync/Synchronizers/HistorySynchronizer.swift
+++ b/Sync/Synchronizers/HistorySynchronizer.swift
@@ -9,7 +9,7 @@ import XCGLogger
 
 private let log = Logger.syncLogger
 private let HistoryTTLInSeconds = 5184000                   // 60 days.
-private let HistoryStorageVersion = 1
+let HistoryStorageVersion = 1
 
 func makeDeletedHistoryRecord(guid: GUID) -> Record<HistoryPayload> {
     // Local modified time is ignored in upload serialization.

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -8,7 +8,7 @@ import Storage
 import XCGLogger
 
 private let log = Logger.syncLogger
-private let PasswordsStorageVersion = 1
+let PasswordsStorageVersion = 1
 
 private func makeDeletedLoginRecord(guid: GUID) -> Record<LoginPayload> {
     // Local modified time is ignored in upload serialization.

--- a/Sync/Synchronizers/Synchronizer.swift
+++ b/Sync/Synchronizers/Synchronizer.swift
@@ -142,10 +142,10 @@ public class BaseCollectionSynchronizer {
             return .Backoff(remainingSeconds: Int(remaining))
         }
 
-        if let _ = self.scratchpad.global?.value {
+        if let metaGlobal = self.scratchpad.global?.value {
             // There's no need to check the global storage format here; the state machine will already have
             // done so.
-            if let engineMeta = self.scratchpad.global?.value.engines?[collection] {
+            if let engineMeta = metaGlobal.engines[collection] {
                 if engineMeta.version > self.storageVersion {
                     return .EngineFormatOutdated(needs: engineMeta.version)
                 }

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -8,7 +8,7 @@ import Storage
 import XCGLogger
 
 private let log = Logger.syncLogger
-private let TabsStorageVersion = 1
+let TabsStorageVersion = 1
 
 public class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchronizer {
     public required init(scratchpad: Scratchpad, delegate: SyncDelegate, basePrefs: Prefs) {

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -130,7 +130,7 @@ class LiveStorageClientTests : LiveAccountTest {
             if let ready = result.successValue {
                 XCTAssertTrue(ready.collectionKeys.defaultBundle.encKey.length == 32)
                 XCTAssertTrue(ready.scratchpad.global != nil)
-                if let clients = ready.scratchpad.global?.value.engines?["clients"] {
+                if let clients = ready.scratchpad.global?.value.engines["clients"] {
                     XCTAssertTrue(clients.syncID.characters.count == 12)
                 }
             }

--- a/SyncTests/LiveStorageClientTests.swift
+++ b/SyncTests/LiveStorageClientTests.swift
@@ -124,7 +124,7 @@ class LiveStorageClientTests : LiveAccountTest {
         let expectation = expectationWithDescription("Waiting on value.")
         let authState = self.getAuthState(NSDate.now())
 
-        let d = chainDeferred(authState, f: { SyncStateMachine.toReady($0, prefs: MockProfilePrefs()) })
+        let d = chainDeferred(authState, f: { SyncStateMachine(prefs: MockProfilePrefs()).toReady($0) })
 
         d.upon { result in
             if let ready = result.successValue {

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -70,10 +70,6 @@ class MetaGlobalTests: XCTestCase {
         server.storeRecords([envelope], inCollection: "crypto")
     }
 
-    func assertStateLabelsSeen(stateLabelsSeen: [String]) {
-        XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, stateLabelsSeen)
-    }
-
     func assertFreshStart(ready: Ready?, after: Timestamp) {
         XCTAssertNotNil(ready)
         guard let ready = ready else {
@@ -99,7 +95,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
             XCTAssertNotNil(result.failureValue as? ClientUpgradeRequiredError)
             XCTAssertNil(result.successValue)
             expectation.fulfill()
@@ -117,7 +113,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -134,7 +131,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -153,7 +151,7 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            self.assertStateLabelsSeen(["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Account
+import Foundation
+import Shared
+import Storage
+@testable import Sync
+import XCGLogger
+import XCTest
+
+private let log = Logger.syncLogger
+
+class MockSyncAuthState: SyncAuthState {
+    let serverRoot: String
+    let kB: NSData
+
+    init(serverRoot: String, kB: NSData) {
+        self.serverRoot = serverRoot
+        self.kB = kB
+    }
+
+    func invalidate() {
+    }
+
+    func token(now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: NSData)>> {
+        let token = TokenServerToken(id: "id", key: "key", api_endpoint: serverRoot, uid: UInt64(0),
+            durationInSeconds: UInt64(5 * 60), remoteTimestamp: Timestamp(now - 1))
+        return deferMaybe((token, self.kB))
+    }
+}
+
+class MetaGlobalTests: XCTestCase {
+    var server: MockSyncServer!
+    var serverRoot: String!
+    var kB: NSData!
+
+    override func setUp() {
+        kB = NSData.randomOfLength(32)!
+        server = MockSyncServer(username: "1234567")
+        server.start()
+        serverRoot = server.baseURL
+    }
+
+    func now() -> Timestamp {
+        return Timestamp(1000 * NSDate().timeIntervalSince1970)
+    }
+
+    func storeMetaGlobal(metaGlobal: MetaGlobal) {
+        let envelope = EnvelopeJSON(JSON([
+            "id": "global",
+            "collection": "meta",
+            "payload": metaGlobal.asPayload().toString(),
+            "modified": Double(NSDate().timeIntervalSince1970)]))
+        server.storeRecords([envelope], inCollection: "meta")
+    }
+
+    func storeKeys(keys: Keys) {
+        let keyBundle = KeyBundle.fromKB(kB)
+        let keys = Keys(defaultBundle: keyBundle)
+        let record = Record(id: "keys", payload: keys.asPayload())
+        let envelope = EnvelopeJSON(keyBundle.serializer({ $0 })(record)!)
+        server.storeRecords([envelope], inCollection: "crypto")
+    }
+
+    func ready() -> ReadyDeferred {
+        let syncPrefs = MockProfilePrefs()
+        let authState: SyncAuthState = MockSyncAuthState(serverRoot: serverRoot, kB: kB)
+        return SyncStateMachine.toReady(authState, prefs: syncPrefs)
+    }
+
+    func assertFreshStart(ready: Ready?, after: Timestamp) {
+        XCTAssertNotNil(ready)
+        guard let ready = ready else {
+            return
+        }
+        // We should have wiped.
+        // We should have uploaded new meta/global and crypto/keys.
+        XCTAssertGreaterThan(server.collections["meta"]?["global"]?.modified ?? 0, after)
+        XCTAssertGreaterThan(server.collections["crypto"]?["keys"]?.modified ?? 0, after)
+        // And we should have downloaded meta/global and crypto/keys.
+        XCTAssertNotNil(ready.scratchpad.global)
+        XCTAssertNotNil(ready.scratchpad.keys)
+        // Basic verifications.
+        XCTAssertEqual(ready.collectionKeys.defaultBundle.encKey.length, 32)
+        if let clients = ready.scratchpad.global?.value.engines?["clients"] {
+            XCTAssertTrue(clients.syncID.characters.count == 12)
+        }
+    }
+
+    func testMetaGlobalVersionTooNew() {
+        // There's no recovery from a meta/global version "in the future": just bail out with an UpgradeRequiredError.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 6, engines: [String: EngineMeta](), declined: nil))
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            XCTAssertNotNil(result.failureValue as? UpgradeRequiredError)
+            XCTAssertNil(result.successValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+
+    func testMetaGlobalVersionTooOld() {
+        // To recover from a meta/global version "in the past", fresh start.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 4, engines: [String: EngineMeta](), declined: nil))
+
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testMetaGlobalMissing() {
+        // To recover from a missing meta/global, fresh start.
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testCryptoKeysMissing() {
+        // To recover from a missing crypto/keys, fresh start.
+        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: nil))
+
+        let afterStores = now()
+        let expectation = expectationWithDescription("Waiting on value.")
+        ready().upon { result in
+            self.assertFreshStart(result.successValue, after: afterStores)
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+}

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -67,7 +67,7 @@ class MetaGlobalTests: XCTestCase {
     func ready() -> ReadyDeferred {
         let syncPrefs = MockProfilePrefs()
         let authState: SyncAuthState = MockSyncAuthState(serverRoot: serverRoot, kB: kB)
-        return SyncStateMachine.toReady(authState, prefs: syncPrefs)
+        return SyncStateMachine(prefs: syncPrefs).toReady(authState)
     }
 
     func assertFreshStart(ready: Ready?, after: Timestamp) {
@@ -104,7 +104,6 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
-
 
     func testMetaGlobalVersionTooOld() {
         // To recover from a meta/global version "in the past", fresh start.

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -472,8 +472,9 @@ class MetaGlobalTests: XCTestCase {
         var engines = newMetaGlobal.engines
         engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "bookmarks")
         engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "forms")
+        engines.removeValueForKey("unknownEngine1")
         var declined = newMetaGlobal.declined.filter({ $0 != "forms" })
-        declined.append("passwords")
+        declined.append("unknownEngine1")
         let secondMetaGlobal = MetaGlobal(syncID: newMetaGlobal.syncID, storageVersion: 5, engines: engines, declined: declined)
         storeMetaGlobal(secondMetaGlobal)
 
@@ -490,8 +491,10 @@ class MetaGlobalTests: XCTestCase {
             // ... and we should have downloaded a fresh crypto/keys -- but its timestamp is identical to the old one!
             // Therefore, the "needsFreshCryptoKeys" stage above is our test that we re-downloaded crypto/keys.
 
-            // We should have marked the changed engine and the newly enabled engine for local reset.
-            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "forms"])
+            // We should have marked the changed engine for local reset, and identified the enabled and disabled engines.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks"])
+            XCTAssertEqual(ready.enginesEnabled(), ["forms"])
+            XCTAssertEqual(ready.enginesDisabled(), ["unknownEngine1"])
 
             // And our engine configuration should reflect the new meta/global on the server.
             XCTAssertNotNil(ready.scratchpad.global)

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -49,16 +49,12 @@ class MetaGlobalTests: XCTestCase {
         stateMachine = SyncStateMachine(prefs: syncPrefs)
     }
 
-    func now() -> Timestamp {
-        return Timestamp(1000 * NSDate().timeIntervalSince1970)
-    }
-
     func storeMetaGlobal(metaGlobal: MetaGlobal) {
         let envelope = EnvelopeJSON(JSON([
             "id": "global",
             "collection": "meta",
             "payload": metaGlobal.asPayload().toString(),
-            "modified": Double(NSDate().timeIntervalSince1970)]))
+            "modified": Double(NSDate.now())/1000]))
         server.storeRecords([envelope], inCollection: "meta")
     }
 
@@ -118,7 +114,7 @@ class MetaGlobalTests: XCTestCase {
         // To recover from a meta/global version "in the past", fresh start.
         storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 4, engines: [String: EngineMeta](), declined: []))
 
-        let afterStores = now()
+        let afterStores = NSDate.now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "remoteUpgradeRequired",
@@ -136,7 +132,7 @@ class MetaGlobalTests: XCTestCase {
 
     func testMetaGlobalMissing() {
         // To recover from a missing meta/global, fresh start.
-        let afterStores = now()
+        let afterStores = NSDate.now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
@@ -156,7 +152,7 @@ class MetaGlobalTests: XCTestCase {
         // To recover from a missing crypto/keys, fresh start.
         storeMetaGlobal(createMetaGlobal())
 
-        let afterStores = now()
+        let afterStores = NSDate.now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
@@ -203,7 +199,7 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
-        let afterFirstSync = now()
+        let afterFirstSync = NSDate.now()
 
         // Now, run through the state machine again.  Nothing's changed remotely, so we should advance quickly.
         let secondExpectation = expectationWithDescription("Waiting on value.")
@@ -264,7 +260,7 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
-        let afterFirstSync = now()
+        let afterFirstSync = NSDate.now()
 
         // Store a fresh crypto/keys, with the same default key, one identical collection key, and one changed collection key.
         let freshCryptoKeys = Keys.init(defaultBundle: cryptoKeys.defaultBundle)
@@ -297,7 +293,7 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
-        let afterSecondSync = now()
+        let afterSecondSync = NSDate.now()
 
         // Now store a random crypto/keys, with a different default key (and no bulk keys).
         let randomCryptoKeys = Keys.random()
@@ -434,7 +430,7 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
-        let afterFirstSync = now()
+        let afterFirstSync = NSDate.now()
 
         // Store a meta/global with a new global syncID.
         let newMetaGlobal = metaGlobal.withSyncID("newID")

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -329,16 +329,19 @@ class MetaGlobalTests: XCTestCase {
         }
     }
 
-    func testEngineConfigurations() {
-        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+    private func createUnusualMetaGlobal() -> MetaGlobal {
         let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5,
             engines: ["bookmarks": EngineMeta(version: 1, syncID: "bookmarks"), "unknownEngine1": EngineMeta(version: 2, syncID: "engineId1")],
-            declined: ["clients, forms", "unknownEngine2"])
+            declined: ["clients", "forms", "unknownEngine2"])
+        return metaGlobal
+    }
+
+    func testEngineConfigurations() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+        let metaGlobal = createUnusualMetaGlobal()
         let cryptoKeys = Keys.random()
         storeMetaGlobal(metaGlobal)
         storeCryptoKeys(cryptoKeys)
-
-        let expectedEngineConfiguration = EngineConfiguration(enabled: ["bookmarks", "unknownEngine1"], declined: ["clients", "forms", "unknownEngine2"])
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
@@ -353,7 +356,7 @@ class MetaGlobalTests: XCTestCase {
             guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
                 return
             }
-            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+            XCTAssertEqual(engineConfiguration, metaGlobal.engineConfiguration())
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -381,18 +384,129 @@ class MetaGlobalTests: XCTestCase {
             guard let global = ready.scratchpad.global?.value else {
                 return
             }
-            XCTAssertEqual(global.engineConfiguration(), expectedEngineConfiguration)
+            XCTAssertEqual(global.engineConfiguration(), metaGlobal.engineConfiguration())
 
             // We should have the same cached engine configuration.
             XCTAssertNotNil(ready.scratchpad.engineConfiguration)
             guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
                 return
             }
-            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+            XCTAssertEqual(engineConfiguration, metaGlobal.engineConfiguration())
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testMetaGlobalModified() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        let metaGlobal = createUnusualMetaGlobal()
+        let cryptoKeys = Keys.random()
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // And we should have downloaded meta/global and crypto/keys.
+            XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
+            XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "history", "passwords", "tabs"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterFirstSync = now()
+
+        // Store a meta/global with a new global syncID.
+        let newMetaGlobal = metaGlobal.withSyncID("newID")
+        storeMetaGlobal(newMetaGlobal)
+
+        // Now, run through the state machine again.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have downloaded a fresh meta/global ...
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.global?.timestamp ?? Timestamp.min, afterFirstSync)
+            // ... and we should have downloaded a fresh crypto/keys -- but its timestamp is identical to the old one!
+            // Therefore, the "needsFreshCryptoKeys" stage above is our test that we re-downloaded crypto/keys.
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "history", "passwords", "tabs"])
+
+            // And our engine configuration should be unchanged.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), metaGlobal.engineConfiguration())
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        // Now store a meta/global with a changed engine syncID, a new engine, and a new declined entry.
+        var engines = newMetaGlobal.engines
+        engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "bookmarks")
+        engines.updateValue(EngineMeta(version: 1, syncID: Bytes.generateGUID()), forKey: "forms")
+        var declined = newMetaGlobal.declined.filter({ $0 != "forms" })
+        declined.append("passwords")
+        let secondMetaGlobal = MetaGlobal(syncID: newMetaGlobal.syncID, storageVersion: 5, engines: engines, declined: declined)
+        storeMetaGlobal(secondMetaGlobal)
+
+        // Now, run through the state machine again.
+        let thirdExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have downloaded a fresh meta/global ...
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.global?.timestamp ?? Timestamp.min, afterFirstSync)
+            // ... and we should have downloaded a fresh crypto/keys -- but its timestamp is identical to the old one!
+            // Therefore, the "needsFreshCryptoKeys" stage above is our test that we re-downloaded crypto/keys.
+
+            // We should have marked the changed engine and the newly enabled engine for local reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "forms"])
+
+            // And our engine configuration should reflect the new meta/global on the server.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), secondMetaGlobal.engineConfiguration())
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            thirdExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -103,7 +103,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "clientUpgradeRequired"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "clientUpgradeRequired"])
             XCTAssertNotNil(result.failureValue as? ClientUpgradeRequiredError)
             XCTAssertNil(result.successValue)
             expectation.fulfill()
@@ -121,8 +121,8 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "remoteUpgradeRequired",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "remoteUpgradeRequired",
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -140,7 +140,7 @@ class MetaGlobalTests: XCTestCase {
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal",
-                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+                "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -159,7 +159,7 @@ class MetaGlobalTests: XCTestCase {
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "missingCryptoKeys", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             self.assertFreshStart(result.successValue, after: afterStores)
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -180,7 +180,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -241,7 +241,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -345,7 +345,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -373,7 +373,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.  We should produce and upload a meta/global reflecting our engine configuration.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -412,7 +412,7 @@ class MetaGlobalTests: XCTestCase {
 
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -443,7 +443,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return
@@ -484,7 +484,7 @@ class MetaGlobalTests: XCTestCase {
         // Now, run through the state machine again.
         let thirdExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
-            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobalVersion", "resolveMetaGlobalContent", "hasMetaGlobal", "hasFreshCryptoKeys", "ready"])
             XCTAssertNotNil(result.successValue)
             guard let ready = result.successValue else {
                 return

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -169,9 +169,6 @@ class MetaGlobalTests: XCTestCase {
         storeMetaGlobal(metaGlobal)
         storeCryptoKeys(cryptoKeys)
 
-        var metaGlobalTimestamp: Timestamp!
-        var cryptoKeysTimestamp: Timestamp!
-
         let expectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
             XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
@@ -179,12 +176,14 @@ class MetaGlobalTests: XCTestCase {
             guard let ready = result.successValue else {
                 return
             }
-            metaGlobalTimestamp = ready.scratchpad.global!.timestamp
-            cryptoKeysTimestamp = ready.scratchpad.keys!.timestamp
 
             // And we should have downloaded meta/global and crypto/keys.
             XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
             XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "history", "passwords", "tabs"])
+            ready.clearLocalCommands()
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
@@ -195,6 +194,8 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
 
+        let afterFirstSync = now()
+
         // Now, run through the state machine again.  Nothing's changed remotely, so we should advance quickly.
         let secondExpectation = expectationWithDescription("Waiting on value.")
         stateMachine.toReady(authState).upon { result in
@@ -204,12 +205,114 @@ class MetaGlobalTests: XCTestCase {
                 return
             }
             // And we should have not downloaded a fresh meta/global or crypto/keys.
-            XCTAssertEqual(ready.scratchpad.global?.timestamp, metaGlobalTimestamp)
-            XCTAssertEqual(ready.scratchpad.keys?.timestamp, cryptoKeysTimestamp)
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterFirstSync)
+            XCTAssertLessThan(ready.scratchpad.keys?.timestamp ?? Timestamp.max, afterFirstSync)
+
+            // We should not have marked any local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), [])
 
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testUpdatedCryptoKeys() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.
+        let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: [])
+        let cryptoKeys = Keys.random()
+        cryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "bookmarks")
+        cryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "clients")
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // And we should have downloaded meta/global and crypto/keys.
+            XCTAssertEqual(ready.scratchpad.global?.value, metaGlobal)
+            XCTAssertEqual(ready.scratchpad.keys?.value, cryptoKeys)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "history", "passwords", "tabs"])
+            ready.clearLocalCommands()
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterFirstSync = now()
+
+        // Store a fresh crypto/keys, with the same default key, one identical collection key, and one changed collection key.
+        let freshCryptoKeys = Keys.init(defaultBundle: cryptoKeys.defaultBundle)
+        freshCryptoKeys.collectionKeys.updateValue(cryptoKeys.forCollection("bookmarks"), forKey: "bookmarks")
+        freshCryptoKeys.collectionKeys.updateValue(KeyBundle.random(), forKey: "clients")
+        storeCryptoKeys(freshCryptoKeys)
+
+        // Now, run through the state machine again.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have not downloaded a fresh meta/global ...
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterFirstSync)
+            // ... but we should have downloaded a fresh crypto/keys.
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.keys?.timestamp ?? Timestamp.min, afterFirstSync)
+
+            // We should have marked only the local engine with a changed key for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["clients"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        let afterSecondSync = now()
+
+        // Now store a random crypto/keys, with a different default key (and no bulk keys).
+        let randomCryptoKeys = Keys.random()
+        storeCryptoKeys(randomCryptoKeys)
+
+        // Now, run through the state machine again.
+        let thirdExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+            // And we should have not downloaded a fresh meta/global ...
+            XCTAssertLessThan(ready.scratchpad.global?.timestamp ?? Timestamp.max, afterSecondSync)
+            // ... but we should have downloaded a fresh crypto/keys.
+            XCTAssertGreaterThanOrEqual(ready.scratchpad.keys?.timestamp ?? Timestamp.min, afterSecondSync)
+
+            // We should have marked all local engines for reset.
+            XCTAssertEqual(ready.collectionsThatNeedLocalReset(), ["bookmarks", "clients", "history", "passwords", "tabs"])
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            thirdExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/MetaGlobalTests.swift
+++ b/SyncTests/MetaGlobalTests.swift
@@ -81,6 +81,15 @@ class MetaGlobalTests: XCTestCase {
         // And we should have downloaded meta/global and crypto/keys.
         XCTAssertNotNil(ready.scratchpad.global)
         XCTAssertNotNil(ready.scratchpad.keys)
+
+        // We should have the default engine configuration.
+        XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+        guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+            return
+        }
+        XCTAssertEqual(engineConfiguration.enabled.sort(), ["addons", "bookmarks", "clients", "forms", "history", "passwords", "prefs", "tabs"])
+        XCTAssertEqual(engineConfiguration.declined, [])
+
         // Basic verifications.
         XCTAssertEqual(ready.collectionKeys.defaultBundle.encKey.length, 32)
         if let clients = ready.scratchpad.global?.value.engines["clients"] {
@@ -145,7 +154,7 @@ class MetaGlobalTests: XCTestCase {
 
     func testCryptoKeysMissing() {
         // To recover from a missing crypto/keys, fresh start.
-        storeMetaGlobal(MetaGlobal(syncID: "id", storageVersion: 5, engines: [String: EngineMeta](), declined: []))
+        storeMetaGlobal(createMetaGlobal())
 
         let afterStores = now()
         let expectation = expectationWithDescription("Waiting on value.")
@@ -313,6 +322,77 @@ class MetaGlobalTests: XCTestCase {
             XCTAssertTrue(result.isSuccess)
             XCTAssertNil(result.failureValue)
             thirdExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+    }
+
+    func testEngineConfigurations() {
+        // When encountering a valid meta/global and crypto/keys, advance smoothly.  Keep the engine configuration for re-upload.
+        let metaGlobal = MetaGlobal(syncID: "id", storageVersion: 5,
+            engines: ["bookmarks": EngineMeta(version: 1, syncID: "bookmarks"), "unknownEngine1": EngineMeta(version: 2, syncID: "engineId1")],
+            declined: ["clients, forms", "unknownEngine2"])
+        let cryptoKeys = Keys.random()
+        storeMetaGlobal(metaGlobal)
+        storeCryptoKeys(cryptoKeys)
+
+        let expectedEngineConfiguration = EngineConfiguration(enabled: ["bookmarks", "unknownEngine1"], declined: ["clients", "forms", "unknownEngine2"])
+
+        let expectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // We should have saved the engine configuration.
+            XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+            guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+                return
+            }
+            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(2000) { (error) in
+            XCTAssertNil(error, "\(error)")
+        }
+
+        // Wipe meta/global.
+        server.collections["meta"]?.removeAll()
+
+        // Now, run through the state machine again.  We should produce and upload a meta/global reflecting our engine configuration.
+        let secondExpectation = expectationWithDescription("Waiting on value.")
+        stateMachine.toReady(authState).upon { result in
+            XCTAssertEqual(self.stateMachine.stateLabelSequence.map { $0.rawValue }, ["initialWithLiveToken", "initialWithLiveTokenAndInfo", "missingMetaGlobal", "freshStartRequired", "serverConfigurationRequired", "initialWithLiveToken", "initialWithLiveTokenAndInfo", "resolveMetaGlobal", "hasMetaGlobal", "needsFreshCryptoKeys", "hasFreshCryptoKeys", "ready"])
+            XCTAssertNotNil(result.successValue)
+            guard let ready = result.successValue else {
+                return
+            }
+
+            // The downloaded meta/global should reflect our local engine configuration.
+            XCTAssertNotNil(ready.scratchpad.global)
+            guard let global = ready.scratchpad.global?.value else {
+                return
+            }
+            XCTAssertEqual(global.engineConfiguration(), expectedEngineConfiguration)
+
+            // We should have the same cached engine configuration.
+            XCTAssertNotNil(ready.scratchpad.engineConfiguration)
+            guard let engineConfiguration = ready.scratchpad.engineConfiguration else {
+                return
+            }
+            XCTAssertEqual(engineConfiguration, expectedEngineConfiguration)
+
+            XCTAssertTrue(result.isSuccess)
+            XCTAssertNil(result.failureValue)
+            secondExpectation.fulfill()
         }
 
         waitForExpectationsWithTimeout(2000) { (error) in

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -133,10 +133,10 @@ class RecordTests: XCTestCase {
             "\"username\":\"5817483\"," +
             "\"modified\":1.32046073744E9}"
 
-        let record = GlobalEnvelope(fullRecord)
+        let record = EnvelopeJSON(fullRecord)
         XCTAssertTrue(record.isValid())
 
-        let global = MetaGlobal.fromPayload(JSON.parse(record.payload))
+        let global = MetaGlobal.fromJSON(JSON.parse(record.payload))
         XCTAssertTrue(global != nil)
 
         if let global = global {

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -140,13 +140,11 @@ class RecordTests: XCTestCase {
         XCTAssertTrue(global != nil)
 
         if let global = global {
-            XCTAssertTrue(global.declined != nil)
-            XCTAssertTrue(global.engines != nil)
-            XCTAssertEqual(["bookmarks"], global.declined!)
+            XCTAssertEqual(["bookmarks"], global.declined)
             XCTAssertEqual(5, global.storageVersion)
             let modified = record.modified
             XCTAssertTrue(1320460737440 == modified)
-            let forms = global.engines!["forms"]
+            let forms = global.engines["forms"]
             let syncID = forms!.syncID
             XCTAssertEqual("GXF29AFprnvc", syncID)
 

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -27,6 +27,7 @@ func compareScratchpads(lhs: Scratchpad, rhs: Scratchpad) {
 
     XCTAssertTrue(lhs.global == rhs.global)
     XCTAssertEqual(lhs.localCommands, rhs.localCommands)
+    XCTAssertEqual(lhs.engineConfiguration, rhs.engineConfiguration)
 }
 
 func roundtrip(s: Scratchpad) -> (Scratchpad, rhs: Scratchpad) {
@@ -39,6 +40,10 @@ class StateTests: XCTestCase {
     func getGlobal() -> Fetched<MetaGlobal> {
         let g = MetaGlobal(syncID: "abcdefghiklm", storageVersion: 5, engines: ["bookmarks": EngineMeta(version: 1, syncID: "dddddddddddd")], declined: ["tabs"])
         return Fetched(value: g, timestamp: NSDate.now())
+    }
+
+    func getEngineConfiguration() -> EngineConfiguration {
+        return EngineConfiguration(enabled: ["bookmarks", "clients"], declined: ["tabs"])
     }
 
     func baseScratchpad() -> Scratchpad {
@@ -56,5 +61,6 @@ class StateTests: XCTestCase {
         compareScratchpads(roundtrip(baseScratchpad()))
         compareScratchpads(roundtrip(baseScratchpad().evolve().setGlobal(getGlobal()).build()))
         compareScratchpads(roundtrip(baseScratchpad().evolve().clearLocalCommands().build()))
+        compareScratchpads(roundtrip(baseScratchpad().evolve().setEngineConfiguration(getEngineConfiguration()).build()))
     }
 }

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -11,7 +11,6 @@ func compareScratchpads(lhs: Scratchpad, rhs: Scratchpad) {
     // This one is set in the constructor!
     XCTAssertEqual(lhs.syncKeyBundle, rhs.syncKeyBundle)
 
-    XCTAssertEqual(lhs.collectionLastFetched, rhs.collectionLastFetched)
     XCTAssertEqual(lhs.clientName, rhs.clientName)
     XCTAssertEqual(lhs.clientGUID, rhs.clientGUID)
     if let lkeys = lhs.keys {

--- a/SyncTests/StateTests.swift
+++ b/SyncTests/StateTests.swift
@@ -51,6 +51,8 @@ class StateTests: XCTestCase {
         let b = Scratchpad(b: syncKeyBundle, persistingTo: MockProfilePrefs()).evolve()
         b.setKeys(keys)
         b.localCommands = Set([
+            .EnableEngine(engine: "tabs"),
+            .DisableEngine(engine: "passwords"),
             .ResetAllEngines(except: Set(["bookmarks", "clients"])),
             .ResetEngine(engine: "clients")])
         return b.build()


### PR DESCRIPTION
With review comments mostly addressed.

I talked to rfkelly and I'm not concerned about node allocations: a client will never see a node allocation that results in a non-blank server, which means our fresh start logic will apply.  (We'll upload a fresh `meta/global` with a new global sync ID, triggering the local resets needed.)