### PR TITLE
Bug 1221972 - Filter out invalid long press events

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2090,6 +2090,12 @@ extension BrowserViewController: FxAContentViewControllerDelegate {
 
 extension BrowserViewController: ContextMenuHelperDelegate {
     func contextMenuHelper(contextMenuHelper: ContextMenuHelper, didLongPressElements elements: ContextMenuHelper.Elements, gestureRecognizer: UILongPressGestureRecognizer) {
+        // locationInView can return (0, 0) when the long press is triggered in an invalid page
+        // state (e.g., long pressing a link before the document changes, then releasing after a
+        // different page loads).
+        let touchPoint = gestureRecognizer.locationInView(view)
+        guard touchPoint != CGPointZero else { return }
+
         let actionSheetController = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.ActionSheet)
         var dialogTitle: String?
 
@@ -2178,7 +2184,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
         // If we're showing an arrow popup, set the anchor to the long press location.
         if let popoverPresentationController = actionSheetController.popoverPresentationController {
             popoverPresentationController.sourceView = view
-            popoverPresentationController.sourceRect = CGRect(origin: gestureRecognizer.locationInView(view), size: CGSizeMake(0, 16))
+            popoverPresentationController.sourceRect = CGRect(origin: touchPoint, size: CGSizeMake(0, 16))
             popoverPresentationController.permittedArrowDirections = .Any
         }
 


### PR DESCRIPTION
After some logging, here's what's happening:
 1. When you touch the element, `touchstart` is being fired [here](https://github.com/mozilla/firefox-ios/blob/0ec1c678534f5ffedc6398288f10908407be234e/Client/Assets/ContextMenu.js#L91), as expected.
 1. After the next page loads and you release your finger, `touchstart` is fired *again*, and it fires on whatever element is at your finger's location on the new page.
 1. This fires off the context menu timeout [here](https://github.com/mozilla/firefox-ios/blob/0ec1c678534f5ffedc6398288f10908407be234e/Client/Assets/ContextMenu.js#L135). There's no `touchend` that happens after to cancel, so the context menu is shown.

This seems like another iOS bug as I wouldn't expect `touchstart` to fire the second time (I'd expect maybe `touchend` to fire instead, or maybe nothing at all in this case). I couldn't find a good way to weed out these bogus cases, so I'm using the result from `locationInView` to do the filtering: if it's (0, 0), assume it's invalid.