### PR TITLE
Bug 1197832 - Add ClientRefTests test target for FBSnapshotTestCase tests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -1827,6 +1827,20 @@
 		E635D25D1B729DEE0078962F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E64ED8F91BC55AE300DAF864 /* UIAlertControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtensions.swift; path = Extensions/UIAlertControllerExtensions.swift; sourceTree = "<group>"; };
 		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
+		E65C5B8D1BEA4E7100D28BEF /* UIImage+Compare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Compare.h"; sourceTree = "<group>"; };
+		E65C5B8E1BEA4E7100D28BEF /* UIImage+Compare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Compare.m"; sourceTree = "<group>"; };
+		E65C5B8F1BEA4E7100D28BEF /* UIImage+Diff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Diff.h"; sourceTree = "<group>"; };
+		E65C5B901BEA4E7100D28BEF /* UIImage+Diff.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Diff.m"; sourceTree = "<group>"; };
+		E65C5B911BEA4E7100D28BEF /* UIImage+Snapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Snapshot.h"; sourceTree = "<group>"; };
+		E65C5B921BEA4E7100D28BEF /* UIImage+Snapshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Snapshot.m"; sourceTree = "<group>"; };
+		E65C5B931BEA4E7100D28BEF /* FBSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
+		E65C5B941BEA4E7100D28BEF /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestCase.h; sourceTree = "<group>"; };
+		E65C5B951BEA4E7100D28BEF /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCase.m; sourceTree = "<group>"; };
+		E65C5B961BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
+		E65C5B971BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
+		E65C5B981BEA4E7100D28BEF /* FBSnapshotTestController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestController.h; sourceTree = "<group>"; };
+		E65C5B991BEA4E7100D28BEF /* FBSnapshotTestController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestController.m; sourceTree = "<group>"; };
+		E65C5B9A1BEA4E7100D28BEF /* SwiftSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
@@ -2273,6 +2287,7 @@
 			children = (
 				E4B334211BBF2393004E2BFF /* Adjust */,
 				E66C5B451BDA81050051AA93 /* Apple */,
+				E65C5B8B1BEA4E7100D28BEF /* FBSnapshotTestCase */,
 				0B5B51AC1B4CDB9E00E3B6E9 /* RaptureXML */,
 				288A2D801AB8B2B90023ABC3 /* Deferred */,
 				288A2D7F1AB8B2B20023ABC3 /* Box */,
@@ -2930,6 +2945,36 @@
 				D36998881AD70A0A00650C6C /* IOKit.framework */,
 			);
 			name = "System Dependencies";
+			sourceTree = "<group>";
+		};
+		E65C5B8B1BEA4E7100D28BEF /* FBSnapshotTestCase */ = {
+			isa = PBXGroup;
+			children = (
+				E65C5B8C1BEA4E7100D28BEF /* Categories */,
+				E65C5B931BEA4E7100D28BEF /* FBSnapshotTestCase-Info.plist */,
+				E65C5B941BEA4E7100D28BEF /* FBSnapshotTestCase.h */,
+				E65C5B951BEA4E7100D28BEF /* FBSnapshotTestCase.m */,
+				E65C5B961BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.h */,
+				E65C5B971BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.m */,
+				E65C5B981BEA4E7100D28BEF /* FBSnapshotTestController.h */,
+				E65C5B991BEA4E7100D28BEF /* FBSnapshotTestController.m */,
+				E65C5B9A1BEA4E7100D28BEF /* SwiftSupport.swift */,
+			);
+			name = FBSnapshotTestCase;
+			path = ThirdParty/FBSnapshotTestCase;
+			sourceTree = "<group>";
+		};
+		E65C5B8C1BEA4E7100D28BEF /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				E65C5B8D1BEA4E7100D28BEF /* UIImage+Compare.h */,
+				E65C5B8E1BEA4E7100D28BEF /* UIImage+Compare.m */,
+				E65C5B8F1BEA4E7100D28BEF /* UIImage+Diff.h */,
+				E65C5B901BEA4E7100D28BEF /* UIImage+Diff.m */,
+				E65C5B911BEA4E7100D28BEF /* UIImage+Snapshot.h */,
+				E65C5B921BEA4E7100D28BEF /* UIImage+Snapshot.m */,
+			);
+			path = Categories;
 			sourceTree = "<group>";
 		};
 		E66C5B451BDA81050051AA93 /* Apple */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -633,6 +633,14 @@
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */; };
+		E65C5BC71BEA4F6500D28BEF /* NativeRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65C5BC61BEA4F6500D28BEF /* NativeRefTests.swift */; };
+		E65C5BD31BEA4F8A00D28BEF /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5B951BEA4E7100D28BEF /* FBSnapshotTestCase.m */; };
+		E65C5BD41BEA4F8A00D28BEF /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5B971BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.m */; };
+		E65C5BD51BEA4F8A00D28BEF /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5B991BEA4E7100D28BEF /* FBSnapshotTestController.m */; };
+		E65C5BDE1BEA522600D28BEF /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5BD91BEA522600D28BEF /* UIImage+Compare.m */; };
+		E65C5BDF1BEA522600D28BEF /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5BDB1BEA522600D28BEF /* UIImage+Diff.m */; };
+		E65C5BE01BEA522600D28BEF /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5BDD1BEA522600D28BEF /* UIImage+Snapshot.m */; };
+		E65C5BE41BEA525800D28BEF /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E65C5BE21BEA525800D28BEF /* Info.plist */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
@@ -1191,20 +1199,6 @@
 			remoteGlobalIDString = 2FA435FA1ABB83B4008031D1;
 			remoteInfo = Account;
 		};
-		E4A85D101BF2600D008BD381 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 39A362B21AAF5E2B00F47390 /* XCGLogger.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 70CB94201B99E728007802FF;
-			remoteInfo = "XCGLogger (watchOS)";
-		};
-		E4A85D121BF2600D008BD381 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 39A362B21AAF5E2B00F47390 /* XCGLogger.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5515A3DF1BA119FA0047BA31;
-			remoteInfo = "XCGLogger (tvOS)";
-		};
 		E4A888181A95679500CDC337 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 28CE83CA1A1D1D5100576538 /* FxA.xcodeproj */;
@@ -1262,6 +1256,13 @@
 			remoteInfo = Shared;
 		};
 		E63CD1B21B31B66400A63AFF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F84B21BD1A090F8100AAB793;
+			remoteInfo = Client;
+		};
+		E65C5BC91BEA4F6500D28BEF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F84B21B61A090F8100AAB793 /* Project object */;
 			proxyType = 1;
