### PR TITLE
Bug 1223132 - Use thread-safe helper instead of UIImage(data: NSData)

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -46,8 +46,6 @@
 		0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2861AC0A2B90052877D /* SnackBar.swift */; };
 		0BB5B2891AC0A2B90052877D /* Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2871AC0A2B90052877D /* Toolbar.swift */; };
 		0BB5B28D1AC0A6130052877D /* Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2871AC0A2B90052877D /* Toolbar.swift */; };
-		0BB5B2BC1AC0AB9F0052877D /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2BB1AC0AB9F0052877D /* UIImage+Extensions.swift */; };
-		0BB5B2D71AC0ABA40052877D /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2BB1AC0AB9F0052877D /* UIImage+Extensions.swift */; };
 		0BB5B30B1AC0AD1F0052877D /* LoginsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */; };
 		0BB5B3601AC0D6360052877D /* BookmarkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */; };
 		0BD19A651A2530840084FBA7 /* Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE108391A1B1ED200D4B712 /* Locking.swift */; };
@@ -377,6 +375,7 @@
 		D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		D34E33031BA793C2006135F0 /* loginForm.html in Resources */ = {isa = PBXBuildFile; fileRef = D34E33021BA793C2006135F0 /* loginForm.html */; };
 		D36998891AD70A0A00650C6C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36998881AD70A0A00650C6C /* IOKit.framework */; };
+		D37016031BF282450063D032 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2BB1AC0AB9F0052877D /* UIImageExtensions.swift */; };
 		D375A9201AE71675001B30D5 /* ViewMemoryLeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */; };
 		D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */; };
 		D38A1BEF1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */; };
@@ -1372,7 +1371,7 @@
 		0BAC7A7F1AC4B135006018CB /* AppConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		0BB5B2861AC0A2B90052877D /* SnackBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnackBar.swift; sourceTree = "<group>"; };
 		0BB5B2871AC0A2B90052877D /* Toolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Toolbar.swift; sourceTree = "<group>"; };
-		0BB5B2BB1AC0AB9F0052877D /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
+		0BB5B2BB1AC0AB9F0052877D /* UIImageExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
 		0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LoginsHelper.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkingTests.swift; sourceTree = "<group>"; };
 		0BD19A661A25309B0084FBA7 /* NSUserDefaultsPrefs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaultsPrefs.swift; sourceTree = "<group>"; };
@@ -2118,7 +2117,7 @@
 				2891CEC31ADC7F2900427D3C /* NSURLExtensions.swift */,
 				2F13E77E1AC0BFF200D75081 /* StringExtensions.swift */,
 				D35275151AA8D13B00E9C906 /* UIColorExtensions.swift */,
-				0BB5B2BB1AC0AB9F0052877D /* UIImage+Extensions.swift */,
+				0BB5B2BB1AC0AB9F0052877D /* UIImageExtensions.swift */,
 				0B5142CB1AE1BAF50014D0B3 /* UIViewExtensions.swift */,
 			);
 			path = Extensions;
@@ -4355,6 +4354,7 @@
 				281B2C081ADF4F29002917DC /* DeferredUtils.swift in Sources */,
 				B729F06A1B75CBEF00745F7A /* UserAgent.swift in Sources */,
 				E69BEA5E1BC6A7F300EA6D04 /* ArrayExtensions.swift in Sources */,
+				D37016031BF282450063D032 /* UIImageExtensions.swift in Sources */,
 				2FDE87521ABA3EA0005317B1 /* TimeConstants.swift in Sources */,
 				2891CEC41ADC7F2900427D3C /* NSURLExtensions.swift in Sources */,
 				2FDE87321ABA3E87005317B1 /* json.swift in Sources */,
@@ -4731,7 +4731,6 @@
 				E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */,
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,
-				0BB5B2BC1AC0AB9F0052877D /* UIImage+Extensions.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
 				E4B3345A1BBF2393004E2BFF /* ADJLogger.m in Sources */,
@@ -4781,7 +4780,6 @@
 				74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */,
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
-				0BB5B2D71AC0ABA40052877D /* UIImage+Extensions.swift in Sources */,
 				D38B2D2F1A8D96D00040E6B5 /* GCDWebServer.m in Sources */,
 				0BA2E43C1A69EDAB000581FA /* Profile.swift in Sources */,
 				7BBFEE9F1BB409EB00A305AA /* ErrorPageHelper.swift in Sources */,

--- a/Client/Extensions/UIImageViewExtensions.swift
+++ b/Client/Extensions/UIImageViewExtensions.swift
@@ -15,3 +15,74 @@ public extension UIImageView {
         self.image = placeholder
     }
 }
