### PR TITLE
Bug 1184344 – Screenshot page as it is loaded in the background.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1563,6 +1563,15 @@ extension BrowserViewController: WKNavigationDelegate {
             // VoiceOver will sometimes be stuck on the element, not allowing user to move
             // forward/backward. Strange, but LayoutChanged fixes that.
             UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+        } else {
+            // Tab is in the backgroud, but we want to be able to see it in the TabTray.
+            // Delay 100ms to let the tab render (it doesn't work without the delay)
+            // before screenshotting.
+            let time = dispatch_time(DISPATCH_TIME_NOW, Int64(100 * NSEC_PER_MSEC))
+            dispatch_after(time, dispatch_get_main_queue()) {
+                let screenshot = self.screenshotHelper.takeScreenshot(tab, aspectRatio: 0, quality: 1)
+                tab.setScreenshot(screenshot)
+            }
         }
 
         addOpenInViewIfNeccessary(webView.URL)


### PR DESCRIPTION
Prefer this approach to iterating tabs without screenshots.

For pathological cases, with lots (10) of background tabs open, and a 100 ms cost of screen shot, iterating through tabs when the tab tray is summoned guarantees a 1 s delay.

Screen shot on didFinishNavigation means that the tab tray gets a best effort immediately, and the worst is 1 seconds of janky scroll.

This does the screenshotting as each page is loaded. 