### PR TITLE
Bug 1215558 - Retain profile when reloading clients in Send To extension.

### DIFF
--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -132,10 +132,18 @@ class ClientPickerViewController: UITableViewController {
     }
 
     private func reloadClients() {
+        guard let profile = self.profile else {
+            return
+        }
+
         reloading = true
-        profile?.getClients().upon({ result in
-            self.reloading = false
-            if let c = result.successValue {
+        profile.getClients().upon({ result in
+            withExtendedLifetime(profile) {
+                self.reloading = false
+                guard let c = result.successValue else {
+                    return
+                }
+
                 self.clients = c
                 dispatch_async(dispatch_get_main_queue()) {
                     if self.clients.count == 0 {


### PR DESCRIPTION
This is another application of the pattern in f80cd8d.

This fixes my artificial replication of the bug, and matches the hints in the stack: we can't have a deallocated profile at the point indicated, because we're explicitly retaining it until our closure returns.