### PR TITLE
Bug1221608 – Spotlight Integration, titles only

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -307,6 +307,8 @@
 		2FFC4D1C1ABE3C360081D675 /* FxAState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFC4D1A1ABE3C360081D675 /* FxAState.swift */; };
 		2FFC4D381ABE3C420081D675 /* FxAStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFC4D371ABE3C420081D675 /* FxAStateTests.swift */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
+		39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */; };
+		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
 		39A362D91AAF5ECE00F47390 /* XCGLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39A362D41AAF5E2C00F47390 /* XCGLogger.framework */; };
 		39A362DA1AAF5ECE00F47390 /* XCGLogger.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 39A362D41AAF5E2C00F47390 /* XCGLogger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		39C5750E1BE28BAE00E1C4B1 /* OnePasswordExtension.h in Sources */ = {isa = PBXBuildFile; fileRef = 39C5750C1BE28BAE00E1C4B1 /* OnePasswordExtension.h */; };
@@ -1567,6 +1569,8 @@
 		2FFC4D1A1ABE3C360081D675 /* FxAState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAState.swift; sourceTree = "<group>"; };
 		2FFC4D371ABE3C420081D675 /* FxAStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAStateTests.swift; sourceTree = "<group>"; };
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
+		39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotlightHelper.swift; path = Helpers/SpotlightHelper.swift; sourceTree = "<group>"; };
+		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
 		39A362B21AAF5E2B00F47390 /* XCGLogger.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = XCGLogger.xcodeproj; path = Carthage/Checkouts/XCGLogger/XCGLogger/Library/XCGLogger.xcodeproj; sourceTree = "<group>"; };
 		39C5750C1BE28BAE00E1C4B1 /* OnePasswordExtension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OnePasswordExtension.h; path = "Carthage/Checkouts/onepassword-extension/OnePasswordExtension.h"; sourceTree = "<group>"; };
 		39C5750D1BE28BAE00E1C4B1 /* OnePasswordExtension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OnePasswordExtension.m; path = "Carthage/Checkouts/onepassword-extension/OnePasswordExtension.m"; sourceTree = "<group>"; };
@@ -2550,6 +2554,14 @@
 			path = ThirdParty;
 			sourceTree = "<group>";
 		};
+		39A359BD1BFCCE7B006B9E87 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */,
+			);
+			name = Helpers;
+			sourceTree = "<group>";
+		};
 		39A362B31AAF5E2B00F47390 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -3264,6 +3276,7 @@
 				F84B21E41A0910F600AAB793 /* Application */,
 				28EADE5C1AFC3A6D007FB2FB /* Extensions */,
 				F84B21F11A0910F600AAB793 /* Frontend */,
+				39A359BD1BFCCE7B006B9E87 /* Helpers */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -3331,6 +3344,7 @@
 				0BF42D381A7C0E8900889E28 /* Favicons.js */,
 				D3B692401B9F9CC8004B87A4 /* FindInPage.js */,
 				0BDA568A1B26B1BE008C9B96 /* LoginsHelper.js */,
+				39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */,
 				E49C0EB01B46109C009092BB /* WindowCloseHelper.js */,
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
 				E699220D1B94E3EF007C480D /* About */,
@@ -4476,6 +4490,7 @@
 				E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */,
 				E4424B3C1AC71FB400F44C38 /* FiraSans-Book.ttf in Resources */,
 				0BF42D391A7C0E8900889E28 /* Favicons.js in Resources */,
+				39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */,
 				E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */,
 				E49C0EB11B46109C009092BB /* WindowCloseHelper.js in Resources */,
 				E4D8F3B01ACDD5150005A2E4 /* InfoPlist.strings in Resources */,
