### PR TITLE
Bug 1215590 - Redefine URLAllowedCharacterSet

### DIFF
--- a/Utils/Extensions/NSCharacterSetExtensions.swift
+++ b/Utils/Extensions/NSCharacterSetExtensions.swift
@@ -6,13 +6,6 @@ import Foundation
 
 extension NSCharacterSet {
     public static func URLAllowedCharacterSet() -> NSCharacterSet {
-        let characterSet = NSMutableCharacterSet()
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLQueryAllowedCharacterSet())
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLUserAllowedCharacterSet())
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLPathAllowedCharacterSet())
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLPasswordAllowedCharacterSet())
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLHostAllowedCharacterSet())
-        characterSet.formUnionWithCharacterSet(NSCharacterSet.URLFragmentAllowedCharacterSet())
-        return characterSet
+        return NSCharacterSet(charactersInString: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%")
     }
 }


### PR DESCRIPTION
Annoyingly, iOS doesn't provide a character set that includes all valid characters for a URL. Even with our big union of all the URL character sets, it looks like we still don't cover everything; in this case, it looks like we're double-escaping `%`s.

This fix replaces that union with a single string of all the valid URL characters.