### PR TITLE
Bug 1213157 - Use correct case for accessing livemark fields.

### DIFF
--- a/Storage/Bookmarks.swift
+++ b/Storage/Bookmarks.swift
@@ -38,8 +38,8 @@ public struct BookmarkMirrorItem {
     let parentName: String?
 
     // Livemarks.
-    let feedURI: String?
-    let siteURI: String?
+    public let feedURI: String?
+    public let siteURI: String?
 
     // Separators.
     let pos: Int?

--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -495,8 +495,8 @@ extension LivemarkPayload: MirrorItemable {
             parentName: self["parentName"].asString!,
             title: self["title"].asString!,
             description: self["description"].asString,
-            feedURI: self["feedURI"].asString!,
-            siteURI: self["siteURI"].asString!
+            feedURI: self.feedURI!,
+            siteURI: self.siteURI!
         )
     }
 }

--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -66,6 +66,14 @@ public enum BookmarkType: String {
 }
 
 public class LivemarkPayload: BookmarkBasePayload {
+    public var feedURI: String? {
+        return self["feedUri"].asString
+    }
+
+    public var siteURI: String? {
+        return self["siteUri"].asString
+    }
+
     override public func isValid() -> Bool {
         if !super.isValid() {
             return false
@@ -86,11 +94,11 @@ public class LivemarkPayload: BookmarkBasePayload {
             return true
         }
 
-        if self["feedUri"].asString != p["feedUri"].asString {
+        if self.feedURI != p.feedURI {
             return false
         }
 
-        if self["siteUri"].asString != p["siteUri"].asString {
+        if self.siteURI != p.siteURI {
             return false
         }
 

--- a/SyncTests/DownloadTests.swift
+++ b/SyncTests/DownloadTests.swift
@@ -76,7 +76,7 @@ class DownloadTests: XCTestCase {
         let rec2 = MockSyncServer.makeValidEnvelope(guid2, modified: ts2)
 
         let server = getServer()
-        server.storeRecords([rec1], inCollection: "clients")
+        server.storeRecords([rec1], inCollection: "clients", now: ts1)
 
         let storageClient = getClient(server)!
         let bookmarksClient = storageClient.clientForCollection("clients", encrypter: getEncrypter())
@@ -99,7 +99,7 @@ class DownloadTests: XCTestCase {
         batcher.reset().value
 
         let ic2 = InfoCollections(collections: ["clients": ts2])
-        server.storeRecords([rec2], inCollection: "clients")
+        server.storeRecords([rec2], inCollection: "clients", now: ts2)
         let fetch2 = batcher.go(ic2, limit: 1).value
         XCTAssertEqual(fetch2.successValue, DownloadEndState.Incomplete)
         let records2 = batcher.retrieve()

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -224,6 +224,7 @@ class RecordTests: XCTestCase {
         ])
         let folder = BookmarkType.payloadFromJSON(validFolder)!
         XCTAssertTrue(folder is FolderPayload)
+        XCTAssertTrue(folder.isValid() ?? false)
         XCTAssertEqual((folder as! FolderPayload).children, ["foo", "bar"])
     }
 
@@ -241,6 +242,54 @@ class RecordTests: XCTestCase {
 
         let bookmark = BookmarkType.payloadFromJSON(json)
         XCTAssertTrue(bookmark is FolderPayload)
+        XCTAssertTrue(bookmark?.isValid() ?? false)
+    }
+
+    func testLivemark() {
+        let json = JSON([
+            "id": "M5bwUKK8hPyF",
+            "type": "livemark",
+            "siteUri": "http://www.bbc.co.uk/go/rss/int/news/-/news/",
+            "feedUri": "http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml",
+            "parentName": "Bookmarks Toolbar",
+            "parentid": "toolbar",
+            "title": "Latest Headlines",
+            "description": "",
+            "children":
+            ["7oBdEZB-8BMO", "SUd1wktMNCTB", "eZe4QWzo1BcY", "YNBhGwhVnQsN",
+            "92Aw2SMEkFg0", "uw0uKqrVFwd-", "x7mx2P3--8FJ", "d-jVF8UuC9Ye",
+            "DV1XVtKLEiZ5", "g4mTaTjr837Z", "1Zi5W3lwBw8T", "FEYqlUHtbBWS",
+            "qQd2u7LjosCB", "VUs2djqYfbvn", "KuhYnHocu7eg", "u2gcg9ILRg-3",
+            "hfK_RP-EC7Ol", "Aq5qsa4E5msH", "6pZIbxuJTn-K", "k_fp0iN3yYMR",
+            "59YD3iNOYO8O", "01afpSdAk2iz", "Cq-kjXDEPIoP", "HtNTjt9UwWWg",
+            "IOU8QRSrTR--", "HJ5lSlBx6d1D", "j2dz5R5U6Khc", "5GvEjrNR0yJl",
+            "67ozIBF5pNVP", "r5YB0cUx6C_w", "FtmFDBNxDQ6J", "BTACeZq9eEtw",
+            "ll4ozQ-_VNJe", "HpImsA4_XuW7", "nJvCUQPLSXwA", "94LG-lh6TUYe",
+            "WHn_QoOL94Os", "l-RvjgsZYlej", "LipQ8abcRstN", "74TiLvarE3n_",
+            "8fCiLQpQGK1P", "Z6h4WkbwfQFa", "GgAzhqakoS6g", "qyt92T8vpMsK",
+            "RyOgVCe2EAOE", "bgSEhW3w6kk5", "hWODjHKGD7Ph", "Cky673aqOHbT",
+            "gZCYT7nx3Nwu", "iJzaJxxrM58L", "rUHCRv68aY5L", "6Jc1hNJiVrV9",
+            "lmNgoayZ-ym8", "R1lyXsDzlfOd", "pinrXwDnRk6g", "Sn7TmZV01vMM",
+            "qoXyU6tcS1dd", "TRLanED-QfBK", "xHbhMeX_FYEA", "aPqacdRlAtaW",
+            "E3H04Wn2RfSi", "eaSIMI6kSrcz", "rtkRxFoG5Vqi", "dectkUglV0Dz",
+            "B4vUE0BE15No", "qgQFW5AQrgB0", "SxAXvwOhu8Zi", "0S6cRPOg-5Z2",
+            "zcZZBGeLnaWW", "B0at8hkQqVZQ", "sgPtgGulbP66", "lwtwGHSCPYaQ",
+            "mNTdpgoRZMbW", "-L8Vci6CbkJY", "bVzudKSQERc1", "Gxl9lb4DXsmL",
+            "3Qr13GucOtEh"]])
+
+        let bookmark = BookmarkType.payloadFromJSON(json)
+        XCTAssertTrue(bookmark is LivemarkPayload)
+
+        let livemark = bookmark as! LivemarkPayload
+        XCTAssertTrue(livemark.isValid() ?? false)
+        let siteURI = "http://www.bbc.co.uk/go/rss/int/news/-/news/"
+        let feedURI = "http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml"
+        XCTAssertEqual(feedURI, livemark.feedURI)
+        XCTAssertEqual(siteURI, livemark.siteURI)
+
+        let m = (livemark as MirrorItemable).toMirrorItem(NSDate.now())
+        XCTAssertEqual("http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml", m.feedURI)
+        XCTAssertEqual("http://www.bbc.co.uk/go/rss/int/news/-/news/", m.siteURI)
     }
 
     func testMobileBookmark() {
@@ -259,6 +308,7 @@ class RecordTests: XCTestCase {
 
         let bookmark = BookmarkType.payloadFromJSON(json)
         XCTAssertTrue(bookmark is BookmarkPayload)
+        XCTAssertTrue(bookmark?.isValid() ?? false)
     }
 
     func testBookmarks() {
@@ -305,6 +355,5 @@ class RecordTests: XCTestCase {
 
         // The mirror item has a translated GUID.
         XCTAssertEqual(BookmarkRoots.RootGUID, pMirror.guid)
-
     }
 }


### PR DESCRIPTION
Our `isValid` method was correct, but our mirror translator was incorrect. This PR makes them match and adds a test to exercise this behavior.