### PR TITLE
Bug 1224227 - Remove overridden backgroundColor on locationTextView

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -318,7 +318,6 @@ class URLBarView: UIView {
         locationTextField.autocapitalizationType = UITextAutocapitalizationType.None
         locationTextField.returnKeyType = UIReturnKeyType.Go
         locationTextField.clearButtonMode = UITextFieldViewMode.WhileEditing
-        locationTextField.backgroundColor = UIColor.whiteColor()
         locationTextField.font = UIConstants.DefaultMediumFont
         locationTextField.accessibilityIdentifier = "address"
         locationTextField.accessibilityLabel = NSLocalizedString("Address and Search", comment: "Accessibility label for address and search field, both words (Address, Search) are therefore nouns.")


### PR DESCRIPTION
We're setting the background color manually when creating the text field, overriding the theme. Looks like we just need to remove that line.