@@ -1827,12 +1828,6 @@
 		E635D25D1B729DEE0078962F /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E64ED8F91BC55AE300DAF864 /* UIAlertControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtensions.swift; path = Extensions/UIAlertControllerExtensions.swift; sourceTree = "<group>"; };
 		E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHelper.swift; sourceTree = "<group>"; };
-		E65C5B8D1BEA4E7100D28BEF /* UIImage+Compare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Compare.h"; sourceTree = "<group>"; };
-		E65C5B8E1BEA4E7100D28BEF /* UIImage+Compare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Compare.m"; sourceTree = "<group>"; };
-		E65C5B8F1BEA4E7100D28BEF /* UIImage+Diff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Diff.h"; sourceTree = "<group>"; };
-		E65C5B901BEA4E7100D28BEF /* UIImage+Diff.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Diff.m"; sourceTree = "<group>"; };
-		E65C5B911BEA4E7100D28BEF /* UIImage+Snapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Snapshot.h"; sourceTree = "<group>"; };
-		E65C5B921BEA4E7100D28BEF /* UIImage+Snapshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Snapshot.m"; sourceTree = "<group>"; };
 		E65C5B931BEA4E7100D28BEF /* FBSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
 		E65C5B941BEA4E7100D28BEF /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestCase.h; sourceTree = "<group>"; };
 		E65C5B951BEA4E7100D28BEF /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCase.m; sourceTree = "<group>"; };
@@ -1841,6 +1836,16 @@
 		E65C5B981BEA4E7100D28BEF /* FBSnapshotTestController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestController.h; sourceTree = "<group>"; };
 		E65C5B991BEA4E7100D28BEF /* FBSnapshotTestController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestController.m; sourceTree = "<group>"; };
 		E65C5B9A1BEA4E7100D28BEF /* SwiftSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
+		E65C5BC41BEA4F6500D28BEF /* NativeRefTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NativeRefTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E65C5BC61BEA4F6500D28BEF /* NativeRefTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRefTests.swift; sourceTree = "<group>"; };
+		E65C5BD81BEA522600D28BEF /* UIImage+Compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Compare.h"; sourceTree = "<group>"; };
+		E65C5BD91BEA522600D28BEF /* UIImage+Compare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Compare.m"; sourceTree = "<group>"; };
+		E65C5BDA1BEA522600D28BEF /* UIImage+Diff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Diff.h"; sourceTree = "<group>"; };
+		E65C5BDB1BEA522600D28BEF /* UIImage+Diff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Diff.m"; sourceTree = "<group>"; };
+		E65C5BDC1BEA522600D28BEF /* UIImage+Snapshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Snapshot.h"; sourceTree = "<group>"; };
+		E65C5BDD1BEA522600D28BEF /* UIImage+Snapshot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Snapshot.m"; sourceTree = "<group>"; };
+		E65C5BE21BEA525800D28BEF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E65C5BE31BEA525800D28BEF /* NativeRefTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NativeRefTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
@@ -2000,6 +2005,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4D567231ADECE2700F1EFE7 /* ReadingList.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E65C5BC11BEA4F6500D28BEF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2494,8 +2506,6 @@
 			children = (
 				39A362D41AAF5E2C00F47390 /* XCGLogger.framework */,
 				39A362D61AAF5E2C00F47390 /* XCGLogger.framework */,
-				E4A85D111BF2600D008BD381 /* XCGLogger.framework */,
-				E4A85D131BF2600D008BD381 /* XCGLogger.framework */,
 				39A362D81AAF5E2C00F47390 /* XCGLoggerTests (iOS).xctest */,
 				7B7692CD1B7CCBD100188277 /* XCGLoggerTests (OS X).xctest */,
 			);
@@ -2950,8 +2960,13 @@
 		E65C5B8B1BEA4E7100D28BEF /* FBSnapshotTestCase */ = {
 			isa = PBXGroup;
 			children = (
-				E65C5B8C1BEA4E7100D28BEF /* Categories */,
 				E65C5B931BEA4E7100D28BEF /* FBSnapshotTestCase-Info.plist */,
+				E65C5BD81BEA522600D28BEF /* UIImage+Compare.h */,
+				E65C5BD91BEA522600D28BEF /* UIImage+Compare.m */,
+				E65C5BDA1BEA522600D28BEF /* UIImage+Diff.h */,
+				E65C5BDB1BEA522600D28BEF /* UIImage+Diff.m */,
+				E65C5BDC1BEA522600D28BEF /* UIImage+Snapshot.h */,
+				E65C5BDD1BEA522600D28BEF /* UIImage+Snapshot.m */,
 				E65C5B941BEA4E7100D28BEF /* FBSnapshotTestCase.h */,
 				E65C5B951BEA4E7100D28BEF /* FBSnapshotTestCase.m */,
 				E65C5B961BEA4E7100D28BEF /* FBSnapshotTestCasePlatform.h */,
@@ -2964,17 +2979,22 @@
 			path = ThirdParty/FBSnapshotTestCase;
 			sourceTree = "<group>";
 		};
-		E65C5B8C1BEA4E7100D28BEF /* Categories */ = {
+		E65C5BC51BEA4F6500D28BEF /* NativeRefTests */ = {
 			isa = PBXGroup;
 			children = (
-				E65C5B8D1BEA4E7100D28BEF /* UIImage+Compare.h */,
-				E65C5B8E1BEA4E7100D28BEF /* UIImage+Compare.m */,
-				E65C5B8F1BEA4E7100D28BEF /* UIImage+Diff.h */,
-				E65C5B901BEA4E7100D28BEF /* UIImage+Diff.m */,
-				E65C5B911BEA4E7100D28BEF /* UIImage+Snapshot.h */,
-				E65C5B921BEA4E7100D28BEF /* UIImage+Snapshot.m */,
+				E65C5BC61BEA4F6500D28BEF /* NativeRefTests.swift */,
+				E65C5BE11BEA525800D28BEF /* Other */,
 			);
-			path = Categories;
+			path = NativeRefTests;
+			sourceTree = "<group>";
+		};
+		E65C5BE11BEA525800D28BEF /* Other */ = {
+			isa = PBXGroup;
+			children = (
+				E65C5BE21BEA525800D28BEF /* Info.plist */,
+				E65C5BE31BEA525800D28BEF /* NativeRefTests-Bridging-Header.h */,
+			);
+			path = Other;
 			sourceTree = "<group>";
 		};
 		E66C5B451BDA81050051AA93 /* Apple */ = {
@@ -3044,6 +3064,7 @@
 				F84B21D61A090F8100AAB793 /* ClientTests */,
 				F8708D1E1A0970990051AB07 /* Extensions */,
 				28CE83B71A1D1D3200576538 /* FxAClient */,
+				E65C5BC51BEA4F6500D28BEF /* NativeRefTests */,
 				F84B21BF1A090F8100AAB793 /* Products */,
 				D34DC84C1A16C40C00D49B7B /* Providers */,
 				E4D567191ADECE2700F1EFE7 /* ReadingList */,
@@ -3080,6 +3101,7 @@
 				E4D567221ADECE2700F1EFE7 /* ReadingListTests.xctest */,
 				E6F9650C1B2F1CF20034B023 /* SharedTests.xctest */,
 				E4BA8A2B1B4B0A1600BC2E95 /* ViewLater.appex */,
+				E65C5BC41BEA4F6500D28BEF /* NativeRefTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3548,6 +3570,24 @@
 			productReference = E4D567221ADECE2700F1EFE7 /* ReadingListTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		E65C5BC31BEA4F6500D28BEF /* NativeRefTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E65C5BCB1BEA4F6500D28BEF /* Build configuration list for PBXNativeTarget "NativeRefTests" */;
+			buildPhases = (
+				E65C5BC01BEA4F6500D28BEF /* Sources */,
+				E65C5BC11BEA4F6500D28BEF /* Frameworks */,
+				E65C5BC21BEA4F6500D28BEF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E65C5BCA1BEA4F6500D28BEF /* PBXTargetDependency */,
+			);
+			name = NativeRefTests;
+			productName = NativeRefTests;
+			productReference = E65C5BC41BEA4F6500D28BEF /* NativeRefTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		E6F9650B1B2F1CF20034B023 /* SharedTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E6F965381B2F1CF20034B023 /* Build configuration list for PBXNativeTarget "SharedTests" */;
@@ -3663,7 +3703,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Mozilla;
 				TargetAttributes = {
@@ -3703,6 +3743,10 @@
 					};
 					E4D567211ADECE2700F1EFE7 = {
 						CreatedOnToolsVersion = 6.3;
+						TestTargetID = F84B21BD1A090F8100AAB793;
+					};
+					E65C5BC31BEA4F6500D28BEF = {
+						CreatedOnToolsVersion = 7.1;
 						TestTargetID = F84B21BD1A090F8100AAB793;
 					};
 					E6F9650B1B2F1CF20034B023 = {
@@ -3815,6 +3859,7 @@
 				F84B22481A0920C600AAB793 /* ShareTo */,
 				E4BA8A2A1B4B0A1600BC2E95 /* ViewLater */,
 				D39FA15E1A83E0EC00EE869C /* UITests */,
+				E65C5BC31BEA4F6500D28BEF /* NativeRefTests */,
 				288A2D851AB8B3260023ABC3 /* Shared */,
 				2FCAE2191ABB51F800877008 /* Storage */,
 				2FCAE2231ABB51F800877008 /* StorageTests */,
@@ -4117,20 +4162,6 @@
 			remoteRef = D3B5A0E91B5459F600C15BCF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		E4A85D111BF2600D008BD381 /* XCGLogger.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = XCGLogger.framework;
-			remoteRef = E4A85D101BF2600D008BD381 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		E4A85D131BF2600D008BD381 /* XCGLogger.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = XCGLogger.framework;
-			remoteRef = E4A85D121BF2600D008BD381 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		E69E4E2A1B9F709A00646EDB /* Breakpad.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -4229,6 +4260,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E65C5BC21BEA4F6500D28BEF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E65C5BE41BEA525800D28BEF /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4699,6 +4738,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E65C5BC01BEA4F6500D28BEF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E65C5BDE1BEA522600D28BEF /* UIImage+Compare.m in Sources */,
+				E65C5BC71BEA4F6500D28BEF /* NativeRefTests.swift in Sources */,
+				E65C5BDF1BEA522600D28BEF /* UIImage+Diff.m in Sources */,
+				E65C5BE01BEA522600D28BEF /* UIImage+Snapshot.m in Sources */,
+				E65C5BD51BEA4F8A00D28BEF /* FBSnapshotTestController.m in Sources */,
+				E65C5BD41BEA4F8A00D28BEF /* FBSnapshotTestCasePlatform.m in Sources */,
+				E65C5BD31BEA4F8A00D28BEF /* FBSnapshotTestCase.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E6F965081B2F1CF20034B023 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -5155,6 +5208,11 @@
 			isa = PBXTargetDependency;
 			target = 2FCAE2191ABB51F800877008 /* Storage */;
 			targetProxy = E4EE05AF1BA3A0A10021B3A7 /* PBXContainerItemProxy */;
+		};
+		E65C5BCA1BEA4F6500D28BEF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F84B21BD1A090F8100AAB793 /* Client */;
+			targetProxy = E65C5BC91BEA4F6500D28BEF /* PBXContainerItemProxy */;
 		};
 		E6C05DB11BA1CDA400CDDD08 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -7267,6 +7325,179 @@
 			};
 			name = FennecNightly;
 		};
