### PR TITLE
Bug 1178320 - Fix broken SearchTests

### DIFF
--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -28,6 +28,14 @@ extension KIFUITestActor {
         return element != nil
     }
 
+    func waitForViewWithAccessibilityHint(hint: String) -> UIView? {
+        var view: UIView? = nil
+        autoreleasepool {
+            waitForAccessibilityElement(nil, view: &view, withElementMatchingPredicate: NSPredicate(format: "accessibilityHint = %@", hint), tappable: false)
+        }
+        return view
+    }
+
     func viewExistsWithLabel(label: String) -> Bool {
         do {
             try self.tryFindingViewWithAccessibilityLabel(label)


### PR DESCRIPTION
The main reason for the tests failing was that the suggestion choice was not
reset inbetween test cases. In addition, there were timing issues when checking
whether suggestions are displayed due to the debouncing UI.