### PR TITLE
Bug 1214794 - first sync top sites crash

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -131,7 +131,6 @@ class TopSitesPanel: UIViewController {
     private func deleteHistoryTileForSite(site: Site, atIndexPath indexPath: NSIndexPath) {
         profile.history.removeSiteFromTopSites(site) >>== {
             self.profile.history.getSitesByFrecencyWithLimit(self.layout.thumbnailCount).uponQueue(dispatch_get_main_queue(), block: { result in
-                self.updateDataSourceWithSites(result)
                 self.deleteOrUpdateSites(result, indexPath: indexPath)
             })
         }
@@ -145,23 +144,32 @@ class TopSitesPanel: UIViewController {
     }
 
     private func deleteOrUpdateSites(result: Maybe<Cursor<Site>>, indexPath: NSIndexPath) {
-        if let data = result.successValue {
-            let numOfThumbnails = self.layout.thumbnailCount
-            collection?.performBatchUpdates({
-                // If we have enough data to fill the tiles after the deletion, then delete and insert the next one from data
-                if (data.count + SuggestedSites.count >= numOfThumbnails) {
-                    self.collection?.deleteItemsAtIndexPaths([indexPath])
-                    self.collection?.insertItemsAtIndexPaths([NSIndexPath(forItem: numOfThumbnails - 1, inSection: 0)])
-                }
+        guard let collectionView = collection else { return }
+        // get the number of top sites items we have before we update the data sourcce 
+        // this is so we know how many new top sites cells to add
+        // as a sync may have brought in more results than we had previously
+        let previousNumberOfTopSitesItems = collectionView.dataSource?.collectionView(collectionView, numberOfItemsInSection: 0) ?? 0
 
-                // If we don't have enough to fill the thumbnail tile area even with suggested tiles, just delete
-                else if (data.count + SuggestedSites.count) < numOfThumbnails {
-                    self.collection?.deleteItemsAtIndexPaths([indexPath])
-                }
-            }, completion: { _ in
-                self.updateRemoveButtonStates()
-            })
-        }
+        // now update the data source with the new data
+        self.updateDataSourceWithSites(result)
+
+        let data = dataSource.data
+        let numOfThumbnails = self.layout.thumbnailCount
+        collection?.performBatchUpdates({
+            // If we have enough data to fill the tiles after the deletion, then delete and insert the next one from data
+            if (data.count + SuggestedSites.count >= numOfThumbnails) {
+                self.collection?.deleteItemsAtIndexPaths([indexPath])
+                self.collection?.dataSource?.collectionView(self.collection!, numberOfItemsInSection: 0)
+                let indexesToAdd = (previousNumberOfTopSitesItems-1..<numOfThumbnails).map{ NSIndexPath(forItem: $0, inSection: 0) }
+                self.collection?.insertItemsAtIndexPaths(indexesToAdd)
+            }
+            // If we don't have enough to fill the thumbnail tile area even with suggested tiles, just delete
+            else if (data.count + SuggestedSites.count) < numOfThumbnails {
+                self.collection?.deleteItemsAtIndexPaths([indexPath])
+            }
+        }, completion: { _ in
+            self.updateRemoveButtonStates()
+        })
     }
 
     /**

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -210,6 +210,8 @@ class TopSitesPanel: UIViewController {
 extension TopSitesPanel: HomePanel {
     func endEditing() {
         editingThumbnails = false
+
+        collection?.reloadData()
     }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1214794
* ensure that when we are performing a sync whilst deleting existing top sites that we add the correct number of cells
 * refresh collection view when editing ends to top sites reflects data rather than mismash of old & new, while preserving tiles during editing so that sites that you may wish to delete do no disappear when you delete another tile.