+		E65C5BCC1BEA4F6500D28BEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					$SRCROOT/,
+					$SDKROOT/usr/include/libxml2,
+					"$SRCROOT/ThirdParty/**",
+				);
+				INFOPLIST_FILE = NativeRefTests/Other/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Fennec.NativeRefTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/$TARGETNAME/Other/NativeRefTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = Debug;
+		};
+		E65C5BCD1BEA4F6500D28BEF /* FennecAurora */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					$SRCROOT/,
+					$SDKROOT/usr/include/libxml2,
+					"$SRCROOT/ThirdParty/**",
+				);
+				INFOPLIST_FILE = NativeRefTests/Other/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Fennec.NativeRefTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/$TARGETNAME/Other/NativeRefTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FennecAurora;
+		};
+		E65C5BCE1BEA4F6500D28BEF /* Firefox */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					$SRCROOT/,
+					$SDKROOT/usr/include/libxml2,
+					"$SRCROOT/ThirdParty/**",
+				);
+				INFOPLIST_FILE = NativeRefTests/Other/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Fennec.NativeRefTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/$TARGETNAME/Other/NativeRefTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Firefox;
+		};
+		E65C5BCF1BEA4F6500D28BEF /* FennecNightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					$SRCROOT/,
+					$SDKROOT/usr/include/libxml2,
+					"$SRCROOT/ThirdParty/**",
+				);
+				INFOPLIST_FILE = NativeRefTests/Other/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Fennec.NativeRefTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/$TARGETNAME/Other/NativeRefTests-Bridging-Header.h";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FennecNightly;
+		};
 		E6F965151B2F1CF20034B023 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -7827,6 +8058,17 @@
 				E4D567351ADECE2900F1EFE7 /* FennecAurora */,
 				E448FCAB1AEE7A6000869B6C /* Firefox */,
 				E4D567361ADECE2900F1EFE7 /* FennecNightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = FennecAurora;
+		};
+		E65C5BCB1BEA4F6500D28BEF /* Build configuration list for PBXNativeTarget "NativeRefTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E65C5BCC1BEA4F6500D28BEF /* Debug */,
+				E65C5BCD1BEA4F6500D28BEF /* FennecAurora */,
+				E65C5BCE1BEA4F6500D28BEF /* Firefox */,
+				E65C5BCF1BEA4F6500D28BEF /* FennecNightly */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = FennecAurora;

--- a/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -184,6 +184,16 @@
                BlueprintIdentifier = "E6F9650B1B2F1CF20034B023"
                BuildableName = "SharedTests.xctest"
                BlueprintName = "SharedTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Client.xcodeproj/xcshareddata/xcschemes/ClientNoTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/ClientNoTests.xcscheme
@@ -159,6 +159,16 @@
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Client.xcodeproj/xcshareddata/xcschemes/ClientRefTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/ClientRefTests.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+               BuildableName = "Client.app"
+               BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "FennecAurora"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "FennecAurora"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Client.xcodeproj/xcshareddata/xcschemes/FennecAurora.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FennecAurora.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -153,6 +153,16 @@
                BlueprintIdentifier = "E4D567211ADECE2700F1EFE7"
                BuildableName = "ReadingListTests.xctest"
                BlueprintName = "ReadingListTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Client.xcodeproj/xcshareddata/xcschemes/FennecNightly.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FennecNightly.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -172,6 +172,16 @@
                BlueprintIdentifier = "E4D567211ADECE2700F1EFE7"
                BuildableName = "ReadingListTests.xctest"
                BlueprintName = "ReadingListTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -153,6 +153,16 @@
                BlueprintIdentifier = "E4D567211ADECE2700F1EFE7"
                BuildableName = "ReadingListTests.xctest"
                BlueprintName = "ReadingListTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Client.xcodeproj/xcshareddata/xcschemes/Travis.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Travis.xcscheme
@@ -164,6 +164,16 @@
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E65C5BC31BEA4F6500D28BEF"
+               BuildableName = "NativeRefTests.xctest"
+               BlueprintName = "NativeRefTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/NativeRefTests/NativeRefTests.swift
+++ b/NativeRefTests/NativeRefTests.swift
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class NativeRefTests: FBSnapshotTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+}