@@ -5023,6 +5038,7 @@
 				2F44FCC71A9E8CF500FD20CC /* SearchSettingsTableViewController.swift in Sources */,
 				E4B3345F1BBF2393004E2BFF /* ADJTimerOnce.m in Sources */,
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
+				39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */,
 				6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */,
 				D38B2D341A8D96D00040E6B5 /* GCDWebServerFunctions.m in Sources */,
 				E4B334611BBF2393004E2BFF /* ADJUtil.m in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -347,6 +347,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
+    func application(application: UIApplication, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool {
+        if let url = userActivity.webpageURL {
+            browserViewController.switchToTabForURLOrOpen(url)
+            return true
+        }
+        return false
+    }
+
     private func viewURLInNewTab(notification: UILocalNotification) {
         if let alertURL = notification.userInfo?[TabSendURLKey] as? String {
             if let urlToOpen = NSURL(string: alertURL) {

--- a/Client/Assets/SpotlightHelper.js
+++ b/Client/Assets/SpotlightHelper.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+  var selectors = {
+    title: "head title",
+    description: "head meta[name='description'], body p",
+  };
+
+  function collectText ($document, selector) {
+    var $el = $document.querySelector(selector);
+    if ($el) {
+      return $el.getAttribute("content") || $el.innerText
+    }
+  }
+
+  function assemblePayload ($document, selectors) {
+    var payload = {};
+    for (var key in selectors) {
+      payload[key] = collectText($document, selectors[key]) || "";
+    }
+    return payload;
+  }
+
+  window.addEventListener("load", function() {
+     var payload = assemblePayload(document, selectors);
+     webkit.messageHandlers.spotlightMessageHandler.postMessage(payload);
+  });
+
+})()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -529,6 +529,19 @@ class BrowserViewController: UIViewController {
         super.viewWillDisappear(animated)
     }
 
+    func resetBrowserChrome() {
+        // animate and reset transform for browser chrome
+        urlBar.updateAlphaForSubviews(1)
+
+        [header,
+            footer,
+            readerModeBar,
+            footerBackdrop,
+            headerBackdrop].forEach { view in
+                view?.transform = CGAffineTransformIdentity
+        }
+    }
+
     override func updateViewConstraints() {
         super.updateViewConstraints()
 
@@ -900,6 +913,11 @@ class BrowserViewController: UIViewController {
     }
 
     func switchToTabForURLOrOpen(url: NSURL) {
+        let previousViewController = navigationController?.topViewController
+        navigationController?.popToViewController(self, animated: false)
+        if let previousViewController = previousViewController where previousViewController != self {
+            resetBrowserChrome()
+        }
         if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
@@ -1368,6 +1386,12 @@ extension BrowserViewController: BrowserDelegate {
         let findInPageHelper = FindInPageHelper(browser: browser)
         findInPageHelper.delegate = self
         browser.addHelper(findInPageHelper, name: FindInPageHelper.name())
+
+        let openURL = {(url: NSURL) -> Void in
+            self.switchToTabForURLOrOpen(url)
+        }
+        let spotlightHelper = SpotlightHelper(browser: browser, openURL: openURL)
+        browser.addHelper(spotlightHelper, name: SpotlightHelper.name())
     }
 
     func browser(browser: Browser, willDeleteWebView webView: WKWebView) {
@@ -2534,16 +2558,7 @@ extension BrowserViewController: TabTrayDelegate {
     // This function animates and resets the browser chrome transforms when
     // the tab tray dismisses.
     func tabTrayDidDismiss(tabTray: TabTrayController) {
-        // animate and reset transform for browser chrome
-        urlBar.updateAlphaForSubviews(1)
-
-        [header,
-            footer,
-            readerModeBar,
-            footerBackdrop,
-            headerBackdrop].forEach { view in
-                view?.transform = CGAffineTransformIdentity
-        }
+        resetBrowserChrome()
     }
 
     func tabTrayDidAddBookmark(tab: Browser) {

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -42,7 +42,7 @@ class FaviconManager : BrowserHelper {
                         manager.downloadImageWithURL(iconUrl, options: SDWebImageOptions(options), progress: nil, completed: { (img, err, cacheType, success, url) -> Void in
                             let fav = Favicon(url: url.absoluteString,
                                 date: NSDate(),
-                                type: IconType(rawValue: icon.1)!)
+                                    type: IconType(rawValue: icon.1)!)
 
                             if let img = img {
                                 fav.width = Int(img.size.width)

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -34,7 +34,7 @@ class FaviconManager : BrowserHelper {
         let manager = SDWebImageManager.sharedManager()
         self.browser?.favicons.removeAll(keepCapacity: false)
         if let tab = self.browser,
-            let url = tab.webView!.URL?.absoluteString {
+            let url = tab.url?.absoluteString {
                 let site = Site(url: url, title: "")
                 var favicons = [Favicon]()
                 if let icons = message.body as? [String: Int] {
@@ -65,12 +65,19 @@ class FaviconManager : BrowserHelper {
 
                             if !tab.isPrivate {
                                 self.profile.favicons.addFavicon(fav, forSite: site)
+                                if tab.favicons.isEmpty {
+                                    self.makeFaviconAvailable(tab, atURL: tab.url!, favicon: fav, withImage: img)
+                                }
                             }
                             tab.favicons.append(fav)
                         })
                     }
                 }
-                
         }
+    }
+
+    func makeFaviconAvailable(tab: Browser, atURL url: NSURL, favicon: Favicon, withImage image: UIImage) {
+        let helper = tab.getHelper(name: "SpotlightHelper") as? SpotlightHelper
+        helper?.updateImage(image, forURL: url)
     }
 }

--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -33,16 +33,28 @@ class FaviconManager : BrowserHelper {
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
         let manager = SDWebImageManager.sharedManager()
         self.browser?.favicons.removeAll(keepCapacity: false)
-        if let url = browser?.webView!.URL?.absoluteString {
-            let site = Site(url: url, title: "")
-            if let icons = message.body as? [String: Int] {
-                for icon in icons {
-                    if let iconUrl = NSURL(string: icon.0), let browser = self.browser {
-                        let options = browser.isPrivate ? [SDWebImageOptions.LowPriority, SDWebImageOptions.CacheMemoryOnly] : [SDWebImageOptions.LowPriority]
+        if let tab = self.browser,
+            let url = tab.webView!.URL?.absoluteString {
+                let site = Site(url: url, title: "")
+                var favicons = [Favicon]()
+                if let icons = message.body as? [String: Int] {
+                    for icon in icons {
+                        if let _ = NSURL(string: icon.0), iconType = IconType(rawValue: icon.1) {
+                            let favicon = Favicon(url: icon.0, date: NSDate(), type: iconType)
+                            favicons.append(favicon)
+                        }
+                    }
+                }
+
+                let options = tab.isPrivate ?
+                    [SDWebImageOptions.LowPriority, SDWebImageOptions.CacheMemoryOnly] : [SDWebImageOptions.LowPriority]
+
+                for icon in favicons {
+                    if let iconUrl = NSURL(string: icon.url) {
                         manager.downloadImageWithURL(iconUrl, options: SDWebImageOptions(options), progress: nil, completed: { (img, err, cacheType, success, url) -> Void in
                             let fav = Favicon(url: url.absoluteString,
                                 date: NSDate(),
-                                    type: IconType(rawValue: icon.1)!)
+                                type: icon.type)
 
                             if let img = img {
                                 fav.width = Int(img.size.width)
@@ -51,14 +63,14 @@ class FaviconManager : BrowserHelper {
                                 return
                             }
 
-                            browser.favicons.append(fav)
-                            if !browser.isPrivate {
+                            if !tab.isPrivate {
                                 self.profile.favicons.addFavicon(fav, forSite: site)
                             }
+                            tab.favicons.append(fav)
                         })
                     }
                 }
-            }
+                
         }
     }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -146,6 +146,15 @@ class TabManager : NSObject {
         return nil
     }
 
+    func getTabFor(url: NSURL) -> Browser? {
+        for tab in tabs {
+            if (tab.webView?.URL == url) {
+                return tab
+            }
+        }
+        return nil
+    }
+
     func selectTab(tab: Browser?) {
         assert(NSThread.isMainThread())
 
@@ -349,8 +358,7 @@ class TabManager : NSObject {
     }
 
     func getTabForURL(url: NSURL) -> Browser? {
-        guard let index = (tabs.indexOf { $0.url == url }) else { return nil }
-        return tabs[index]
+        return tabs.filter { $0.webView?.URL == url } .first
     }
 
     func storeChanges() {

--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import CoreSpotlight
+import WebKit
+
+
+private let log = Logger.browserLogger
+private let browsingActivityType: String = "org.mozilla.ios.firefox.browsing"
+
+class SpotlightHelper: NSObject {
+    private(set) var activity: NSUserActivity? {
+        willSet {
+            activity?.invalidate()
+        }
+        didSet {
+            activity?.delegate = self
+        }
+    }
+
+    private var urlForThumbnail: NSURL?
+    private var thumbnailImage: UIImage?
+
+    private let createNewTab: ((url: NSURL) -> ())?
+
+    private weak var tab: Browser?
+
+    init(browser: Browser, openURL: ((url: NSURL) -> ())? = nil) {
+        createNewTab = openURL
+        self.tab = browser
+
+        if let path = NSBundle.mainBundle().pathForResource("SpotlightHelper", ofType: "js") {
+            if let source = try? NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String {
+                let userScript = WKUserScript(source: source, injectionTime: WKUserScriptInjectionTime.AtDocumentEnd, forMainFrameOnly: true)
+                browser.webView!.configuration.userContentController.addUserScript(userScript)
+            }
+        }
+    }
+
+    deinit {
+        // Invalidate the currently held user activity (in willSet)
+        // and release it.
+        self.activity = nil
+    }
+
+    func update(pageContent: [String: String], forURL url: NSURL) {
+        var activity: NSUserActivity
+        if let currentActivity = self.activity where currentActivity.webpageURL == url {
+            activity = currentActivity
+        } else {
+            activity = createUserActivity()
+            self.activity = activity
+            activity.webpageURL = url
+        }
+
+        activity.title = pageContent["title"]
+        if #available(iOS 9, *) {
+            if !(tab?.isPrivate ?? true) {
+                let attrs = CSSearchableItemAttributeSet(itemContentType: kUTTypeHTML as String)
+                attrs.contentDescription = pageContent["description"]
+                attrs.contentURL = url
+                activity.contentAttributeSet = attrs
+                activity.eligibleForSearch = true
+
+                // We can't be certain that the favicon isn't already available.
+                // If it is, for this URL, then update the activity with the favicon now.
+                if let image = thumbnailImage where urlForThumbnail == url {
+                    updateImage(image, forURL: url)
+                }
+            }
+        }
+        activity.becomeCurrent()
+    }
+
+    func updateImage(image: UIImage, forURL url: NSURL) {
+        guard let currentActivity = self.activity where currentActivity.webpageURL == url else {
+            // We've got a favicon, but not for this URL.
+            // Let's store it until we can get the title and description.
+            urlForThumbnail = url
+            thumbnailImage = image
+            return
+        }
+
+        if #available(iOS 9.0, *) {
+            activity?.contentAttributeSet?.thumbnailData = UIImagePNGRepresentation(image)
+        }
+        urlForThumbnail = nil
+        thumbnailImage = nil
+    }
+
+    func becomeCurrent() {
+        activity?.becomeCurrent()
+    }
+
+    func createUserActivity() -> NSUserActivity {
+        return NSUserActivity(activityType: browsingActivityType)
+    }
+}
+
+extension SpotlightHelper: NSUserActivityDelegate {
+    @objc func userActivityWasContinued(userActivity: NSUserActivity) {
+        if let url = userActivity.webpageURL {
+            createNewTab?(url: url)
+        }
+    }
+}
+
+extension SpotlightHelper: BrowserHelper {
+    static func name() -> String {
+        return "SpotlightHelper"
+    }
+
+    func scriptMessageHandlerName() -> String? {
+        return "spotlightMessageHandler"
+    }
+
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        if let tab = self.tab,
+            let url = tab.url,
+            let payload = message.body as? [String: String] {
+                update(payload, forURL: url)
+        }
+    }
+}

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -67,6 +67,10 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Websites you visit may request your location.</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>org.mozilla.ios.firefox.browsing</string>
+	</array>
 	<key>ReleaseChannel</key>
 	<string>$(MOZ_RELEASE_CHANNEL)</string>
 	<key>UIAppFonts</key>

--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -153,7 +153,7 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
         })
     }
 
-    private func getFavicon(siteUrl: NSURL, icon: Favicon, profile: Profile) -> Deferred<Maybe<Favicon>> {
+    func getFavicon(siteUrl: NSURL, icon: Favicon, profile: Profile) -> Deferred<Maybe<Favicon>> {
         let deferred = Deferred<Maybe<Favicon>>()
         let url = icon.url
         let manager = SDWebImageManager.sharedManager()


### PR DESCRIPTION
First success for indexing titles of opened-during-the-lifetime-of-the-install pages.

There are a few choices around when to invalidate the user activity.
 * when the tab closes
 * after each location change and when the tab closes

Currently maintaining a model of one user activity per tab; though the call to `activity.becomeCurrent()` should be done when the tab becomes visible.

I would quite like to beef up the BrowserHelper to be a one-to-many delegate for Browser.

We probably shouldn't be indexing all pages (detect form submission? piggy back on the readability check? index only reader mode text?).