### PR TITLE
Bug 1215669 - Queue tab screenshots if BVC isn't visible

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -48,6 +48,7 @@ class Browser: NSObject {
     var sessionData: SessionData?
     var lastRequest: NSURLRequest? = nil
     var restoring: Bool = false
+    var pendingScreenshot = false
 
     /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
     var lastTitle: String?

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -117,7 +117,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func didInit() {
-        screenshotHelper = BrowserScreenshotHelper(controller: self)
+        screenshotHelper = ScreenshotHelper(controller: self)
         tabManager.addDelegate(self)
         tabManager.addNavigationDelegate(self)
     }
@@ -2009,29 +2009,6 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 }
             }
         }
-    }
-}
-
-private class BrowserScreenshotHelper: ScreenshotHelper {
-    private weak var controller: BrowserViewController?
-
-    init(controller: BrowserViewController) {
-        self.controller = controller
-    }
-
-    func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
-        if let url = tab.url {
-            if AboutUtils.isAboutHomeURL(url) {
-                if let homePanel = controller?.homePanelController {
-                    return homePanel.view.screenshot(aspectRatio, quality: quality)
-                }
-            } else {
-                let offset = CGPointMake(0, -(tab.webView?.scrollView.contentInset.top ?? 0))
-                return tab.webView?.screenshot(aspectRatio, offset: offset, quality: quality)
-            }
-        }
-
-        return nil
     }
 }
 

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -7,6 +7,25 @@ import Foundation
 /**
  * Handles screenshots for a given browser, including pages with non-webview content.
  */
-protocol ScreenshotHelper {
-    func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage?
+class ScreenshotHelper {
+    private weak var controller: BrowserViewController?
+
+    init(controller: BrowserViewController) {
+        self.controller = controller
+    }
+
+    func takeScreenshot(tab: Browser, aspectRatio: CGFloat, quality: CGFloat) -> UIImage? {
+        if let url = tab.url {
+            if AboutUtils.isAboutHomeURL(url) {
+                if let homePanel = controller?.homePanelController {
+                    return homePanel.view.screenshot(aspectRatio, quality: quality)
+                }
+            } else {
+                let offset = CGPointMake(0, -(tab.webView?.scrollView.contentInset.top ?? 0))
+                return tab.webView?.screenshot(aspectRatio, offset: offset, quality: quality)
+            }
+        }
+
+        return nil
+    }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -54,7 +54,7 @@ class TabManager : NSObject {
         }
     }
 
-    private var tabs: [Browser] = []
+    private(set) var tabs = [Browser]()
     private var _selectedIndex = -1
     private let defaultNewTabRequest: NSURLRequest
     private let navDelegate: TabManagerNavDelegate

--- a/Utils/Extensions/UIViewExtensions.swift
+++ b/Utils/Extensions/UIViewExtensions.swift
@@ -25,7 +25,7 @@ extension UIView {
      * Takes a screenshot of the view with the given aspect ratio.
      * An aspect ratio of 0 means capture the entire view.
      */
-    func screenshot(aspectRatio: CGFloat, offset: CGPoint? = nil, quality: CGFloat = 1) -> UIImage? {
+    func screenshot(aspectRatio: CGFloat = 0, offset: CGPoint? = nil, quality: CGFloat = 1) -> UIImage? {
         assert(aspectRatio >= 0)
 
         var size: CGSize


### PR DESCRIPTION
I think the issue here is that `WKWebView` doesn't render if its view controller isn't visible (presumably as an optimization). This fixes the problem by waiting until BVC is visible, then trying again.

I spent awhile trying to figure out a good way to determine view controller visibility; in particular, I tried `self.navigationController?.visibleViewController === self` and `isViewLoaded() && view.window != nil`. Those *mostly* work, but I found I could trigger some edge casey false positives if the screenshotting fires during the tab tray -> BVC transition (these conditions all return `true`, yet the screenshot was still blank). I bit the bullet and tacked on a `viewIsVisible` boolean that I just keep track of manually.