### PR TITLE
Bug 1199370 – Better top site domain extraction

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -387,7 +387,7 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         //
         // Instead we'll painstakingly re-extract those things here.
 
-        let domainURL = NSURL(string: site.url)?.normalizedHost() ?? site.url
+        let domainURL = NSURL(string: site.url)?.baseDomain() ?? site.url
         cell.textLabel.text = domainURL
         cell.imageWrapper.backgroundColor = UIColor.clearColor()
 


### PR DESCRIPTION
There are no good solutions to this problem, because Top Sites is explicitly not Top URLs, and mapping multiple URLs to a single common URL can never be canonical.