### PR TITLE
Bug 1223009 - Startup Crash in GCDWebserver

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -162,6 +162,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AboutHomeHandler.register(server)
         AboutLicenseHandler.register(server)
         SessionRestoreHandler.register(server)
+        // Bug 1223009 was an issue whereby CGDWebserver crashed when moving to a background task
+        // catching and handling the error seemed to fix things, but we're not sure why.
+        // Either way, not implicitly unwrapping a try is not a great way of doing things
+        // so this is better anyway.
         do {
             try server.start()
         } catch let err as NSError {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -162,7 +162,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AboutHomeHandler.register(server)
         AboutLicenseHandler.register(server)
         SessionRestoreHandler.register(server)
-        server.start()
+        do {
+            try server.start()
+        } catch let err as NSError {
+            log.error("Unable to start WebServer \(err)")
+        }
     }
 
     private func setUserAgent() {

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 class WebServer {
-    private static let WebServerSharedInstance = WebServer()
+    static let WebServerSharedInstance = WebServer()
 
     class var sharedInstance: WebServer {
         return WebServerSharedInstance

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -18,8 +18,10 @@ class WebServer {
     }
 
     func start() -> Bool {
-        if !server.running {
-            try! server.startWithOptions([GCDWebServerOption_Port: 6571, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true])
+        withExtendedLifetime(server) {
+            if !server.running {
+                try! server.startWithOptions([GCDWebServerOption_Port: 6571, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true])
+            }
         }
         return server.running
     }

--- a/Client/Application/WebServer.swift
+++ b/Client/Application/WebServer.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-private let WebServerSharedInstance = WebServer()
-
 class WebServer {
+    private static let WebServerSharedInstance = WebServer()
+
     class var sharedInstance: WebServer {
         return WebServerSharedInstance
     }
@@ -17,11 +17,9 @@ class WebServer {
         return "http://localhost:\(server.port)"
     }
 
-    func start() -> Bool {
-        withExtendedLifetime(server) {
-            if !server.running {
-                try! server.startWithOptions([GCDWebServerOption_Port: 6571, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true])
-            }
+    func start() throws -> Bool{
+        if !server.running {
+            try server.startWithOptions([GCDWebServerOption_Port: 6571, GCDWebServerOption_BindToLocalhost: true, GCDWebServerOption_AutomaticallySuspendInBackground: true])
         }
         return server.running
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1223009
https://bugzilla.mozilla.org/show_bug.cgi?id=1223426

ensure GCDWebserver sticks around until after all of it's callbacks are executed