### PR TITLE
Bug 1219241 - Updating the UI for reader view to webView:didCommitNavigation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -778,12 +778,9 @@ class BrowserViewController: UIViewController {
             toolbar?.updateReloadStatus(loading)
             urlBar.updateReloadStatus(loading)
         case KVOURL:
-            if let tab = tabManager.selectedTab where tab.webView?.URL == nil {
+            guard let tab = tabManager.selectedTab where tab.webView?.URL == nil else {
                 log.debug("URL is nil!")
-            }
-
-            if let tab = tabManager.selectedTab where tab.webView === webView && !tab.restoring {
-                updateUIForReaderHomeStateForTab(tab)
+                break
             }
         case KVOCanGoBack:
             guard let canGoBack = change?[NSKeyValueChangeNewKey] as? Bool else { break }
@@ -1594,6 +1591,12 @@ extension BrowserViewController: WKNavigationDelegate {
             } else {
                 completionHandler(NSURLSessionAuthChallengeDisposition.PerformDefaultHandling, nil)
             }
+    }
+
+    func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
+        if let tab = tabManager.selectedTab where tab.webView === webView && !tab.restoring {
+            updateUIForReaderHomeStateForTab(tab)
+        }
     }
 
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1219241

This is so that we don't trigger a layout of the UI on a webpage that may trigger a redirect just because the URL has changed.