### PR TITLE
Bug 1224908: Fix accessibility of tabs button

### DIFF
--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -58,6 +58,8 @@ class TabsButton: UIControl {
         insideButton.addSubview(borderView)
         insideButton.addSubview(titleLabel)
         addSubview(insideButton)
+        isAccessibilityElement = true
+        accessibilityTraits |= UIAccessibilityTraitButton
     }
 
     override func updateConstraints() {


### PR DESCRIPTION
[Bug 1224908: Fix accessibility of tabs button](https://bugzilla.mozilla.org/show_bug.cgi?id=1224908)

- isAccessibilityElement ensures accessibility is handled by the
  TabsButton wrapper view itself, and does not descend to subviews
- accessibilityTraits ensure VoiceOver says that TabsButton is a button

I ran BookmarkingTests (which use the tabs button) and they worked (I
did not run others as some tests already fail without this change
applied, and I did not want to compare which fail with it and which fail
without it).

Patch donated by [A11Y LTD.](http://a11y.ltd.uk)