### PR TITLE
Bug 1203014 - Make Log Out a button (visually)

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -44,6 +44,7 @@ class ConnectSetting: WithoutAccountSetting {
 // Sync setting for disconnecting a Firefox Account.  Shown when we have an account.
 class DisconnectSetting: WithAccountSetting {
     override var accessoryType: UITableViewCellAccessoryType { return .None }
+    override var textAlignment: NSTextAlignment { return .Center }
 
     override var title: NSAttributedString? {
         return NSAttributedString(string: NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account"), attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
@@ -61,6 +62,8 @@ class DisconnectSetting: WithAccountSetting {
         alertController.addAction(
             UIAlertAction(title: NSLocalizedString("Log Out", comment: "Disconnect button in the 'log out firefox account' alert"), style: .Destructive) { (action) in
                 self.settings.profile.removeAccount()
+                self.settings.settings = self.settings.generateSettings()
+                self.settings.SELfirefoxAccountDidChange()
             })
         navigationController?.presentViewController(alertController, animated: true, completion: nil)
     }

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -117,11 +117,17 @@ class AppSettingsTableViewController: SettingsTableViewController {
                 VersionSetting(settings: self),
                 LicenseAndAcknowledgementsSetting(),
                 YourRightsSetting(),
-                DisconnectSetting(settings: self),
                 ExportBrowserDataSetting(settings: self),
                 DeleteExportedDataSetting(settings: self),
-            ])
-        ]
+            ])]
+            
+            if (profile.hasAccount()) {
+                settings += [
+                    SettingSection(title: nil, children: [
+                        DisconnectSetting(settings: self),
+                        ])
+                ]
+            }
 
         return settings
     }

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -52,12 +52,15 @@ class Setting {
 
     var accessoryType: UITableViewCellAccessoryType { return .None }
 
+    var textAlignment: NSTextAlignment { return .Left }
+    
     private(set) var enabled: Bool = true
 
     // Called when the cell is setup. Call if you need the default behaviour.
     func onConfigureCell(cell: UITableViewCell) {
         cell.detailTextLabel?.attributedText = status
         cell.textLabel?.attributedText = title
+        cell.textLabel?.textAlignment = textAlignment
         cell.accessoryType = accessoryType
         cell.accessoryView = nil
         cell.selectionStyle = enabled ? .Default : .None
@@ -241,11 +244,11 @@ class SettingsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         tableView.registerClass(SettingsTableViewCell.self, forCellReuseIdentifier: Identifier)
         tableView.registerClass(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderIdentifier)
         tableView.tableFooterView = SettingsTableFooterView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 128))
-
+        
         tableView.separatorColor = UIConstants.TableViewSeparatorColor
         tableView.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
     }
@@ -298,7 +301,7 @@ class SettingsTableViewController: UITableViewController {
         }
     }
 
-    @objc private func SELfirefoxAccountDidChange() {
+    @objc func SELfirefoxAccountDidChange() {
         self.tableView.reloadData()
     }
 


### PR DESCRIPTION
If applied, this commit will create new property of Setting class with default text alignment - left.
Override text alignment for log out button setting to centre.
Move logout to separate section.