--- a/NativeRefTests/Other/Info.plist
+++ b/NativeRefTests/Other/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/NativeRefTests/Other/NativeRefTests-Bridging-Header.h
+++ b/NativeRefTests/Other/NativeRefTests-Bridging-Header.h
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef NativeRefTests_Bridging_Header_h
+#define NativeRefTests_Bridging_Header_h
+
+#import "Client-Bridging-Header.h"
+#import <FBSnapshotTestCase/FBSnapshotTestCase.h>
+
+#endif /* NativeRefTests_Bridging_Header_h */

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+
+#import <QuartzCore/QuartzCore.h>
+
+#import <UIKit/UIKit.h>
+
+#import <XCTest/XCTest.h>
+
+/*
+ There are three ways of setting reference image directories.
+
+ 1. Set the preprocessor macro FB_REFERENCE_IMAGE_DIR to a double quoted
+    c-string with the path.
+ 2. Set an environment variable named FB_REFERENCE_IMAGE_DIR with the path. This
+    takes precedence over the preprocessor macro to allow for run-time override.
+ 3. Keep everything unset, which will cause the reference images to be looked up
+    inside the bundle holding the current test, in the
+    Resources/ReferenceImages_* directories.
+ */
+#ifndef FB_REFERENCE_IMAGE_DIR
+#define FB_REFERENCE_IMAGE_DIR ""
+#endif
+
+/**
+ Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
+ @param view The view to snapshot
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param suffixes An NSOrderedSet of strings for the different suffixes
+ @param tolerance The percentage of pixels that can differ and still count as an 'identical' view
+ */
+#define FBSnapshotVerifyViewWithOptions(view__, identifier__, suffixes__, tolerance__) \
+  FBSnapshotVerifyViewOrLayerWithOptions(View, view__, identifier__, suffixes__, tolerance__)
+
+#define FBSnapshotVerifyView(view__, identifier__) \
+  FBSnapshotVerifyViewWithOptions(view__, identifier__, FBSnapshotTestCaseDefaultSuffixes(), 0)
+
+
+/**
+ Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
+ @param layer The layer to snapshot
+ @param identifier An optional identifier, used is there are multiple snapshot tests in a given -test method.
+ @param suffixes An NSOrderedSet of strings for the different suffixes
+ @param tolerance The percentage of pixels that can differ and still count as an 'identical' layer
+ */
+#define FBSnapshotVerifyLayerWithOptions(layer__, identifier__, suffixes__, tolerance__) \
+  FBSnapshotVerifyViewOrLayerWithOptions(Layer, layer__, identifier__, suffixes__, tolerance__)
+
+#define FBSnapshotVerifyLayer(layer__, identifier__) \
+  FBSnapshotVerifyLayerWithOptions(layer__, identifier__, FBSnapshotTestCaseDefaultSuffixes(), 0)
+
+
+#define FBSnapshotVerifyViewOrLayerWithOptions(what__, viewOrLayer__, identifier__, suffixes__, tolerance__) \
+{ \
+  NSString *referenceImageDirectory = [self getReferenceImageDirectoryWithDefault:(@ FB_REFERENCE_IMAGE_DIR)]; \
+  XCTAssertNotNil(referenceImageDirectory, @"Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.");\
+  XCTAssertTrue((suffixes__.count > 0), @"Suffixes set cannot be empty %@", suffixes__); \
+  \
+  BOOL testSuccess__ = NO; \
+  NSError *error__ = nil; \
+  NSMutableArray *errors__ = [NSMutableArray array]; \
+  \
+  if (self.recordMode) { \
+    \
+    NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffixes__.firstObject]; \
+    BOOL referenceImageSaved__ = [self compareSnapshotOf ## what__ :(viewOrLayer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
+    if (!referenceImageSaved__) { \
+      [errors__ addObject:error__]; \
+    } \
+  } else { \
+    \
+    for (NSString *suffix__ in suffixes__) { \
+      NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffix__]; \
+      BOOL referenceImageAvailable = [self referenceImageRecordedInDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
+      \
+      if (referenceImageAvailable) { \
+        BOOL comparisonSuccess__ = [self compareSnapshotOf ## what__ :(viewOrLayer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
+        [errors__ removeAllObjects]; \
+        if (comparisonSuccess__) { \
+          testSuccess__ = YES; \
+          break; \
+        } else { \
+          [errors__ addObject:error__]; \
+        } \
+      } else { \
+        [errors__ addObject:error__]; \
+      } \
+    } \
+  } \
+  XCTAssertTrue(testSuccess__, @"Snapshot comparison failed: %@", errors__.firstObject); \
+  XCTAssertFalse(self.recordMode, @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!"); \
+}
+
+
+/**
+ The base class of view snapshotting tests. If you have small UI component, it's often easier to configure it in a test
+ and compare an image of the view to a reference image that write lots of complex layout-code tests.
+ 
+ In order to flip the tests in your subclass to record the reference images set @c recordMode to @c YES.
+ 
+ @attention When recording, the reference image directory should be explicitly
+            set, otherwise the images may be written to somewhere inside the
+            simulator directory.
+
+ For example:
+ @code
+ - (void)setUp
+ {
+    [super setUp];
+    self.recordMode = YES;
+ }
+ @endcode
+ */
+@interface FBSnapshotTestCase : XCTestCase
+
+/**
+ When YES, the test macros will save reference images, rather than performing an actual test.
+ */
+@property (readwrite, nonatomic, assign) BOOL recordMode;
+
+/**
+ When @c YES appends the name of the device model and OS to the snapshot file name.
+ The default value is @c NO.
+ */
+@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
+ When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
+ There are several things that do not work if renderInContext: is used.
+ - UIVisualEffect #70
+ - UIAppearance #91
+ - Size Classes #92
+ 
+ @attention If the view does't belong to a UIWindow, it will create one and add the view as a subview.
+ */
+@property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
+
+- (void)setUp NS_REQUIRES_SUPER;
+- (void)tearDown NS_REQUIRES_SUPER;
+
+/**
+ Performs the comparison or records a snapshot of the layer if recordMode is YES.
+ @param layer The Layer to snapshot
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                    identifier:(NSString *)identifier
+                     tolerance:(CGFloat)tolerance
+                         error:(NSError **)errorPtr;
+
+/**
+ Performs the comparison or records a snapshot of the view if recordMode is YES.
+ @param view The view to snapshot
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)compareSnapshotOfView:(UIView *)view
+     referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                   identifier:(NSString *)identifier
+                    tolerance:(CGFloat)tolerance
+                        error:(NSError **)errorPtr;
+
+/**
+ Checks if reference image with identifier based name exists in the reference images directory.
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if reference image exists.
+ */
+- (BOOL)referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
+                               identifier:(NSString *)identifier
+                                    error:(NSError **)errorPtr;
+
+/**
+ Returns the reference image directory.
+
+ Helper function used to implement the assert macros.
+
+ @param dir directory to use if environment variable not specified. Ignored if null or empty.
+ */
+- (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir;
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <FBSnapshotTestCase/FBSnapshotTestCase.h>
+#import <FBSnapshotTestCase/FBSnapshotTestController.h>
+
+@implementation FBSnapshotTestCase
+{
+  FBSnapshotTestController *_snapshotController;
+}
+
+#pragma mark - Overrides
+
+- (void)setUp
+{
+  [super setUp];
+  _snapshotController = [[FBSnapshotTestController alloc] initWithTestName:NSStringFromClass([self class])];
+}
+
+- (void)tearDown
+{
+  _snapshotController = nil;
+  [super tearDown];
+}
+
+- (BOOL)recordMode
+{
+  return _snapshotController.recordMode;
+}
+
+- (void)setRecordMode:(BOOL)recordMode
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.recordMode = recordMode;
+}
+
+- (BOOL)isDeviceAgnostic
+{
+  return _snapshotController.deviceAgnostic;
+}
+
+- (void)setDeviceAgnostic:(BOOL)deviceAgnostic
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.deviceAgnostic = deviceAgnostic;
+}
+
+- (BOOL)usesDrawViewHierarchyInRect
+{
+  return _snapshotController.usesDrawViewHierarchyInRect;
+}
+
+- (void)setUsesDrawViewHierarchyInRect:(BOOL)usesDrawViewHierarchyInRect
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
+}
+
+#pragma mark - Public API
+
+- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
+      referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                    identifier:(NSString *)identifier
+                     tolerance:(CGFloat)tolerance
+                         error:(NSError **)errorPtr
+{
+  return [self _compareSnapshotOfViewOrLayer:layer
+                    referenceImagesDirectory:referenceImagesDirectory
+                                  identifier:identifier
+                                   tolerance:tolerance
+                                       error:errorPtr];
+}
+
+- (BOOL)compareSnapshotOfView:(UIView *)view
+     referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                   identifier:(NSString *)identifier
+                    tolerance:(CGFloat)tolerance
+                        error:(NSError **)errorPtr
+{
+  return [self _compareSnapshotOfViewOrLayer:view
+                    referenceImagesDirectory:referenceImagesDirectory
+                                  identifier:identifier
+                                   tolerance:tolerance
+                                       error:errorPtr];
+}
+
+- (BOOL)referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
+                               identifier:(NSString *)identifier
+                                    error:(NSError **)errorPtr
+{
+    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+    _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
+    UIImage *referenceImage = [_snapshotController referenceImageForSelector:self.invocation.selector
+                                                                  identifier:identifier
+                                                                       error:errorPtr];
+
+    return (referenceImage != nil);
+}
+
+- (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir
+{
+  NSString *envReferenceImageDirectory = [NSProcessInfo processInfo].environment[@"FB_REFERENCE_IMAGE_DIR"];
+  if (envReferenceImageDirectory) {
+    return envReferenceImageDirectory;
+  }
+  if (dir && dir.length > 0) {
+    return dir;
+  }
+  return [[NSBundle bundleForClass:self.class].resourcePath stringByAppendingPathComponent:@"ReferenceImages"];
+}
+
+
+#pragma mark - Private API
+
+- (BOOL)_compareSnapshotOfViewOrLayer:(id)viewOrLayer
+             referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                           identifier:(NSString *)identifier
+                            tolerance:(CGFloat)tolerance
+                                error:(NSError **)errorPtr
+{
+  _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
+  return [_snapshotController compareSnapshotOfViewOrLayer:viewOrLayer
+                                                  selector:self.invocation.selector
+                                                identifier:identifier
+                                                 tolerance:tolerance
+                                                     error:errorPtr];
+}
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ Returns a Boolean value that indicates whether the snapshot test is running in 64Bit.
+ This method is a convenience for creating the suffixes set based on the architecture
+ that the test is running.
+ 
+ @returns @c YES if the test is running in 64bit, otherwise @c NO.
+ */
+BOOL FBSnapshotTestCaseIs64Bit(void);
+
+/**
+ Returns a default set of strings that is used to append a suffix based on the architectures.
+ @warning Do not modify this function, you can create your own and use it with @c FBSnapshotVerifyViewWithOptions()
+ 
+ @returns An @c NSOrderedSet object containing strings that are appended to the reference images directory.
+ */
+NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void);
+  
+/**
+ Returns a fully «normalized» file name.
+ Strips punctuation and spaces and replaces them with @c _. Also appends the device model, running OS and screen size to the file name.
+ 
+ @returns An @c NSString object containing the passed @c fileName with the device model, OS and screen size appended at the end.
+ */
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+#import <UIKit/UIKit.h>
+
+BOOL FBSnapshotTestCaseIs64Bit(void)
+{
+#if __LP64__
+  return YES;
+#else
+  return NO;
+#endif
+}
+
+NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void)
+{
+  NSMutableOrderedSet *suffixesSet = [[NSMutableOrderedSet alloc] init];
+  [suffixesSet addObject:@"_32"];
+  [suffixesSet addObject:@"_64"];
+  if (FBSnapshotTestCaseIs64Bit()) {
+    return [suffixesSet reversedOrderedSet];
+  } 
+  return [suffixesSet copy];
+}
+
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName)
+{
+  UIDevice *device = [UIDevice currentDevice];
+  CGSize screenSize = [[UIApplication sharedApplication] keyWindow].bounds.size;
+  NSString *os = device.systemVersion;
+  
+  fileName = [NSString stringWithFormat:@"%@_%@%@_%.0fx%.0f", fileName, device.model, os, screenSize.width, screenSize.height];
+  
+  NSMutableCharacterSet *invalidCharacters = [NSMutableCharacterSet new];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
+  NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
+  fileName = [validComponents componentsJoinedByString:@"_"];
+  
+  return fileName;
+}

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, FBSnapshotTestControllerErrorCode) {
+  FBSnapshotTestControllerErrorCodeUnknown,
+  FBSnapshotTestControllerErrorCodeNeedsRecord,
+  FBSnapshotTestControllerErrorCodePNGCreationFailed,
+  FBSnapshotTestControllerErrorCodeImagesDifferentSizes,
+  FBSnapshotTestControllerErrorCodeImagesDifferent,
+};
+/**
+ Errors returned by the methods of FBSnapshotTestController use this domain.
+ */
+extern NSString *const FBSnapshotTestControllerErrorDomain;
+
+/**
+ Errors returned by the methods of FBSnapshotTestController sometimes contain this key in the `userInfo` dictionary.
+ */
+extern NSString *const FBReferenceImageFilePathKey;
+
+/**
+ Provides the heavy-lifting for FBSnapshotTestCase. It loads and saves images, along with performing the actual pixel-
+ by-pixel comparison of images.
+ Instances are initialized with the test class, and directories to read and write to.
+ */
+@interface FBSnapshotTestController : NSObject
+
+/**
+ Record snapshots.
+ */
+@property (readwrite, nonatomic, assign) BOOL recordMode;
+
+/**
+ When @c YES appends the name of the device model and OS to the snapshot file name.
+ The default value is @c NO.
+ */
+@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
+ Uses drawViewHierarchyInRect:afterScreenUpdates: to draw the image instead of renderInContext:
+ */
+@property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
+
+/**
+ The directory in which referfence images are stored.
+ */
+@property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
+
+/**
+ @param testClass The subclass of FBSnapshotTestCase that is using this controller.
+ @returns An instance of FBSnapshotTestController.
+ */
+- (instancetype)initWithTestClass:(Class)testClass;
+
+/**
+ Designated initializer.
+ @param testName The name of the tests.
+ @returns An instance of FBSnapshotTestController.
+ */
+- (instancetype)initWithTestName:(NSString *)testName;
+
+/**
+ Performs the comparison of the layer.
+ @param layer The Layer to snapshot.
+ @param selector The test method being run.
+ @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
+ @param error An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
+                      selector:(SEL)selector
+                    identifier:(NSString *)identifier
+                         error:(NSError **)errorPtr;
+
+/**
+ Performs the comparison of the view.
+ @param view The view to snapshot.
+ @param selector The test method being run.
+ @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
+ @param error An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)compareSnapshotOfView:(UIView *)view
+                     selector:(SEL)selector
+                   identifier:(NSString *)identifier
+                        error:(NSError **)errorPtr;
+
+/**
+ Performs the comparison of a view or layer.
+ @param view The view or layer to snapshot.
+ @param selector The test method being run.
+ @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
+ @param tolerance The percentage of pixels that can differ and still be considered 'identical'
+ @param error An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
+                            selector:(SEL)selector
+                          identifier:(NSString *)identifier
+                           tolerance:(CGFloat)tolerance
+                               error:(NSError **)errorPtr;
+
+/**
+ Loads a reference image.
+ @param selector The test method being run.
+ @param identifier The optional identifier, used when multiple images are tested in a single -test method.
+ @param errorPtr An error, if this methods returns nil, the error will be something useful.
+ @returns An image.
+ */
+- (UIImage *)referenceImageForSelector:(SEL)selector
+                            identifier:(NSString *)identifier
+                                 error:(NSError **)errorPtr;
+
+/**
+ Performs a pixel-by-pixel comparison of the two images with an allowable margin of error.
+ @param referenceImage The reference (correct) image.
+ @param image The image to test against the reference.
+ @param tolerance The percentage of pixels that can differ and still be considered 'identical'
+ @param errorPtr An error that indicates why the comparison failed if it does.
+ @returns YES if the comparison succeeded and the images are the same(ish).
+ */
+- (BOOL)compareReferenceImage:(UIImage *)referenceImage
+                      toImage:(UIImage *)image
+                    tolerance:(CGFloat)tolerance
+                        error:(NSError **)errorPtr;
+
+/**
+ Saves the reference image and the test image to `failedOutputDirectory`.
+ @param referenceImage The reference (correct) image.
+ @param testImage The image to test against the reference.
+ @param selector The test method being run.
+ @param identifier The optional identifier, used when multiple images are tested in a single -test method.
+ @param errorPtr An error that indicates why the comparison failed if it does.
+ @returns YES if the save succeeded.
+ */
+- (BOOL)saveFailedReferenceImage:(UIImage *)referenceImage
+                       testImage:(UIImage *)testImage
+                        selector:(SEL)selector
+                      identifier:(NSString *)identifier
+                           error:(NSError **)errorPtr;
+@end

