### PR TITLE
Bug 1223985 - Delay loading of queued tabs to viewDidAppear, not applicationDidBecomeActive.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -160,10 +160,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Eventually we'll sync in response to notifications.
     func applicationDidBecomeActive(application: UIApplication) {
         self.profile?.syncManager.applicationDidBecomeActive()
-
-        // We could load these here, but then we have to futz with the tab counter
-        // and making NSURLRequests.
-        self.browserViewController.loadQueuedTabs()
     }
 
     func applicationDidEnterBackground(application: UIApplication) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -494,6 +494,9 @@ class BrowserViewController: UIViewController {
 
         log.debug("BVC calling super.viewDidAppear.")
         super.viewDidAppear(animated)
+
+        log.debug("BVC loading queued tabs.")
+        self.loadQueuedTabs()
         log.debug("BVC done.")
     }
 


### PR DESCRIPTION
This means we won't load queued tabs until you show the home panels. Perhaps that's OK?