### PR TITLE
Bug 1211984 - Top Sites Frecency Caching

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -63,7 +63,6 @@ class TopSitesPanel: UIViewController {
         self.profile = profile
         super.init(nibName: nil, bundle: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "notificationReceived:", name: NotificationPrivateDataClearedHistory, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -88,12 +87,11 @@ class TopSitesPanel: UIViewController {
 
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationPrivateDataClearedHistory, object: nil)
     }
     
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
+        case NotificationFirefoxAccountChanged:
             refreshHistory(maxFrecencyLimit)
             break
         default:

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -130,14 +130,15 @@ class TopSitesPanel: UIViewController {
 
     private func deleteHistoryTileForSite(site: Site, atIndexPath indexPath: NSIndexPath) {
         profile.history.removeSiteFromTopSites(site) >>== {
-            self.profile.history.getSitesByFrecencyWithLimit(self.layout.thumbnailCount).uponQueue(dispatch_get_main_queue(), block: { result in
+            self.profile.history.getTopSitesWithLimit(self.layout.thumbnailCount).uponQueue(dispatch_get_main_queue(), block: { result in
+                self.updateDataSourceWithSites(result)
                 self.deleteOrUpdateSites(result, indexPath: indexPath)
             })
         }
     }
 
     private func refreshHistory(frequencyLimit: Int) {
-        self.profile.history.getSitesByFrecencyWithLimit(frequencyLimit).uponQueue(dispatch_get_main_queue(), block: { result in
+        self.profile.history.getTopSitesWithLimit(frequencyLimit).uponQueue(dispatch_get_main_queue(), block: { result in
             self.updateDataSourceWithSites(result)
             self.collection?.reloadData()
         })

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -137,13 +137,13 @@ class TopSitesPanel: UIViewController {
         }
     }
 
-    private func refreshTopSites(frequencyLimit: Int) {
+    private func refreshTopSites(frecencyLimit: Int) {
         // Reload right away with whatever is in the cache, then check to see if the cache is invalid. If it's invalid,
         // invalidate the cache and requery. This allows us to always show results right away if they are cached but
         // also load in the up-to-date results asynchronously if needed
-        reloadTopSitesWithLimit(frequencyLimit) >>> {
+        reloadTopSitesWithLimit(frecencyLimit) >>> {
             return self.profile.history.invalidateTopSitesIfNeeded() >>== { result in
-                return result ? self.reloadTopSitesWithLimit(frequencyLimit) : succeed()
+                return result ? self.reloadTopSitesWithLimit(frecencyLimit) : succeed()
             }
         }
     }

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -76,7 +76,7 @@ public class MockProfile: Profile {
      * collection of tables.
      */
     private lazy var places: protocol<BrowserHistory, Favicons, SyncableHistory, ResettableSyncStorage> = {
-        return SQLiteHistory(db: self.db)!
+        return SQLiteHistory(db: self.db, prefs: MockProfilePrefs())!
     }()
 
     var favicons: Favicons {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -263,7 +263,7 @@ public class BrowserProfile: Profile {
      * that this is initialized first.
      */
     private lazy var places: protocol<BrowserHistory, Favicons, SyncableHistory, ResettableSyncStorage> = {
-        return SQLiteHistory(db: self.db)!
+        return SQLiteHistory(db: self.db, prefs: self.prefs)!
     }()
 
     var favicons: Favicons {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -234,6 +234,7 @@ public class BrowserProfile: Profile {
         }
     }
 
+    // These selectors run on which ever thread sent the notifications (not the main thread)
     @objc
     func onProfileDidFinishSyncing(notification: NSNotification) {
         history.setTopSitesNeedsInvalidation()

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -29,7 +29,8 @@ public protocol BrowserHistory {
 
     func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func setTopSitesNeedsInvalidation()
-    func invalidateTopSitesIfNeeded() -> Deferred<Bool>
+    func invalidateTopSitesIfNeeded() -> Deferred<Maybe<Bool>>
+    func setTopSitesCacheSize(size: Int32)
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -26,6 +26,9 @@ public protocol BrowserHistory {
     func getSitesByFrecencyWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func getSitesByFrecencyWithLimit(limit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>>
     func getSitesByLastVisit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
+
+    func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
+    func purgeTopSitesCache() -> Success
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -28,7 +28,7 @@ public protocol BrowserHistory {
     func getSitesByLastVisit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
 
     func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
-    func purgeTopSitesCache() -> Success
+    func invalidateTopSites() -> Success
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -29,7 +29,7 @@ public protocol BrowserHistory {
 
     func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func setTopSitesNeedsInvalidation()
-    func invalidateTopSitesIfNeeded() -> Success
+    func invalidateTopSitesIfNeeded() -> Deferred<Bool>
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -28,7 +28,8 @@ public protocol BrowserHistory {
     func getSitesByLastVisit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
 
     func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
-    func invalidateTopSites() -> Success
+    func setTopSitesNeedsInvalidation()
+    func invalidateTopSitesIfNeeded() -> Success
 }
 
 /**

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -362,7 +362,7 @@ public class BrowserTable: Table {
             (historyIDsWithIcon, nil),
             (iconForURL, nil),
             (getQueueTableCreationString(forVersion: version), nil),
-            (getTopSitesTableCreationString(forVersion: version), nil)
+            (getTopSitesTableCreationString(forVersion: version), nil),
         ]
 
         assert(queries.count == AllTablesIndicesAndViews.count, "Did you forget to add your table, index, or view to the list?")

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -425,7 +425,7 @@ extension SQLiteHistory: BrowserHistory {
             let sql = "SELECT" +
                       " historyID, url, title, guid, domain_id, domain" +
                       ", localVisitDate, remoteVisitDate, localVisitCount, remoteVisitCount" +
-                      ", iconID, iconURL, iconDate, iconType, iconWidth" +
+                      ", iconID, iconURL, iconDate, iconType, iconWidth, frecencies" +
                       " FROM (\(historySQL)) LEFT OUTER JOIN " +
                       "view_history_id_favicon ON historyID = view_history_id_favicon.id"
             let factory = SQLiteHistory.iconHistoryColumnFactory

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -264,9 +264,17 @@ extension SQLiteHistory: BrowserHistory {
         return self.db.runQuery(topSitesQuery, args: [limit], factory: factory)
     }
 
-    public func invalidateTopSites() -> Success {
-        return purgeTopSitesCache() >>> {
-            self.updateTopSitesCacheWithLimit(TopSitesCacheSize)
+    public func setTopSitesNeedsInvalidation() {
+        prefs.setBool(false, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
+    }
+
+    public func invalidateTopSitesIfNeeded() -> Success {
+        if !(prefs.boolForKey(PrefsKeys.KeyTopSitesCacheIsValid) ?? false) {
+            return purgeTopSitesCache() >>> {
+                self.updateTopSitesCacheWithLimit(TopSitesCacheSize)
+            }
+        } else {
+            return succeed()
         }
     }
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -320,8 +320,10 @@ extension SQLiteHistory: BrowserHistory {
 
     private func purgeTopSitesCache() -> Success {
         let deleteQuery = "DELETE FROM \(TableCachedTopSites)"
-        prefs.removeObjectForKey(PrefsKeys.KeyLastFrecencyCacheTime)
-        return self.db.run(deleteQuery, withArgs: nil)
+        return self.db.run(deleteQuery, withArgs: nil) >>> {
+            self.prefs.removeObjectForKey(PrefsKeys.KeyLastFrecencyCacheTime)
+            return succeed()
+        }
     }
 
     private func updateTopSitesCacheWithLimit(limit : Int) -> Success {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -264,6 +264,14 @@ extension SQLiteHistory: BrowserHistory {
         }
     }
 
+    public func purgeTopSitesCache() -> Success {
+        let deleteQuery = "DELETE FROM \(TableCachedTopSites)"
+        return self.db.run(deleteQuery, withArgs: nil) >>> {
+            self.prefs.removeObjectForKey(PrefsKeys.KeyLastFrecencyCacheTime)
+            return succeed()
+        }
+    }
+
     public func getSitesByFrecencyWithLimit(limit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> {
         return self.getFilteredSitesByFrecencyWithLimit(limit, whereURLContains: filter)
     }
@@ -316,14 +324,6 @@ extension SQLiteHistory: BrowserHistory {
         let whereData = "(\(TableDomains).showOnTopSites IS 1) AND (\(TableDomains).domain NOT LIKE 'r.%') "
         let groupBy = "GROUP BY domain_id "
         return (whereData, groupBy)
-    }
-
-    private func purgeTopSitesCache() -> Success {
-        let deleteQuery = "DELETE FROM \(TableCachedTopSites)"
-        return self.db.run(deleteQuery, withArgs: nil) >>> {
-            self.prefs.removeObjectForKey(PrefsKeys.KeyLastFrecencyCacheTime)
-            return succeed()
-        }
     }
 
     private func updateTopSitesCacheWithLimit(limit : Int) -> Success {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -250,10 +250,39 @@ extension SQLiteHistory: BrowserHistory {
 
     public func getSitesByFrecencyWithLimit(limit: Int, includeIcon: Bool) -> Deferred<Maybe<Cursor<Site>>> {
         // Exclude redirect domains. Bug 1194852.
-        let whereData = "(\(TableDomains).showOnTopSites IS 1) AND (\(TableDomains).domain NOT LIKE 'r.%') "
-        let groupBy = "GROUP BY domain_id "
-
+        let (whereData, groupBy) = self.topSiteClauses()
         return self.getFilteredSitesByFrecencyWithLimit(limit, groupClause: groupBy, whereData: whereData, includeIcon: includeIcon)
+    }
+
+    public func getTopSitesWithLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>> {
+        let purgeTopSites: () -> Success = {
+            let deleteQuery = "DELETE FROM \(TableCachedTopSites)"
+            return self.db.run(deleteQuery, withArgs: nil)
+        }
+
+        let insertTopSites: () -> Success = { frecencyResults in
+            let (whereData, groupBy) = self.topSiteClauses()
+            let (query, args) = self.filteredSitesByFrecencyQueryWithLimit(limit, groupClause: groupBy, whereData: whereData)
+            let insertQuery = "INSERT INTO \(TableCachedTopSites) \(query)"
+            return self.db.run(insertQuery, withArgs: args)
+        }
+
+        let topSitesResult: () -> Deferred<Maybe<Cursor<Site>>> = {
+            // Grab all of the entries for top sites
+            let topSitesQuery = "SELECT * FROM \(TableCachedTopSites) ORDER BY frecencies DESC LIMIT (?)"
+            let factory = SQLiteHistory.iconHistoryColumnFactory
+            return self.db.runQuery(topSitesQuery, args: [limit], factory: factory)
+        }
+
+        let lastComputeTime: Timestamp = 0
+
+        // If the cached data is too stale, dump everything, recompute, cache, and return
+        let now = NSDate.now()
+        if now - lastComputeTime > OneHourInMilliseconds {
+            return (purgeTopSites() >>> insertTopSites) >>> topSitesResult
+        } else {
+            return topSitesResult()
+        }
     }
 
     public func getSitesByFrecencyWithLimit(limit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>> {
@@ -302,6 +331,12 @@ extension SQLiteHistory: BrowserHistory {
         let site = basicHistoryColumnFactory(row)
         site.icon = iconColumnFactory(row)
         return site
+    }
+
+    private func topSiteClauses() -> (String, String) {
+        let whereData = "(\(TableDomains).showOnTopSites IS 1) AND (\(TableDomains).domain NOT LIKE 'r.%') "
+        let groupBy = "GROUP BY domain_id "
+        return (whereData, groupBy)
     }
 
     private func getFilteredSitesByVisitDateWithLimit(limit: Int,
@@ -362,6 +397,28 @@ extension SQLiteHistory: BrowserHistory {
                                                      groupClause: String = "GROUP BY historyID ",
                                                      whereData: String? = nil,
                                                      includeIcon: Bool = true) -> Deferred<Maybe<Cursor<Site>>> {
+        let factory: (SDRow) -> Site
+        if includeIcon {
+            factory = SQLiteHistory.iconHistoryColumnFactory
+        } else {
+            factory = SQLiteHistory.basicHistoryColumnFactory
+        }
+
+        let (query, args) = filteredSitesByFrecencyQueryWithLimit(limit,
+            whereURLContains: filter,
+            groupClause: groupClause,
+            whereData: whereData,
+            includeIcon: includeIcon
+        )
+
+        return db.runQuery(query, args: args, factory: factory)
+    }
+
+    private func filteredSitesByFrecencyQueryWithLimit(limit: Int,
+                                                       whereURLContains filter: String? = nil,
+                                                       groupClause: String = "GROUP BY historyID ",
+                                                       whereData: String? = nil,
+                                                       includeIcon: Bool = true) -> (String, Args?) {
         let localFrecencySQL = getLocalFrecencySQL()
         let remoteFrecencySQL = getRemoteFrecencySQL()
         let sixMonthsInMicroseconds: UInt64 = 15_724_800_000_000      // 182 * 1000 * 1000 * 60 * 60 * 24
@@ -404,7 +461,7 @@ extension SQLiteHistory: BrowserHistory {
         "((localVisitDate > \(sixMonthsAgo)) OR (remoteVisitDate > \(sixMonthsAgo)))" +    // Exclude really old items.
         ") ORDER BY frecency DESC" +
         " LIMIT 1000"                                 // Don't even look at a huge set. This avoids work.
-
+        
         // Next: merge by domain and sum frecency, ordering by that sum and reducing to a (typically much lower) limit.
         let historySQL =
         "SELECT historyID, url, title, guid, domain_id, domain" +
@@ -417,23 +474,21 @@ extension SQLiteHistory: BrowserHistory {
         groupClause + " " +
         "ORDER BY frecencies DESC " +
         "LIMIT \(limit) "
-
+        
         // Finally: join this small list to the favicon data.
         if includeIcon {
             // We select the history items then immediately join to get the largest icon.
             // We do this so that we limit and filter *before* joining against icons.
             let sql = "SELECT" +
-                      " historyID, url, title, guid, domain_id, domain" +
-                      ", localVisitDate, remoteVisitDate, localVisitCount, remoteVisitCount" +
-                      ", iconID, iconURL, iconDate, iconType, iconWidth, frecencies" +
-                      " FROM (\(historySQL)) LEFT OUTER JOIN " +
-                      "view_history_id_favicon ON historyID = view_history_id_favicon.id"
-            let factory = SQLiteHistory.iconHistoryColumnFactory
-            return db.runQuery(sql, args: args, factory: factory)
+            " historyID, url, title, guid, domain_id, domain" +
+            ", localVisitDate, remoteVisitDate, localVisitCount, remoteVisitCount" +
+            ", iconID, iconURL, iconDate, iconType, iconWidth, frecencies" +
+            " FROM (\(historySQL)) LEFT OUTER JOIN " +
+            "view_history_id_favicon ON historyID = view_history_id_favicon.id"
+            return (sql, args)
         }
 
-        let factory = SQLiteHistory.basicHistoryColumnFactory
-        return db.runQuery(historySQL, args: args, factory: factory)
+        return (historySQL, args)
     }
 }
 

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -500,6 +500,26 @@ class TestSQLiteHistoryFrecencyPerf: XCTestCase {
     }
 }
 
+class TestSQLiteHistoryTopSitesCachePref: XCTestCase {
+    func testCachePerf() {
+        let files = MockFiles()
+        let db = BrowserDB(filename: "browser.db", files: files)
+        let prefs = MockProfilePrefs()
+        let history = SQLiteHistory(db: db, prefs: prefs)!
+
+        let count = 500
+
+        history.clearHistory().value
+        populateHistoryForFrecencyCalcuations(history, siteCount: count)
+
+        history.purgeTopSitesCache().value
+        self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {
+            history.getTopSitesWithLimit(100).value
+            self.stopMeasuring()
+        }
+    }
+}
+
 private func populateHistoryForFrecencyCalcuations(history: SQLiteHistory, siteCount count: Int) {
     for i in 0...count {
         let site = Site(url: "http://s\(i)ite\(i)/foo", title: "A \(i)")

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -7,6 +7,7 @@ import Foundation
 public struct PrefsKeys {
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
+    public static let KeyLastFrecencyCacheTime = "lastFrecencyCacheTime"
 }
 
 public protocol Prefs {

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct PrefsKeys {
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
-    public static let KeyLastFrecencyCacheTime = "lastFrecencyCacheTime"
+    public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"
 }
 
 public protocol Prefs {

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -8,6 +8,7 @@ public struct PrefsKeys {
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
     public static let KeyLastSyncFinishTime = "lastSyncFinishTime"
     public static let KeyTopSitesCacheIsValid = "topSitesCacheIsValid"
+    public static let KeyTopSitesCacheSize = "topSitesCacheSize"
 }
 
 public protocol Prefs {


### PR DESCRIPTION
In-progress work on caching frecency results for a faster Top Sites Panel.
So far,

1. Added cached_top_sites table to store frecency values
2. Added getTopSitesWithLimit method to SQLiteHistory to return all top sites from cache if it's valid and dump/recalculate cache when cache is stale (> 1 day old).

To do:

1. Need to hook into the various history events to update our cache (updateVisit, insertVisit, remove, etc). Not sure if hooking into Swift methods is the best way or adding triggers to the visits/history table would be best.
2. Instead of using 'now' for the frecency calculations, it needs to be set to a time in the future for the approximation otherwise the calculations will be wrong. Just need to refactor the frecency query methods to pass in a timestamp (which will be a day ahead of our last cached time).