### PR TITLE
Bug 1212923 - Fetch records oldest-first and apply record-timestamp batching.

### DIFF
--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
 import Shared

--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -260,7 +260,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         let (offset, since) = self.fetchParameters()
         log.debug("Fetching newer=\(since), offset=\(offset).")
 
-        let fetch = self.client.getSince(since, sort: SortOption.Newest, limit: limit, offset: offset)
+        let fetch = self.client.getSince(since, sort: SortOption.Oldest, limit: limit, offset: offset)
 
         func handleFailure(err: MaybeErrorType) -> Deferred<Maybe<DownloadEndState>> {
             log.debug("Handling failure.")
@@ -286,11 +286,10 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
             // If there are records, advance to just before the timestamp of the last.
             // If our next fetch with X-Weave-Next-Offset fails, at least we'll start here.
             //
-            // Without Bug 1212189 we get records in the wrong order, and this approach doesn't work.
-            // Commented out until then.
+            // This approach is only valid if we're fetching oldest-first.
             if let newBase = response.value.last?.modified {
-                // TODO
-                // self.baseTimestamp = newBase - 1
+                log.debug("Advancing baseTimestamp to \(newBase) - 1")
+                self.baseTimestamp = newBase - 1
             }
 
             log.debug("Got success response with \(response.metadata.records) records.")

--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -260,7 +260,7 @@ class BatchingDownloader<T: CleartextPayloadJSON> {
         let (offset, since) = self.fetchParameters()
         log.debug("Fetching newer=\(since), offset=\(offset).")
 
-        let fetch = self.client.getSince(since, sort: SortOption.Oldest, limit: limit, offset: offset)
+        let fetch = self.client.getSince(since, sort: SortOption.OldestFirst, limit: limit, offset: offset)
 
         func handleFailure(err: MaybeErrorType) -> Deferred<Maybe<DownloadEndState>> {
             log.debug("Handling failure.")

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -169,6 +169,7 @@ private func optionalUIntegerHeader(input: AnyObject?) -> Timestamp? {
 
 public enum SortOption: String {
     case Newest = "newest"
+    case Oldest = "oldest"
     case Index = "index"
 }
 

--- a/Sync/StorageClient.swift
+++ b/Sync/StorageClient.swift
@@ -168,8 +168,8 @@ private func optionalUIntegerHeader(input: AnyObject?) -> Timestamp? {
 }
 
 public enum SortOption: String {
-    case Newest = "newest"
-    case Oldest = "oldest"
+    case NewestFirst = "newest"
+    case OldestFirst = "oldest"
     case Index = "index"
 }
 

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -23,7 +23,6 @@ private func optStringArray(x: AnyObject?) -> [String]? {
     return str.componentsSeparatedByString(",").map { $0.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
 }
 
-// TODO: flesh out.
 private struct SyncRequestSpec {
     let collection: String
     let id: String?
@@ -55,6 +54,8 @@ private struct SyncRequestSpec {
 
         let sort: SortOption?
         switch request.query["sort"] as? String ?? "" {
+        case "oldest":
+            sort = SortOption.OldestFirst
         case "newest":
             sort = SortOption.NewestFirst
         case "index":

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -253,6 +253,8 @@ class MockSyncServer {
             switch sort {
             case SortOption.Newest:
                 items.sortInPlace { $0.modified < $1.modified }
+            case SortOption.Oldest:
+                items.sortInPlace { $0.modified > $1.modified }
             case SortOption.Index:
                 log.warning("Index sorting not yet supported.")
             }

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -56,7 +56,7 @@ private struct SyncRequestSpec {
         let sort: SortOption?
         switch request.query["sort"] as? String ?? "" {
         case "newest":
-            sort = SortOption.Newest
+            sort = SortOption.NewestFirst
         case "index":
             sort = SortOption.Index
         default:
@@ -251,9 +251,9 @@ class MockSyncServer {
 
         if let sort = spec.sort {
             switch sort {
-            case SortOption.Newest:
+            case SortOption.NewestFirst:
                 items.sortInPlace { $0.modified < $1.modified }
-            case SortOption.Oldest:
+            case SortOption.OldestFirst:
                 items.sortInPlace { $0.modified > $1.modified }
             case SortOption.Index:
                 log.warning("Index sorting not yet supported.")


### PR DESCRIPTION
Tested against stage:

```
2015-10-12 18:58:04.656 [Debug] [BookmarksDownloader.swift:279] handleSuccess > Handling success.
2015-10-12 18:58:04.657 [Debug] [BookmarksDownloader.swift:291] handleSuccess > Advancing baseTimestamp to 1444701453870 - 1
2015-10-12 18:58:04.657 [Debug] [BookmarksDownloader.swift:295] handleSuccess > Got success response with Optional(5) records.
…
2015-10-12 18:58:04.796 [Debug] [BookmarksDownloader.swift:279] handleSuccess > Handling success.
2015-10-12 18:58:04.797 [Debug] [BookmarksDownloader.swift:291] handleSuccess > Advancing baseTimestamp to 1444701466260 - 1
2015-10-12 18:58:04.797 [Debug] [BookmarksDownloader.swift:295] handleSuccess > Got success response with Optional(4) records.
2015-10-12 18:58:04.797 [Debug] [BookmarksDownloader.swift:307] handleSuccess > Advancing lastModified to Optional(1444701466260) ?? 1444701466260.
```