### PR TITLE
Bug 1211991 - Removed frecency query on rotate. Replaced with fixed query and reload data

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -26,6 +26,13 @@ class TopSitesPanel: UIViewController {
     }()
     private lazy var layout: TopSitesLayout = { return TopSitesLayout() }()
 
+    private lazy var maxFrecencyLimit: Int = {
+        return max(
+            self.calculateApproxThumbnailCountForOrientation(UIInterfaceOrientation.LandscapeLeft),
+            self.calculateApproxThumbnailCountForOrientation(UIInterfaceOrientation.Portrait)
+        )
+    }()
+
     var editingThumbnails: Bool = false {
         didSet {
             if editingThumbnails != oldValue {
@@ -76,7 +83,7 @@ class TopSitesPanel: UIViewController {
             make.edges.equalTo(self.view)
         }
         self.collection = collection
-        self.refreshHistory(maxFrecencyLimit())
+        self.refreshHistory(maxFrecencyLimit)
     }
 
     deinit {
@@ -87,7 +94,7 @@ class TopSitesPanel: UIViewController {
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
         case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
-            refreshHistory(maxFrecencyLimit())
+            refreshHistory(maxFrecencyLimit)
             break
         default:
             // no need to do anything at all
@@ -155,19 +162,6 @@ class TopSitesPanel: UIViewController {
                 self.updateRemoveButtonStates()
             })
         }
-    }
-
-    /**
-    Finds an approximation of the maximum number of top site tiles we will need to show regardless
-    of the current orientation.
-
-    - returns: Maximum number of tiles we should query for when fetching frecency results to fill the grid
-    */
-    private func maxFrecencyLimit() -> Int {
-        return max(
-            calculateApproxThumbnailCountForOrientation(.LandscapeLeft),
-            calculateApproxThumbnailCountForOrientation(.Portrait)
-        )
     }
 
     /**

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -10,6 +10,7 @@ import Storage
 private let log = Logger.browserLogger
 
 private let ThumbnailIdentifier = "Thumbnail"
+private let FrecencyLimit = 20
 
 extension UIView {
     public class func viewOrientationForSize(size: CGSize) -> UIInterfaceOrientation {
@@ -44,8 +45,8 @@ class TopSitesPanel: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        self.refreshHistory(self.layout.thumbnailCount)
         self.layout.setupForOrientation(UIView.viewOrientationForSize(size))
+        self.collection?.reloadData()
     }
 
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
@@ -76,7 +77,7 @@ class TopSitesPanel: UIViewController {
             make.edges.equalTo(self.view)
         }
         self.collection = collection
-        self.refreshHistory(layout.thumbnailCount)
+        self.refreshHistory(FrecencyLimit)
     }
 
     deinit {
@@ -87,7 +88,7 @@ class TopSitesPanel: UIViewController {
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
         case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
-            refreshHistory(self.layout.thumbnailCount)
+            refreshHistory(FrecencyLimit)
             break
         default:
             // no need to do anything at all


### PR DESCRIPTION
Instead of requerying on rotation which produced the same values, I've changed it to only query on viewWillAppear with the maximum number of items that can be displayed so we no longer need to query on rotation since the layouts will display a subset of the original queried content.