### PR TITLE
Fixes 1216545 - Crash in libAVFAudio.dylib

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -3641,6 +3641,9 @@
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
 							};
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
 							com.apple.Keychain = {
 								enabled = 1;
 							};


### PR DESCRIPTION
This patch adds *audio* as a required background mode. This prevents the crash and also makes the app behave similar to Safari wrt audio. You can now for example start a podcast in a tab, answer a phone call, or play a game, and the podcast will be correctly suspended and resumed.