### PR TITLE
Bug 1212536 - When Account requires no action, don't go to /force_auth.

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -325,10 +325,7 @@ private class AccountStatusSetting: WithAccountSetting {
                 viewController.url = cs?.URL
             case .None, .NeedsUpgrade:
                 // In future, we'll want to link to /settings and an upgrade page, respectively.
-                if let cs = NSURLComponents(URL: account.configuration.forceAuthURL, resolvingAgainstBaseURL: false) {
-                    cs.queryItems?.append(NSURLQueryItem(name: "email", value: account.email))
-                    viewController.url = cs.URL
-                }
+                return
             }
         }
         navigationController?.pushViewController(viewController, animated: true)


### PR DESCRIPTION
This was fallout from Bug 1184700, which simply added incorrect
behaviour; the bad commit was
https://github.com/mozilla/firefox-ios/tree/0351129b72be1617814be28ed1311962c366ad31.