### PR TITLE
Bug 1221235 - Don't vacuum inside a transaction, don't fail CPD for trivial reasons.

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -91,8 +91,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     }
 
     private func onNewModel(model: BookmarksModel) {
-        self.source = model
         dispatch_async(dispatch_get_main_queue()) {
+            self.source = model
             self.tableView.reloadData()
         }
     }


### PR DESCRIPTION
Three fixes here.

The first is that this vacuum would fail because it was occurring inside a transaction.

The second is that I saw it block trying to retrieve results. We no longer treat it as a cursorable query.

The third is that our CPD operation overall was failing on iOS 8 because we don't have permissions to delete the Snapshots folder. I added a clause to ignore that error.