### PR TITLE
Bug 1223099 - Don't call setTopSitesNeedsInvalidation during initial app startup.

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -206,8 +206,6 @@ public class BrowserProfile: Profile {
             self.syncManager.onNewProfile()
             prefs.clearAll()
         }
-
-        history.setTopSitesNeedsInvalidation()
     }
 
     // Extensions don't have a UIApplication.

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -110,6 +110,9 @@ public class SQLiteHistory {
         self.favicons = FaviconsTable<Favicon>()
         self.prefs = prefs
 
+        // Always start by needing invalidation.
+        self.setTopSitesNeedsInvalidation()
+
         // BrowserTable exists only to perform create/update etc. operations -- it's not
         // a queryable thing that needs to stick around.
         if !db.createOrUpdate(BrowserTable(version: version ?? BrowserTable.DefaultVersion)) {


### PR DESCRIPTION
In order to call this method we need to initialize `profile.history`, which involves database work.