### PR TITLE
Fixes 1221949 - Stop button reloads the page on iPad devices

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -580,6 +580,7 @@ extension URLBarView: BrowserToolbarProtocol {
     }
 
     func updateReloadStatus(isLoading: Bool) {
+        helper?.updateReloadStatus(isLoading)
         if isLoading {
             stopReloadButton.setImage(helper?.ImageStop, forState: .Normal)
             stopReloadButton.setImage(helper?.ImageStopPressed, forState: .Highlighted)


### PR DESCRIPTION
This patch transfers the `isLoading` state to the `BrowserToolbarHelper`, which is the component that deals with presses on the Stop/Reload button. Without the state transferred, it always thinks it needs to reload the page.