--- a/ThirdParty/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/ThirdParty/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -1,0 +1,356 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+#import <FBSnapshotTestCase/UIImage+Compare.h>
+#import <FBSnapshotTestCase/UIImage+Diff.h>
+#import <FBSnapshotTestCase/UIImage+Snapshot.h>
+
+#import <UIKit/UIKit.h>
+
+NSString *const FBSnapshotTestControllerErrorDomain = @"FBSnapshotTestControllerErrorDomain";
+NSString *const FBReferenceImageFilePathKey = @"FBReferenceImageFilePathKey";
+
+typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
+  FBTestSnapshotFileNameTypeReference,
+  FBTestSnapshotFileNameTypeFailedReference,
+  FBTestSnapshotFileNameTypeFailedTest,
+  FBTestSnapshotFileNameTypeFailedTestDiff,
+};
+
+@implementation FBSnapshotTestController
+{
+  NSString *_testName;
+  NSFileManager *_fileManager;
+}
+
+#pragma mark - Initializers
+
+- (instancetype)initWithTestClass:(Class)testClass;
+{
+  return [self initWithTestName:NSStringFromClass(testClass)];
+}
+
+- (instancetype)initWithTestName:(NSString *)testName
+{
+  if (self = [super init]) {
+    _testName = [testName copy];
+    _deviceAgnostic = NO;
+    
+    _fileManager = [[NSFileManager alloc] init];
+  }
+  return self;
+}
+
+#pragma mark - Overrides
+
+- (NSString *)description
+{
+  return [NSString stringWithFormat:@"%@ %@", [super description], _referenceImagesDirectory];
+}
+
+#pragma mark - Public API
+
+- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
+                      selector:(SEL)selector
+                    identifier:(NSString *)identifier
+                         error:(NSError **)errorPtr
+{
+  return [self compareSnapshotOfViewOrLayer:layer
+                                   selector:selector
+                                 identifier:identifier
+                                  tolerance:0
+                                      error:errorPtr];
+}
+
+- (BOOL)compareSnapshotOfView:(UIView *)view
+                     selector:(SEL)selector
+                   identifier:(NSString *)identifier
+                        error:(NSError **)errorPtr
+{
+  return [self compareSnapshotOfViewOrLayer:view
+                                   selector:selector
+                                 identifier:identifier
+                                  tolerance:0
+                                      error:errorPtr];
+}
+
+- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
+                            selector:(SEL)selector
+                          identifier:(NSString *)identifier
+                           tolerance:(CGFloat)tolerance
+                               error:(NSError **)errorPtr
+{
+  if (self.recordMode) {
+    return [self _recordSnapshotOfViewOrLayer:viewOrLayer selector:selector identifier:identifier error:errorPtr];
+  } else {
+    return [self _performPixelComparisonWithViewOrLayer:viewOrLayer selector:selector identifier:identifier tolerance:tolerance error:errorPtr];
+  }
+}
+
+- (UIImage *)referenceImageForSelector:(SEL)selector
+                            identifier:(NSString *)identifier
+                                 error:(NSError **)errorPtr
+{
+  NSString *filePath = [self _referenceFilePathForSelector:selector identifier:identifier];
+  UIImage *image = [UIImage imageWithContentsOfFile:filePath];
+  if (nil == image && NULL != errorPtr) {
+    BOOL exists = [_fileManager fileExistsAtPath:filePath];
+    if (!exists) {
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeNeedsRecord
+                                  userInfo:@{
+               FBReferenceImageFilePathKey: filePath,
+                 NSLocalizedDescriptionKey: @"Unable to load reference image.",
+          NSLocalizedFailureReasonErrorKey: @"Reference image not found. You need to run the test in record mode",
+                   }];
+    } else {
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeUnknown
+                                  userInfo:nil];
+    }
+  }
+  return image;
+}
+
+- (BOOL)compareReferenceImage:(UIImage *)referenceImage
+                      toImage:(UIImage *)image
+                    tolerance:(CGFloat)tolerance
+                        error:(NSError **)errorPtr
+{
+  if (CGSizeEqualToSize(referenceImage.size, image.size)) {
+    BOOL imagesEqual = [referenceImage fb_compareWithImage:image tolerance:tolerance];
+    if (NULL != errorPtr) {
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeImagesDifferent
+                                  userInfo:@{
+                                             NSLocalizedDescriptionKey: @"Images different",
+                                             }];
+    }
+    return imagesEqual;
+  }
+  if (NULL != errorPtr) {
+    *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                    code:FBSnapshotTestControllerErrorCodeImagesDifferentSizes
+                                userInfo:@{
+                                           NSLocalizedDescriptionKey: @"Images different sizes",
+                                           NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"referenceImage:%@, image:%@",
+                                                                              NSStringFromCGSize(referenceImage.size),
+                                                                              NSStringFromCGSize(image.size)],
+                                           }];
+  }
+  return NO;
+}
+
+- (BOOL)saveFailedReferenceImage:(UIImage *)referenceImage
+                       testImage:(UIImage *)testImage
+                        selector:(SEL)selector
+                      identifier:(NSString *)identifier
+                           error:(NSError **)errorPtr
+{
+  NSData *referencePNGData = UIImagePNGRepresentation(referenceImage);
+  NSData *testPNGData = UIImagePNGRepresentation(testImage);
+
+  NSString *referencePath = [self _failedFilePathForSelector:selector
+                                                  identifier:identifier
+                                                fileNameType:FBTestSnapshotFileNameTypeFailedReference];
+
+  NSError *creationError = nil;
+  BOOL didCreateDir = [_fileManager createDirectoryAtPath:[referencePath stringByDeletingLastPathComponent]
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:&creationError];
+  if (!didCreateDir) {
+    if (NULL != errorPtr) {
+      *errorPtr = creationError;
+    }
+    return NO;
+  }
+
+  if (![referencePNGData writeToFile:referencePath options:NSDataWritingAtomic error:errorPtr]) {
+    return NO;
+  }
+
+  NSString *testPath = [self _failedFilePathForSelector:selector
+                                             identifier:identifier
+                                           fileNameType:FBTestSnapshotFileNameTypeFailedTest];
+
+  if (![testPNGData writeToFile:testPath options:NSDataWritingAtomic error:errorPtr]) {
+    return NO;
+  }
+
+  NSString *diffPath = [self _failedFilePathForSelector:selector
+                                             identifier:identifier
+                                           fileNameType:FBTestSnapshotFileNameTypeFailedTestDiff];
+
+  UIImage *diffImage = [referenceImage fb_diffWithImage:testImage];
+  NSData *diffImageData = UIImagePNGRepresentation(diffImage);
+
+  if (![diffImageData writeToFile:diffPath options:NSDataWritingAtomic error:errorPtr]) {
+    return NO;
+  }
+
+  NSLog(@"If you have Kaleidoscope installed you can run this command to see an image diff:\n"
+        @"ksdiff \"%@\" \"%@\"", referencePath, testPath);
+
+  return YES;
+}
+
+#pragma mark - Private API
+
+- (NSString *)_fileNameForSelector:(SEL)selector
+                        identifier:(NSString *)identifier
+                      fileNameType:(FBTestSnapshotFileNameType)fileNameType
+{
+  NSString *fileName = nil;
+  switch (fileNameType) {
+    case FBTestSnapshotFileNameTypeFailedReference:
+      fileName = @"reference_";
+      break;
+    case FBTestSnapshotFileNameTypeFailedTest:
+      fileName = @"failed_";
+      break;
+    case FBTestSnapshotFileNameTypeFailedTestDiff:
+      fileName = @"diff_";
+      break;
+    default:
+      fileName = @"";
+      break;
+  }
+  fileName = [fileName stringByAppendingString:NSStringFromSelector(selector)];
+  if (0 < identifier.length) {
+    fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
+  }
+  
+  if (self.isDeviceAgnostic) {
+    fileName = FBDeviceAgnosticNormalizedFileName(fileName);
+  }
+  
+  if ([[UIScreen mainScreen] scale] > 1) {
+    fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
+  }
+  fileName = [fileName stringByAppendingPathExtension:@"png"];
+  return fileName;
+}
+
+- (NSString *)_referenceFilePathForSelector:(SEL)selector
+                                 identifier:(NSString *)identifier
+{
+  NSString *fileName = [self _fileNameForSelector:selector
+                                       identifier:identifier
+                                     fileNameType:FBTestSnapshotFileNameTypeReference];
+  NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:_testName];
+  filePath = [filePath stringByAppendingPathComponent:fileName];
+  return filePath;
+}
+
+- (NSString *)_failedFilePathForSelector:(SEL)selector
+                              identifier:(NSString *)identifier
+                            fileNameType:(FBTestSnapshotFileNameType)fileNameType
+{
+  NSString *fileName = [self _fileNameForSelector:selector
+                                       identifier:identifier
+                                     fileNameType:fileNameType];
+  NSString *folderPath = NSTemporaryDirectory();
+  if (getenv("IMAGE_DIFF_DIR")) {
+    folderPath = @(getenv("IMAGE_DIFF_DIR"));
+  }
+  NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
+  filePath = [filePath stringByAppendingPathComponent:fileName];
+  return filePath;
+}
+
+- (BOOL)_performPixelComparisonWithViewOrLayer:(id)viewOrLayer
+                                      selector:(SEL)selector
+                                    identifier:(NSString *)identifier
+                                     tolerance:(CGFloat)tolerance
+                                         error:(NSError **)errorPtr
+{
+  UIImage *referenceImage = [self referenceImageForSelector:selector identifier:identifier error:errorPtr];
+  if (nil != referenceImage) {
+    UIImage *snapshot = [self _imageForViewOrLayer:viewOrLayer];
+    BOOL imagesSame = [self compareReferenceImage:referenceImage toImage:snapshot tolerance:tolerance error:errorPtr];
+    if (!imagesSame) {
+      [self saveFailedReferenceImage:referenceImage
+                           testImage:snapshot
+                            selector:selector
+                          identifier:identifier
+                               error:errorPtr];
+    }
+    return imagesSame;
+  }
+  return NO;
+}
+
+- (BOOL)_recordSnapshotOfViewOrLayer:(id)viewOrLayer
+                            selector:(SEL)selector
+                          identifier:(NSString *)identifier
+                               error:(NSError **)errorPtr
+{
+  UIImage *snapshot = [self _imageForViewOrLayer:viewOrLayer];
+  return [self _saveReferenceImage:snapshot selector:selector identifier:identifier error:errorPtr];
+}
+
+- (BOOL)_saveReferenceImage:(UIImage *)image
+                   selector:(SEL)selector
+                 identifier:(NSString *)identifier
+                      error:(NSError **)errorPtr
+{
+  BOOL didWrite = NO;
+  if (nil != image) {
+    NSString *filePath = [self _referenceFilePathForSelector:selector identifier:identifier];
+    NSData *pngData = UIImagePNGRepresentation(image);
+    if (nil != pngData) {
+      NSError *creationError = nil;
+      BOOL didCreateDir = [_fileManager createDirectoryAtPath:[filePath stringByDeletingLastPathComponent]
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:&creationError];
+      if (!didCreateDir) {
+        if (NULL != errorPtr) {
+          *errorPtr = creationError;
+        }
+        return NO;
+      }
+      didWrite = [pngData writeToFile:filePath options:NSDataWritingAtomic error:errorPtr];
+      if (didWrite) {
+        NSLog(@"Reference image save at: %@", filePath);
+      }
+    } else {
+      if (nil != errorPtr) {
+        *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                        code:FBSnapshotTestControllerErrorCodePNGCreationFailed
+                                    userInfo:@{
+                                               FBReferenceImageFilePathKey: filePath,
+                                               }];
+      }
+    }
+  }
+  return didWrite;
+}
+
+- (UIImage *)_imageForViewOrLayer:(id)viewOrLayer
+{
+  if ([viewOrLayer isKindOfClass:[UIView class]]) {
+    if (_usesDrawViewHierarchyInRect) {
+      return [UIImage fb_imageForView:viewOrLayer];
+    } else {
+      return [UIImage fb_imageForViewLayer:viewOrLayer];
+    }
+  } else if ([viewOrLayer isKindOfClass:[CALayer class]]) {
+    return [UIImage fb_imageForLayer:viewOrLayer];
+  } else {
+    [NSException raise:@"Only UIView and CALayer classes can be snapshotted" format:@"%@", viewOrLayer];
+  }
+  return nil;
+}
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/SwiftSupport.swift
+++ b/ThirdParty/FBSnapshotTestCase/SwiftSupport.swift
@@ -1,0 +1,66 @@
+/*
+*  Copyright (c) 2015, Facebook, Inc.
+*  All rights reserved.
+*
+*  This source code is licensed under the BSD-style license found in the
+*  LICENSE file in the root directory of this source tree. An additional grant
+*  of patent rights can be found in the PATENTS file in the same directory.
+*
+*/
+
+public extension FBSnapshotTestCase {
+  public func FBSnapshotVerifyView(view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
+    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes)
+  }
+
+  public func FBSnapshotVerifyLayer(layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
+    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes)
+  }
+
+  private func FBSnapshotVerifyViewOrLayer(viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
+    let envReferenceImageDirectory = self.getReferenceImageDirectoryWithDefault(FB_REFERENCE_IMAGE_DIR)
+    var error: NSError?
+    var comparisonSuccess = false
+
+    if let envReferenceImageDirectory = envReferenceImageDirectory {
+      for suffix in suffixes {
+        let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
+        if viewOrLayer.isKindOfClass(UIView) {
+          do {
+            try compareSnapshotOfView(viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0)
+            comparisonSuccess = true
+          } catch let error1 as NSError {
+            error = error1
+            comparisonSuccess = false
+          }
+        } else if viewOrLayer.isKindOfClass(CALayer) {
+          do {
+            try compareSnapshotOfLayer(viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0)
+            comparisonSuccess = true
+          } catch let error1 as NSError {
+            error = error1
+            comparisonSuccess = false
+          }
+        } else {
+          assertionFailure("Only UIView and CALayer classes can be snapshotted")
+        }
+
+        assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
+
+        if comparisonSuccess || recordMode {
+          break
+        }
+
+        assert(comparisonSuccess, message: "Snapshot comparison failed: \(error)", file: file, line: line)
+      }
+    } else {
+      XCTFail("Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.")
+    }
+  }
+
+  func assert(assertion: Bool, message: String, file: String, line: UInt) {
+    if !assertion {
+      XCTFail(message, file: file, line: line)
+    }
+  }
+}

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Compare.h
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Compare.h
@@ -1,0 +1,37 @@
+//
+//  Created by Gabriel Handford on 3/1/09.
+//  Copyright 2009-2013. All rights reserved.
+//  Created by John Boiles on 10/20/11.
+//  Copyright (c) 2011. All rights reserved
+//  Modified by Felix Schulze on 2/11/13.
+//  Copyright 2013. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Compare)
+
+- (BOOL)fb_compareWithImage:(UIImage *)image tolerance:(CGFloat)tolerance;
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Compare.m
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Compare.m
@@ -1,0 +1,134 @@
+//
+//  Created by Gabriel Handford on 3/1/09.
+//  Copyright 2009-2013. All rights reserved.
+//  Created by John Boiles on 10/20/11.
+//  Copyright (c) 2011. All rights reserved
+//  Modified by Felix Schulze on 2/11/13.
+//  Copyright 2013. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <FBSnapshotTestCase/UIImage+Compare.h>
+
+// This makes debugging much more fun
+typedef union {
+    uint32_t raw;
+    unsigned char bytes[4];
+    struct {
+        char red;
+        char green;
+        char blue;
+        char alpha;
+    } __attribute__ ((packed)) pixels;
+} FBComparePixel;
+
+@implementation UIImage (Compare)
+
+- (BOOL)fb_compareWithImage:(UIImage *)image tolerance:(CGFloat)tolerance
+{
+  NSAssert(CGSizeEqualToSize(self.size, image.size), @"Images must be same size.");
+  
+  CGSize referenceImageSize = CGSizeMake(CGImageGetWidth(self.CGImage), CGImageGetHeight(self.CGImage));
+  CGSize imageSize = CGSizeMake(CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage));
+    
+  // The images have the equal size, so we could use the smallest amount of bytes because of byte padding
+  size_t minBytesPerRow = MIN(CGImageGetBytesPerRow(self.CGImage), CGImageGetBytesPerRow(image.CGImage));
+  size_t referenceImageSizeBytes = referenceImageSize.height * minBytesPerRow;
+  void *referenceImagePixels = calloc(1, referenceImageSizeBytes);
+  void *imagePixels = calloc(1, referenceImageSizeBytes);
+
+  if (!referenceImagePixels || !imagePixels) {
+    free(referenceImagePixels);
+    free(imagePixels);
+    return NO;
+  }
+  
+  CGContextRef referenceImageContext = CGBitmapContextCreate(referenceImagePixels,
+                                                             referenceImageSize.width,
+                                                             referenceImageSize.height,
+                                                             CGImageGetBitsPerComponent(self.CGImage),
+                                                             minBytesPerRow,
+                                                             CGImageGetColorSpace(self.CGImage),
+                                                             (CGBitmapInfo)kCGImageAlphaPremultipliedLast
+                                                             );
+  CGContextRef imageContext = CGBitmapContextCreate(imagePixels,
+                                                    imageSize.width,
+                                                    imageSize.height,
+                                                    CGImageGetBitsPerComponent(image.CGImage),
+                                                    minBytesPerRow,
+                                                    CGImageGetColorSpace(image.CGImage),
+                                                    (CGBitmapInfo)kCGImageAlphaPremultipliedLast
+                                                    );
+
+  if (!referenceImageContext || !imageContext) {
+    CGContextRelease(referenceImageContext);
+    CGContextRelease(imageContext);
+    free(referenceImagePixels);
+    free(imagePixels);
+    return NO;
+  }
+
+  CGContextDrawImage(referenceImageContext, CGRectMake(0, 0, referenceImageSize.width, referenceImageSize.height), self.CGImage);
+  CGContextDrawImage(imageContext, CGRectMake(0, 0, imageSize.width, imageSize.height), image.CGImage);
+
+  CGContextRelease(referenceImageContext);
+  CGContextRelease(imageContext);
+
+  BOOL imageEqual = YES;
+
+  // Do a fast compare if we can
+  if (tolerance == 0) {
+    imageEqual = (memcmp(referenceImagePixels, imagePixels, referenceImageSizeBytes) == 0);
+  } else {
+    // Go through each pixel in turn and see if it is different
+    const NSInteger pixelCount = referenceImageSize.width * referenceImageSize.height;
+
+    FBComparePixel *p1 = referenceImagePixels;
+    FBComparePixel *p2 = imagePixels;
+
+    NSInteger numDiffPixels = 0;
+    for (int n = 0; n < pixelCount; ++n) {
+      // If this pixel is different, increment the pixel diff count and see
+      // if we have hit our limit.
+      if (p1->raw != p2->raw) {
+        numDiffPixels ++;
+
+        CGFloat percent = (CGFloat)numDiffPixels / pixelCount;
+        if (percent > tolerance) {
+          imageEqual = NO;
+          break;
+        }
+      }
+
+      p1++;
+      p2++;
+    }
+  }
+
+  free(referenceImagePixels);
+  free(imagePixels);
+
+  return imageEqual;
+}
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Diff.h
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Diff.h
@@ -1,0 +1,37 @@
+//
+//  Created by Gabriel Handford on 3/1/09.
+//  Copyright 2009-2013. All rights reserved.
+//  Created by John Boiles on 10/20/11.
+//  Copyright (c) 2011. All rights reserved
+//  Modified by Felix Schulze on 2/11/13.
+//  Copyright 2013. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Diff)
+
+- (UIImage *)fb_diffWithImage:(UIImage *)image;
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Diff.m
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Diff.m
@@ -1,0 +1,56 @@
+//
+//  Created by Gabriel Handford on 3/1/09.
+//  Copyright 2009-2013. All rights reserved.
+//  Created by John Boiles on 10/20/11.
+//  Copyright (c) 2011. All rights reserved
+//  Modified by Felix Schulze on 2/11/13.
+//  Copyright 2013. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the "Software"), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <FBSnapshotTestCase/UIImage+Diff.h>
+
+@implementation UIImage (Diff)
+
+- (UIImage *)fb_diffWithImage:(UIImage *)image
+{
+  if (!image) {
+    return nil;
+  }
+  CGSize imageSize = CGSizeMake(MAX(self.size.width, image.size.width), MAX(self.size.height, image.size.height));
+  UIGraphicsBeginImageContextWithOptions(imageSize, YES, 0);
+  CGContextRef context = UIGraphicsGetCurrentContext();
+  [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
+  CGContextSetAlpha(context, 0.5);
+  CGContextBeginTransparencyLayer(context, NULL);
+  [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
+  CGContextSetBlendMode(context, kCGBlendModeDifference);
+  CGContextSetFillColorWithColor(context,[UIColor whiteColor].CGColor);
+  CGContextFillRect(context, CGRectMake(0, 0, self.size.width, self.size.height));
+  CGContextEndTransparencyLayer(context);
+  UIImage *returnImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return returnImage;
+}
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Snapshot.h
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Snapshot.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Snapshot)
+
+/// Uses renderInContext: to get a snapshot of the layer.
++ (UIImage *)fb_imageForLayer:(CALayer *)layer;
+
+/// Uses renderInContext: to get a snapshot of the view layer.
++ (UIImage *)fb_imageForViewLayer:(UIView *)view;
+
+/// Uses drawViewHierarchyInRect: to get a snapshot of the view and adds the view into a window if needed.
++ (UIImage *)fb_imageForView:(UIView *)view;
+
+@end

--- a/ThirdParty/FBSnapshotTestCase/UIImage+Snapshot.m
+++ b/ThirdParty/FBSnapshotTestCase/UIImage+Snapshot.m
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <FBSnapshotTestCase/UIImage+Snapshot.h>
+
+@implementation UIImage (Snapshot)
+
++ (UIImage *)fb_imageForLayer:(CALayer *)layer
+{
+  CGRect bounds = layer.bounds;
+  NSAssert1(CGRectGetWidth(bounds), @"Zero width for layer %@", layer);
+  NSAssert1(CGRectGetHeight(bounds), @"Zero height for layer %@", layer);
+
+  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+  CGContextRef context = UIGraphicsGetCurrentContext();
+  NSAssert1(context, @"Could not generate context for layer %@", layer);
+  CGContextSaveGState(context);
+  [layer layoutIfNeeded];
+  [layer renderInContext:context];
+  CGContextRestoreGState(context);
+
+  UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return snapshot;
+}
+
++ (UIImage *)fb_imageForViewLayer:(UIView *)view
+{
+  [view layoutIfNeeded];
+  return [self fb_imageForLayer:view.layer];
+}
+
++ (UIImage *)fb_imageForView:(UIView *)view
+{
+  CGRect bounds = view.bounds;
+  NSAssert1(CGRectGetWidth(bounds), @"Zero width for view %@", view);
+  NSAssert1(CGRectGetHeight(bounds), @"Zero height for view %@", view);  
+
+  UIWindow *window = view.window;
+  if (window == nil) {
+    window = [[UIWindow alloc] initWithFrame:bounds];
+    [window addSubview:view];
+    [window makeKeyAndVisible];
+  }
+  
+  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+  [view layoutIfNeeded];
+  [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
+
+  UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return snapshot;
+}
+
+@end


### PR DESCRIPTION
This PR adds the FBSnapshotTestCase library as a ThirdParty source along with a new test target for writing RefTests on our native view components.