### PR TITLE
Bug 1221247 - Assign source on the main thread immediately before calling tableView.reloadData.

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -91,8 +91,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     }
 
     private func onNewModel(model: BookmarksModel) {
-        self.source = model
         dispatch_async(dispatch_get_main_queue()) {
+            self.source = model
             self.tableView.reloadData()
         }
     }


### PR DESCRIPTION
This reduces the likelihood that we'll switch out our data between two UITableViewDataSource method calls.

Because we immediately call `reloadData` on the same thread after switching out our data, we should never get split state.