+
+
+public class ImageOperation : NSObject, SDWebImageOperation {
+    public var cacheOperation: NSOperation?
+
+    var cancelled: Bool {
+        if let cacheOperation = cacheOperation {
+            return cacheOperation.cancelled
+        }
+        return false
+    }
+
+    @objc public func cancel() {
+        if let cacheOperation = cacheOperation {
+            cacheOperation.cancel()
+        }
+    }
+}
+
+// This is an extension to SDWebImage's api to allow passing in a cache to be used for lookup.
+public typealias CompletionBlock = (img: UIImage?, err: NSError, type: SDImageCacheType, key: String) -> Void
+extension UIImageView {
+    // This is a helper function for custom async loaders. It starts an operation that will check for the image in
+    // a cache (either one passed in or the default if none is specified). If its found in the cache its returned,
+    // otherwise, block is run and should return an image to show.
+    private func runBlockIfNotInCache(key: String, var cache: SDImageCache? = nil, completed: CompletionBlock, block: () -> UIImage?) {
+        self.sd_cancelCurrentImageLoad()
+
+        let operation = ImageOperation()
+        if cache == nil {
+            cache = SDImageCache.sharedImageCache()
+        }
+
+        operation.cacheOperation = cache!.queryDiskCacheForKey(key, done: { (var image, cacheType) -> Void in
+            let err = NSError(domain: "UIImage+Extensions.runBlockIfNotInCache", code: 0, userInfo: nil)
+            // If this was cancelled, don't bother notifying the caller
+            if operation.cancelled {
+                return
+            }
+
+            // If it was found in the cache, we can just use it
+            if let image = image {
+                self.image = image
+                self.setNeedsLayout()
+            } else {
+                // Otherwise, the block has a chance to load it
+                image = block()
+                if image != nil {
+                    self.image = image
+                    cache!.storeImage(image, forKey: key)
+                }
+            }
+
+            completed(img: image, err: err, type: cacheType, key: key)
+        })
+
+        self.sd_setImageLoadOperation(operation, forKey: "UIImageViewImageLoad")
+    }
+
+    public func moz_getImageFromCache(key: String, cache: SDImageCache, completed: CompletionBlock) {
+        // This cache is filled outside of here. If we don't find the key in it, nothing to do here.
+        runBlockIfNotInCache(key, cache: cache, completed: completed) { _ in return nil}
+    }
+
+    // Looks up an asset in local storage.
+    public func moz_loadAsset(named: String, completed: CompletionBlock) {
+        runBlockIfNotInCache(named, completed: completed) {
+            return UIImage(named: named)
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2135,7 +2135,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         // we might be overwriting something that the user has subsequently added
                         if pasteBoard.string == url.absoluteString {
                             guard let imageData = responseData where responseError == nil else { return }
-                            pasteBoard.image = UIImage(data: imageData)
+                            pasteBoard.image = UIImage.imageFromDataThreadSafe(imageData)
                             application.endBackgroundTask(taskId)
                         }
                 }
@@ -2161,7 +2161,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             .validate(statusCode: 200..<300)
             .response { _, _, data, _ in
                 if let data = data,
-                   let image = UIImage(data: data) {
+                   let image = UIImage.imageFromDataThreadSafe(data) {
                     success(image)
                 }
             }

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -252,7 +252,7 @@ class OpenSearchParser {
         if let imageElement = largestImageElement,
                imageURL = NSURL(string: imageElement.text!),
                imageData = NSData(contentsOfURL: imageURL),
-               image = UIImage(data: imageData) {
+               image = UIImage.imageFromDataThreadSafe(imageData) {
             uiImage = image
         } else {
             print("Error: Invalid search image data")

--- a/Storage/DiskImageStore.swift
+++ b/Storage/DiskImageStore.swift
@@ -47,8 +47,7 @@ public class DiskImageStore {
         return deferDispatchAsync(queue) { () -> Deferred<Maybe<UIImage>> in
             let imagePath = (self.filesDir as NSString).stringByAppendingPathComponent(key)
             if let data = NSData(contentsOfFile: imagePath),
-                let image = UIImage(data: data)
-            {
+                   image = UIImage.imageFromDataThreadSafe(data) {
                 return deferMaybe(image)
             }
 

--- a/Utils/Extensions/UIImage+Extensions.swift
+++ b/Utils/Extensions/UIImage+Extensions.swift
@@ -11,7 +11,7 @@ extension UIImage {
         let rect = CGRect(origin: CGPointZero, size: size)
         color.setFill()
         CGContextFillRect(context, rect)
-        let image = UIGraphicsGetImageFromCurrentImageContext();
+        let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image
     }
@@ -22,75 +22,5 @@ extension UIImage {
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return scaledImage
-    }
-}
-
-public class ImageOperation : NSObject, SDWebImageOperation {
-    public var cacheOperation: NSOperation?
-
-    var cancelled: Bool {
-        if let cacheOperation = cacheOperation {
-            return cacheOperation.cancelled
-        }
-        return false
-    }
-
-    @objc public func cancel() {
-        if let cacheOperation = cacheOperation {
-            cacheOperation.cancel()
-        }
-    }
-}
-
-// This is an extension to SDWebImage's api to allow passing in a cache to be used for lookup.
-public typealias CompletionBlock = (img: UIImage?, err: NSError, type: SDImageCacheType, key: String) -> Void
-extension UIImageView {
-    // This is a helper function for custom async loaders. It starts an operation that will check for the image in
-    // a cache (either one passed in or the default if none is specified). If its found in the cache its returned,
-    // otherwise, block is run and should return an image to show.
-    private func runBlockIfNotInCache(key: String, var cache: SDImageCache? = nil, completed: CompletionBlock, block: () -> UIImage?) {
-        self.sd_cancelCurrentImageLoad()
-
-        let operation = ImageOperation()
-        if cache == nil {
-            cache = SDImageCache.sharedImageCache()
-        }
-
-        operation.cacheOperation = cache!.queryDiskCacheForKey(key, done: { (var image, cacheType) -> Void in
-            let err = NSError(domain: "UIImage+Extensions.runBlockIfNotInCache", code: 0, userInfo: nil)
-            // If this was cancelled, don't bother notifying the caller
-            if operation.cancelled {
-                return
-            }
-
-            // If it was found in the cache, we can just use it
-            if let image = image {
-                self.image = image
-                self.setNeedsLayout()
-            } else {
-                // Otherwise, the block has a chance to load it
-                image = block()
-                if image != nil {
-                    self.image = image
-                    cache!.storeImage(image, forKey: key)
-                }
-            }
-
-            completed(img: image, err: err, type: cacheType, key: key)
-        })
-
-        self.sd_setImageLoadOperation(operation, forKey: "UIImageViewImageLoad")
-    }
-
-    public func moz_getImageFromCache(key: String, cache: SDImageCache, completed: CompletionBlock) {
-        // This cache is filled outside of here. If we don't find the key in it, nothing to do here.
-        runBlockIfNotInCache(key, cache: cache, completed: completed) { _ in return nil}
-    }
-
-    // Looks up an asset in local storage.
-    public func moz_loadAsset(named: String, completed: CompletionBlock) {
-        runBlockIfNotInCache(named, completed: completed) {
-            return UIImage(named: named)
-        }
     }
 }

--- a/Utils/Extensions/UIImageExtensions.swift
+++ b/Utils/Extensions/UIImageExtensions.swift
@@ -5,7 +5,19 @@
 import Foundation
 import UIKit
 
+private let imageLock = NSLock()
+
 extension UIImage {
+    /// Despite docs that say otherwise, UIImage(data: NSData) isn't thread-safe (see bug 1223132).
+    /// As a workaround, synchronize access to this initializer.
+    /// This fix requires that you *always* use this over UIImage(data: NSData)!
+    public static func imageFromDataThreadSafe(data: NSData) -> UIImage? {
+        imageLock.lock()
+        let image = UIImage(data: data)
+        imageLock.unlock()
+        return image
+    }
+
     public static func createWithColor(size: CGSize, color: UIColor) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
         let context = UIGraphicsGetCurrentContext()

--- a/Utils/Extensions/UIImageExtensions.swift
+++ b/Utils/Extensions/UIImageExtensions.swift
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import UIKit
 
 extension UIImage {
-    class func createWithColor(size: CGSize, color: UIColor) -> UIImage {
-        UIGraphicsBeginImageContextWithOptions(size, false, 0.0);
-        let context = UIGraphicsGetCurrentContext();
+    public static func createWithColor(size: CGSize, color: UIColor) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        let context = UIGraphicsGetCurrentContext()
         let rect = CGRect(origin: CGPointZero, size: size)
         color.setFill()
         CGContextFillRect(context, rect)
@@ -16,7 +17,7 @@ extension UIImage {
         return image
     }
 
-    func createScaled(size: CGSize) -> UIImage {
+    public func createScaled(size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         drawInRect(CGRect(origin: CGPoint(x: 0, y: 0), size: size))
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()


### PR DESCRIPTION
Note that we also do off-thread operations with `UIImage` in `put`:
```
         return deferDispatchAsync(queue) { () -> Success in
             let imagePath = (self.filesDir as NSString).stringByAppendingPathComponent(key)
             if let data = UIImageJPEGRepresentation(image, self.quality) {
```

It's unclear whether this is also unsafe, though moving it to the main thread would be pretty costly (IIRC, this operation took hundreds of milliseconds when I ran some benchmarks). I'm inclined to leave it as is for now until we have evidence that it's a problem.