### PR TITLE
Fixes 1215972 - Better audio session interruption handling

### DIFF
--- a/Client/Frontend/Widgets/AuralProgressBar.swift
+++ b/Client/Frontend/Widgets/AuralProgressBar.swift
@@ -50,11 +50,13 @@ class AuralProgressBar {
 
             connectPlayerNodes()
 
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("audioEngineConfigurationDidChange:"), name: AVAudioEngineConfigurationChangeNotification, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("handleAudioEngineConfigurationDidChangeNotification:"), name: AVAudioEngineConfigurationChangeNotification, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("handleAudioSessionInterruptionNotification:"), name: AVAudioSessionInterruptionNotification, object: nil)
         }
 
         deinit {
             NSNotificationCenter.defaultCenter().removeObserver(self, name: AVAudioEngineConfigurationChangeNotification, object: nil)
+            NSNotificationCenter.defaultCenter().removeObserver(self, name: AVAudioSessionInterruptionNotification, object: nil)
         }
 
         func connectPlayerNodes() {
@@ -68,16 +70,38 @@ class AuralProgressBar {
             engine.disconnectNodeOutput(progressPlayer)
         }
 
-        @objc func audioEngineConfigurationDidChange(notification: NSNotification) {
-            disconnectPlayerNodes()
-            connectPlayerNodes()
-
+        func startEngine() {
             if !engine.running {
-                do { try engine.start() }
-                catch {
-                    log.error("Unable to restart AVAudioEngine. Player will not automatically restart : \(error)")
+                do {
+                    try engine.start()
+                } catch {
+                    log.error("Unable to start AVAudioEngine: \(error)")
                 }
             }
+        }
+
+        @objc func handleAudioSessionInterruptionNotification(notification: NSNotification) {
+            if let interruptionTypeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt {
+                if let interruptionType = AVAudioSessionInterruptionType(rawValue: interruptionTypeValue) {
+                    switch interruptionType {
+                    case .Began:
+                        tickPlayer.stop()
+                        progressPlayer.stop()
+                    case .Ended:
+                        if let interruptionOptionValue = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt {
+                            let interruptionOption = AVAudioSessionInterruptionOptions(rawValue: interruptionOptionValue)
+                            if interruptionOption == .ShouldResume {
+                                startEngine()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        @objc func handleAudioEngineConfigurationDidChangeNotification(notification: NSNotification) {
+            disconnectPlayerNodes()
+            connectPlayerNodes()
         }
 
         func start() {


### PR DESCRIPTION
This patch includes some minor changes to the handling of audio session interruptions.

* When we receive a `AVAudioEngineConfigurationChangeNotification` we only rebuild the audio node graph and do not try to start the audio again
* We now also listen to `AVAudioSessionInterruptionNotification` where we either stop the two `AVAudioPlayerNode` instances or we (re)start the engine.

Tested with the reported STR:

* With headphones plugged into your iPhone visit a site with some sort of streaming media content (e.g, http://espn.go.com)
* Start watching a video
* During playback hit the power button on your iPhone to turn the screen off
* Remove headphones
* Turn on the phone and open Firefox, it will consistently crash

Also tested with *VoiceOver* enabled to make sure that the `AuralProgressBar` keeps working.