### PR TITLE
Bug 1223237 - Preserve tabs only if we're not restoring

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1421,12 +1421,12 @@ extension BrowserViewController: TabManagerDelegate {
         updateInContentHomePanel(selected?.url)
     }
 
-    func tabManager(tabManager: TabManager, didCreateTab tab: Browser, restoring: Bool) {
+    func tabManager(tabManager: TabManager, didCreateTab tab: Browser) {
     }
 
-    func tabManager(tabManager: TabManager, didAddTab tab: Browser, restoring: Bool) {
+    func tabManager(tabManager: TabManager, didAddTab tab: Browser) {
         // If we are restoring tabs then we update the count once at the end
-        if !restoring {
+        if !tabManager.isRestoring {
             updateTabCountUsingTabManager(tabManager)
         }
         tab.browserDelegate = self

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -421,6 +421,8 @@ extension TabManager {
     }
 
     private func preserveTabsInternal() {
+        guard !isRestoring else { return }
+
         let path = tabsStateArchivePath()
         var savedTabs = [SavedTab]()
         var savedUUIDs = Set<String>()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -546,10 +546,10 @@ extension TabTrayController: TabManagerDelegate {
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Browser?, previous: Browser?) {
     }
 
-    func tabManager(tabManager: TabManager, didCreateTab tab: Browser, restoring: Bool) {
+    func tabManager(tabManager: TabManager, didCreateTab tab: Browser) {
     }
 
-    func tabManager(tabManager: TabManager, didAddTab tab: Browser, restoring: Bool) {
+    func tabManager(tabManager: TabManager, didAddTab tab: Browser) {
         // Get the index of the added tab from it's set (private or normal)
         guard let index = tabsToDisplay.indexOf(tab) else { return }
         

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -45,7 +45,7 @@ class TabManagerTests: XCTestCase {
         // add some non-private tabs to the tab manager
         for _ in 0..<3 {
             let tab = Browser(configuration: configuration)
-            manager.configureTab(tab, request: NSURLRequest(URL: NSURL(string: "http://yahoo.com")!), flushToDisk: false, zombie: false, restoring: false)
+            manager.configureTab(tab, request: NSURLRequest(URL: NSURL(string: "http://yahoo.com")!), flushToDisk: false, zombie: false)
         }
 
         manager.storeChanges()
@@ -63,7 +63,7 @@ class TabManagerTests: XCTestCase {
             // create some private tabs
             for _ in 0..<3 {
                 let tab = Browser(configuration: configuration, isPrivate: true)
-                manager.configureTab(tab, request: NSURLRequest(URL: NSURL(string: "http://yahoo.com")!), flushToDisk: false, zombie: false, restoring: false)
+                manager.configureTab(tab, request: NSURLRequest(URL: NSURL(string: "http://yahoo.com")!), flushToDisk: false, zombie: false)
             }
 
             manager.storeChanges()


### PR DESCRIPTION
Skips preserving tabs if we're in the middle of restoring. I did some minor refactoring with the way we're handling restoring: rather than passing this boolean around everywhere that might use it, `TabManager` owns the restoring state and updates it before/after the restore happens.