### PR TITLE
Bug 1221511 - Fix crash when quitting Private mode with "Close Private Tabs" option on

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -445,7 +445,7 @@ class TabTrayController: UIViewController {
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
         if !privateMode && profile.prefs.boolForKey("settings.closePrivateTabs") ?? false {
-            tabManager.privateTabs.forEach { tabManager.removeTab($0) }
+            tabManager.removeAllPrivateTabsAndNotify(false)
         }
 
         togglePrivateMode.setSelected(privateMode, animated: true)


### PR DESCRIPTION
When quitting private mode with "Close Private Tabs" option on, the app
crashes if a tab is opened.

This fix the issue by bypassing some method calls if tab is already
closed.