### PR TITLE
Bug 1217181 - Fix TabManagerTests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A994951A3686BD008AD1AC /* BrowserViewController.swift */; };
 		D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A994961A3686BD008AD1AC /* Browser.swift */; };
 		D3ACB4541AD33F2200748D50 /* WeakList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ACB4381AD33EBA00748D50 /* WeakList.swift */; };
+		D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */; settings = {ASSET_TAGS = (); }; };
 		D3BA7E0C1B0E902A00153782 /* ContextMenu.js in Resources */ = {isa = PBXBuildFile; fileRef = D3BA7E0B1B0E902A00153782 /* ContextMenu.js */; };
 		D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */; };
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
@@ -1622,6 +1623,7 @@
 		D3A994951A3686BD008AD1AC /* BrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserViewController.swift; sourceTree = "<group>"; };
 		D3A994961A3686BD008AD1AC /* Browser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
 		D3ACB4381AD33EBA00748D50 /* WeakList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakList.swift; sourceTree = "<group>"; };
+		D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
 		D3BA7E0B1B0E902A00153782 /* ContextMenu.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ContextMenu.js; sourceTree = "<group>"; };
 		D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextMenuHelper.swift; sourceTree = "<group>"; };
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -3051,6 +3053,7 @@
 				4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */,
 				0BE108351A1B1EC700D4B712 /* TestLocking.swift */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
+				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
 			);
 			path = ClientTests;
@@ -4785,6 +4788,7 @@
 				2F834D1B1A80629A006A0B7B /* FxAContentViewController.swift in Sources */,
 				D3FA77971A43B5390010CD32 /* OpenSearch.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
+				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				7BBFEEA11BB40A0800A305AA /* ReaderModeCache.swift in Sources */,
 				D38B2D441A8D96D00040E6B5 /* GCDWebServerMultiPartFormRequest.m in Sources */,
 				E42475DD1AB73B9B00B23D33 /* SWCellScrollView.m in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -250,14 +250,14 @@ extension AppDelegate: UINavigationControllerDelegate {
 }
 
 extension AppDelegate: TabManagerStateDelegate {
-    func tabManagerDidStoreChanges(tabManager: TabManager) {
+    func tabManagerWillStoreTabs(tabs: [Browser]) {
         // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
-        let storedTabs: [RemoteTab] = tabManager.normalTabs.flatMap( Browser.toTab )
+        let storedTabs: [RemoteTab] = tabs.flatMap( Browser.toTab )
 
         // Don't insert into the DB immediately. We tend to contend with more important
         // work like querying for top sites.
         let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(100 * NSEC_PER_MSEC)), queue) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(ProfileRemoteTabsSyncDelay * Double(NSEC_PER_MSEC))), queue) {
             self.profile?.storeTabs(storedTabs)
         }
     }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -45,7 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window!.backgroundColor = UIColor.whiteColor()
 
         let defaultRequest = NSURLRequest(URL: UIConstants.DefaultHomePage)
-        self.tabManager = TabManager(defaultNewTabRequest: defaultRequest, profile: profile)
+        let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
+        self.tabManager = TabManager(defaultNewTabRequest: defaultRequest, prefs: profile.prefs, imageStore: imageStore)
+        self.tabManager.stateDelegate = self
         browserViewController = BrowserViewController(profile: profile, tabManager: self.tabManager)
 
         // Add restoration class, the factory that will return the ViewController we 
@@ -244,6 +246,20 @@ extension AppDelegate: UINavigationControllerDelegate {
             } else {
                 return nil
             }
+    }
+}
+
+extension AppDelegate: TabManagerStateDelegate {
+    func tabManagerDidStoreChanges(tabManager: TabManager) {
+        // It is possible that not all tabs have loaded yet, so we filter out tabs with a nil URL.
+        let storedTabs: [RemoteTab] = tabManager.normalTabs.flatMap( Browser.toTab )
+
+        // Don't insert into the DB immediately. We tend to contend with more important
+        // work like querying for top sites.
+        let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(100 * NSEC_PER_MSEC)), queue) {
+            self.profile?.storeTabs(storedTabs)
+        }
     }
 }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -17,7 +17,7 @@ protocol TabManagerDelegate: class {
 }
 
 protocol TabManagerStateDelegate: class {
-    func tabManagerDidStoreChanges(tabManager: TabManager)
+    func tabManagerWillStoreTabs(tabs: [Browser])
 }
 
 // We can't use a WeakList here because this is a protocol.
@@ -328,10 +328,10 @@ class TabManager : NSObject {
     }
 
     func storeChanges() {
+        stateDelegate?.tabManagerWillStoreTabs(tabs: normalTabs)
+
         // Also save (full) tab state to disk.
         preserveTabs()
-
-        stateDelegate?.tabManagerDidStoreChanges(self)
     }
 
     func prefsDidChange() {

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -69,8 +69,7 @@ class TabManagerTests: XCTestCase {
             manager.storeChanges()
 
             // We can't use waitForCondition here since we're testing a non-change.
-            // The TabManager storeChanges() delay is 100ms, so 200ms should be sufficient.
-            wait(0.2)
+            wait(ProfileRemoteTabsSyncDelay * 2)
 
             // now test that the database still contains only 3 tabs
             remoteTabs = profile.remoteClientsAndTabs.getTabsForClientWithGUID(nil).value.successValue

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -27,7 +27,7 @@ class TabManagerTests: XCTestCase {
 
     func testTabManagerStoresChangesInDB() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(defaultNewTabRequest: NSURLRequest(URL: NSURL(fileURLWithPath: "http://localhost")), profile: profile)
+        let manager = TabManager(defaultNewTabRequest: NSURLRequest(URL: NSURL(fileURLWithPath: "http://localhost")), prefs: profile.prefs, imageStore: nil)
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
 

--- a/ClientTests/XCTestCaseExtensions.swift
+++ b/ClientTests/XCTestCaseExtensions.swift
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    func wait(time: NSTimeInterval) {
+        let expectation = expectationWithDescription("Wait")
+        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(time * Double(NSEC_PER_SEC)))
+        dispatch_after(delayTime, dispatch_get_main_queue()) {
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(time + 1, handler: nil)
+    }
+
+    func waitForCondition(timeout timeout: NSTimeInterval = 10, condition: () -> Bool) {
+        let timeoutTime = NSDate.timeIntervalSinceReferenceDate() + timeout
+
+        while !condition() {
+            if NSDate.timeIntervalSinceReferenceDate() > timeoutTime {
+                XCTFail("Condition timed out")
+                return
+            }
+
+            wait(0.1)
+        }
+    }
+}

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -14,6 +14,7 @@ private let log = Logger.syncLogger
 
 public let ProfileDidStartSyncingNotification = "ProfileDidStartSyncingNotification"
 public let ProfileDidFinishSyncingNotification = "ProfileDidFinishSyncingNotification"
+public let ProfileRemoteTabsSyncDelay: NSTimeInterval = 0.1
 
 public protocol SyncManager {
     var isSyncing: Bool { get }


### PR DESCRIPTION
Part 1 fixes the crash. My first iteration of this simply made `profile` not `unowned`, but thinking about the `TabManager` responsibilities, it really has no business holding a `profile` at all. I move the remote tab saving to `AppDelegate`, so now `TabManager` needs to hold on only to the much simpler `Prefs` instance.

Part 2 adds some helper methods for testing async events.

Part 3 uses these helpers to make the tests pass with the async `storeChanges` we're using.