### PR TITLE
Fixes 1224062 - Replace usage of sortInPlace with sort

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -608,8 +608,8 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
         // visible cells do sometimes return also not visible cells when attempting to go past the last cell with VoiceOver right-flick gesture; so make sure we have only visible cells (yeah...)
         visibleCells = visibleCells.filter { !CGRectIsEmpty(CGRectIntersection($0.frame, bounds)) }
 
-        var indexPaths = visibleCells.map { self.collectionView.indexPathForCell($0)! }
-        indexPaths.sortInPlace { $0.section < $1.section || ($0.section == $1.section && $0.row < $1.row) }
+        let indexPaths = visibleCells.map { self.collectionView.indexPathForCell($0)! }
+            .sort { $0.section < $1.section || ($0.section == $1.section && $0.row < $1.row) }
 
         if indexPaths.count == 0 {
             return NSLocalizedString("No tabs", comment: "Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray")

--- a/SharedTests/RollingFileLoggerTests.swift
+++ b/SharedTests/RollingFileLoggerTests.swift
@@ -74,11 +74,9 @@ class RollingFileLoggerTests: XCTestCase {
         let dirURL = NSURL(fileURLWithPath: logDir)
         let prefix = "test"
 
-        // Create 5 log files with spread out over 5 hours
-        var logFilePaths = [0,1,2,3,4].map { self.createNewLogFileWithSize(200, withDate: NSDate().dateByAddingTimeInterval(60 * 60 * $0)) }
-
-        // Reorder paths so oldest is first
-        logFilePaths.sortInPlace { $0 < $1 }
+        // Create 5 log files with spread out over 5 hours and reorder paths so oldest is first
+        let logFilePaths = [0,1,2,3,4].map { self.createNewLogFileWithSize(200, withDate: NSDate().dateByAddingTimeInterval(60 * 60 * $0)) }
+            .sort { $0 < $1 }
 
         let directorySize = try! manager.getAllocatedSizeOfDirectoryAtURL(dirURL, forFilesPrefixedWith: prefix)
 

--- a/SyncTests/MockSyncServer.swift
+++ b/SyncTests/MockSyncServer.swift
@@ -253,10 +253,10 @@ class MockSyncServer {
         if let sort = spec.sort {
             switch sort {
             case SortOption.NewestFirst:
-                items.sortInPlace { $0.modified > $1.modified }
+                items = items.sort { $0.modified > $1.modified }
                 log.debug("Sorted items newest first: \(items.map { $0.modified })")
             case SortOption.OldestFirst:
-                items.sortInPlace { $0.modified < $1.modified }
+                items = items.sort { $0.modified < $1.modified }
                 log.debug("Sorted items oldest first: \(items.map { $0.modified })")
             case SortOption.Index:
                 log.warning("Index sorting not yet supported.")

--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -51,7 +51,7 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
                     }
                 }
 
-                oldIcons.sortInPlace({ (a, b) -> Bool in
+                oldIcons = oldIcons.sort({ (a, b) -> Bool in
                     return a.width > b.width
                 })
 

--- a/Utils/RollingFileLogger.swift
+++ b/Utils/RollingFileLogger.swift
@@ -62,9 +62,9 @@ public class RollingFileLogger: XCGLogger {
         }
 
         do {
-            var logFiles = try NSFileManager.defaultManager().contentsOfDirectoryAtPath(logDirectoryPath!)
-            logFiles = logFiles.filter { $0.hasPrefix("\(prefix).") }
-            logFiles.sortInPlace { $0 < $1 }
+            let logFiles = try NSFileManager.defaultManager().contentsOfDirectoryAtPath(logDirectoryPath!)
+                .filter { $0.hasPrefix("\(prefix).") }
+                .sort { $0 < $1 }
 
             if let oldestLogFilename = logFiles.first {
                 try NSFileManager.defaultManager().removeItemAtPath("\(logDirectoryPath!)/\(oldestLogFilename)")


### PR DESCRIPTION
This patch replaces all usages of `sortInPlace` with `sort`. See bug description why this needs to happen.