### PR TITLE
Bug 1213623 - Speculative fixes for startup hangs caused by WAL replay.

### DIFF
--- a/Storage/Bookmarks.swift
+++ b/Storage/Bookmarks.swift
@@ -147,6 +147,7 @@ public struct BookmarkMirrorItem {
 
 public protocol BookmarkMirrorStorage {
     func applyRecords(records: [BookmarkMirrorItem]) -> Success
+    func doneApplyingRecordsAfterDownload() -> Success
 }
 
 

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -55,6 +55,9 @@ public protocol SyncableHistory: AccountRemovalDelegate {
      */
     func markAsSynchronized(_: [GUID], modified: Timestamp) -> Deferred<Maybe<Timestamp>>
     func markAsDeleted(guids: [GUID]) -> Success
+
+    func doneApplyingRecordsAfterDownload() -> Success
+    func doneUpdatingMetadataAfterUpload() -> Success
 }
 
 // TODO: integrate Site with this.

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -227,6 +227,24 @@ public class BrowserDB {
 }
 
 extension BrowserDB {
+    func vacuum() {
+        log.debug("Vacuuming a BrowserDB.")
+        db.transaction { connection in
+            connection.vacuum()
+            return true
+        }
+    }
+
+    func checkpoint() {
+        log.debug("Checkpointing a BrowserDB.")
+        db.transaction { connection in
+            connection.checkpoint()
+            return true
+        }
+    }
+}
+
+extension BrowserDB {
     public class func varlist(count: Int) -> String {
         return "(" + Array(count: count, repeatedValue: "?").joinWithSeparator(", ") + ")"
     }

--- a/Storage/SQL/SQLiteBookmarks.swift
+++ b/Storage/SQL/SQLiteBookmarks.swift
@@ -542,6 +542,11 @@ public class SQLiteBookmarkMirrorStorage: BookmarkMirrorStorage {
 
         return deferred
     }
+
+    public func doneApplyingRecordsAfterDownload() -> Success {
+        self.db.checkpoint()
+        return succeed()
+    }
 }
 
 extension SQLiteBookmarkMirrorStorage: BookmarksModelFactory {
@@ -673,6 +678,11 @@ public class MergedSQLiteBookmarks {
 extension MergedSQLiteBookmarks: BookmarkMirrorStorage {
     public func applyRecords(records: [BookmarkMirrorItem]) -> Success {
         return self.mirror.applyRecords(records)
+    }
+
+    public func doneApplyingRecordsAfterDownload() -> Success {
+        // It doesn't really matter which one we checkpoint -- they're both backed by the same DB.
+        return self.mirror.doneApplyingRecordsAfterDownload()
     }
 }
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -138,11 +138,16 @@ extension SQLiteHistory: BrowserHistory {
 
     // Note: clearing history isn't really a sane concept in the presence of Sync.
     // This method should be split to do something else.
+    // Bug 1162778.
     public func clearHistory() -> Success {
-        return db.run([("DELETE FROM \(TableVisits)", nil),
-                       ("DELETE FROM \(TableHistory)", nil),
-                       ("DELETE FROM \(TableDomains)", nil),
-                       self.favicons.getCleanupCommands()])
+        return self.db.run([
+            ("DELETE FROM \(TableVisits)", nil),
+            ("DELETE FROM \(TableHistory)", nil),
+            ("DELETE FROM \(TableDomains)", nil),
+            self.favicons.getCleanupCommands(),
+            ])
+            // We've probably deleted a lot of stuff. Vacuum now to recover the space.
+            >>> effect(self.db.vacuum)
     }
 
     func recordVisitedSite(site: Site) -> Success {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -845,6 +845,16 @@ extension SQLiteHistory: SyncableHistory {
         let args: Args = guids.map { $0 as AnyObject }
         return self.db.run(sql, withArgs: args) >>> always(modified)
     }
+
+    public func doneApplyingRecordsAfterDownload() -> Success {
+        self.db.checkpoint()
+        return succeed()
+    }
+
+    public func doneUpdatingMetadataAfterUpload() -> Success {
+        self.db.checkpoint()
+        return succeed()
+    }
 }
 
 extension SQLiteHistory: ResettableSyncStorage {

--- a/Sync/BookmarksDownloader.swift
+++ b/Sync/BookmarksDownloader.swift
@@ -135,6 +135,7 @@ public class BookmarksMirrorer {
             case .Complete:
                 log.info("Done with batched mirroring.")
                 return self.applyRecordsFromBatcher()
+                   >>> self.storage.doneApplyingRecordsAfterDownload
             case .Incomplete:
                 log.debug("Running another batch.")
                 // This recursion is fine because Deferred always pushes callbacks onto a queue.

--- a/SyncTests/HistorySynchronizerTests.swift
+++ b/SyncTests/HistorySynchronizerTests.swift
@@ -161,6 +161,14 @@ extension MockSyncableHistory: SyncableHistory {
         // TODO
         return succeed()
     }
+
+    func doneApplyingRecordsAfterDownload() -> Success {
+        return succeed()
+    }
+
+    func doneUpdatingMetadataAfterUpload() -> Success {
+        return succeed()
+    }
 }
 
 


### PR DESCRIPTION
This is just a better database configuration that will prevent some WAL overgrowth, a vacuum at some appropriate times, and — if the reporter indicates that Sync was involved — I'll add some manual checkpointing if necessary.