### PR TITLE
Bug 1212728 - Update yahoo-jp.xml search plugin to add affiliate code…

### DIFF
--- a/Client/Assets/SearchPlugins/ja/yahoo-jp.xml
+++ b/Client/Assets/SearchPlugins/ja/yahoo-jp.xml
@@ -10,7 +10,7 @@
 <Url type="text/html" method="GET" template="http://search.yahoo.co.jp/search">
   <Param name="p" value="{searchTerms}"/>
   <Param name="ei" value="UTF-8"/>
-  <MozParam name="fr" condition="pref" pref="yahoo-fr-ja" />
+  <Param name="fr" value="mozff" />
 </Url>
 <SearchForm>http://search.yahoo.co.jp/</SearchForm>
 </SearchPlugin>


### PR DESCRIPTION
Pick up the latest search plugin of Yahoo! Japan from bug 1200170.

Affiliate code is set by MozParam, but MozParam isn't supported on some platform such as Firefox Android and iOS.  We should use Param instead of MozParam.