### PR TITLE
Bug 1217209 - Remove updating of tab count on tab selection

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1356,9 +1356,6 @@ extension BrowserViewController: TabManagerDelegate {
 
             updateURLBarDisplayURL(tab)
 
-            let count = tab.isPrivate ? tabManager.privateTabs.count : tabManager.normalTabs.count
-            urlBar.updateTabCount(count, animated: false)
-
             if tab.isPrivate {
                 readerModeCache = MemoryReaderModeCache.sharedInstance
                 applyPrivateModeTheme()

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -214,7 +214,7 @@ class TabManager : NSObject {
         if configuration == nil {
             configuration = isPrivate ? privateConfiguration : self.configuration
         }
-
+        
         let tab = Browser(configuration: configuration, isPrivate: isPrivate)
         configureTab(tab, request: request, flushToDisk: flushToDisk, zombie: zombie, restoring: restoring)
         return tab


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1217209

In the instances of popup windows, the animation-less `urlBar.updateTabCount` call from BVC `didSelectedTabChange` was canceling the already running animation from BVC `didAddTab`.
In all other instances, either `didAddTab` performs the animation and `didSelectedTabChange` is not called, or `didSelectedTabChange` gets called when no changes have been made to the tab count, so all other animations remain as they should.