### PR TITLE
Bug 1224440 - Rework BrowserTable and database upgrade tests

### DIFF
--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -337,8 +337,8 @@ extension BrowserDB {
         return run([(sql, args)])
     }
 
-    func run(sql: [String]) -> Success {
-        return self.run(sql.map { (sql: $0, args: nil) })
+    func run(commands: [String]) -> Success {
+        return self.run(commands.map { (sql: $0, args: nil) })
     }
 
     /**

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -337,6 +337,10 @@ extension BrowserDB {
         return run([(sql, args)])
     }
 
+    func run(sql: [String]) -> Success {
+        return self.run(sql.map { (sql: $0, args: nil) })
+    }
+
     /**
      * Runs an array of sql commands. Note: These will all run in order in a transaction and will block
      * the callers thread until they've finished. If any of them fail the operation will abort (no more

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -52,9 +52,9 @@ public class BrowserDB {
     }
 
     // Creates a table and writes its table info into the table-table database.
-    private func createTable(conn: SQLiteDBConnection, table: Table) -> TableResult {
+    private func createTable(conn: SQLiteDBConnection, table: SectionCreator) -> TableResult {
         log.debug("Try create \(table.name) version \(table.version)")
-        if !table.create(conn, version: table.version) {
+        if !table.create(conn) {
             // If creating failed, we'll bail without storing the table info
             log.debug("Creation failed.")
             return .Failed
@@ -66,7 +66,7 @@ public class BrowserDB {
 
     // Updates a table and writes its table into the table-table database.
     // Exposed internally for testing.
-    func updateTable(conn: SQLiteDBConnection, table: Table) -> TableResult {
+    func updateTable(conn: SQLiteDBConnection, table: SectionUpdater) -> TableResult {
         log.debug("Trying update \(table.name) version \(table.version)")
         var from = 0
         // Try to find the stored version of the table
@@ -82,7 +82,7 @@ public class BrowserDB {
             return .Exists
         }
 
-        if !table.updateTable(conn, from: from, to: table.version) {
+        if !table.updateTable(conn, from: from) {
             // If the update failed, we'll bail without writing the change to the table-table.
             log.debug("Updating failed.")
             return .Failed

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -411,6 +411,8 @@ public class BrowserTable: Table {
             return drop(db) && create(db, version: to)
         }
 
+        log.debug("Updating browser tables from \(from) to \(to).")
+
         if from < 4 && to >= 4 {
             return drop(db) && create(db, version: to)
         }

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -103,10 +103,30 @@ public class BrowserTable: Table {
         return true
     }
 
+    func run(db: SQLiteDBConnection, queries: [String]) -> Bool {
+        for sql in queries {
+            if !run(db, sql: sql) {
+                return false
+            }
+        }
+        return true
+    }
+
     func runValidQueries(db: SQLiteDBConnection, queries: [(String?, Args?)]) -> Bool {
         for (sql, args) in queries {
             if let sql = sql {
                 if !run(db, sql: sql, args: args) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    func runValidQueries(db: SQLiteDBConnection, queries: [String?]) -> Bool {
+        for sql in queries {
+            if let sql = sql {
+                if !run(db, sql: sql) {
                     return false
                 }
             }

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -352,7 +352,7 @@ public class BrowserTable: Table {
         let indexStructureParentIdx = "CREATE INDEX IF NOT EXISTS \(IndexBookmarksMirrorStructureParentIdx) " +
             "ON \(TableBookmarksMirrorStructure) (parent, idx)"
 
-        let queries: [String?] = [
+        let queries: [String] = [
             getDomainsTableCreationString(),
             getHistoryTableCreationString(),
             favicons,
@@ -375,7 +375,7 @@ public class BrowserTable: Table {
 
         log.debug("Creating \(queries.count) tables, views, and indices.")
 
-        return self.runValidQueries(db, queries: queries) &&
+        return self.run(db, queries: queries) &&
                self.prepopulateRootFolders(db)
     }
 
@@ -405,8 +405,7 @@ public class BrowserTable: Table {
         }
 
         if from < 5 && to >= 5  {
-            let queries: [String] = [getQueueTableCreationString()]
-            if !self.runValidQueries(db, queries: queries) {
+            if !self.run(db, sql: getQueueTableCreationString()) {
                 return false
             }
         }

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -126,14 +126,7 @@ public class BrowserTable: Table {
     }
 
     func runValidQueries(db: SQLiteDBConnection, queries: [String?]) -> Bool {
-        for sql in queries {
-            if let sql = sql {
-                if !run(db, sql: sql) {
-                    return false
-                }
-            }
-        }
-        return true
+        return self.run(db: db, queries: optFilter(queries))
     }
 
     func prepopulateRootFolders(db: SQLiteDBConnection) -> Bool {

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -414,18 +414,9 @@ public class BrowserTable: Table {
             if !self.run(db, queries: [
                 "DROP INDEX IF EXISTS \(IndexVisitsSiteIDDate)",
                 "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) ON \(TableVisits) (siteID, is_local, date)",
-            ]) {
-                return false
-            }
-        }
-
-        if from < 7 && to >= 7 {
-            let queries: [String] = [
                 getDomainsTableCreationString(),
                 "ALTER TABLE \(TableHistory) ADD COLUMN domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE",
-            ]
-
-            if !self.runValidQueries(db, queries: queries) {
+            ]) {
                 return false
             }
 

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -366,23 +366,23 @@ public class BrowserTable: Table {
         let indexStructureParentIdx = "CREATE INDEX IF NOT EXISTS \(IndexBookmarksMirrorStructureParentIdx) " +
             "ON \(TableBookmarksMirrorStructure) (parent, idx)"
 
-        let queries: [(String?, Args?)] = [
-            (getDomainsTableCreationString(forVersion: version), nil),
-            (getHistoryTableCreationString(forVersion: version), nil),
-            (favicons, nil),
-            (visits, nil),
-            (bookmarks, nil),
-            (bookmarksMirror, nil),
-            (bookmarksMirrorStructure, nil),
-            (indexStructureParentIdx, nil),
-            (faviconSites, nil),
-            (indexShouldUpload, nil),
-            (indexSiteIDDate, nil),
-            (widestFavicons, nil),
-            (historyIDsWithIcon, nil),
-            (iconForURL, nil),
-            (getQueueTableCreationString(forVersion: version), nil),
-            (getTopSitesTableCreationString(forVersion: version), nil),
+        let queries: [String?] = [
+            getDomainsTableCreationString(forVersion: version),
+            getHistoryTableCreationString(forVersion: version),
+            favicons,
+            visits,
+            bookmarks,
+            bookmarksMirror,
+            bookmarksMirrorStructure,
+            indexStructureParentIdx,
+            faviconSites,
+            indexShouldUpload,
+            indexSiteIDDate,
+            widestFavicons,
+            historyIDsWithIcon,
+            iconForURL,
+            getQueueTableCreationString(forVersion: version),
+            getTopSitesTableCreationString(forVersion: version),
         ]
 
         assert(queries.count == AllTablesIndicesAndViews.count, "Did you forget to add your table, index, or view to the list?")
@@ -416,7 +416,7 @@ public class BrowserTable: Table {
         }
 
         if from < 5 && to >= 5  {
-            let queries: [(String?, Args?)] = [(getQueueTableCreationString(forVersion: to), nil)]
+            let queries: [String?] = [getQueueTableCreationString(forVersion: to)]
             if !self.runValidQueries(db, queries: queries) {
                 return false
             }
@@ -424,17 +424,17 @@ public class BrowserTable: Table {
 
         if from < 6 && to >= 6 {
             if !self.run(db, queries: [
-                ("DROP INDEX IF EXISTS \(IndexVisitsSiteIDDate)", nil),
-                ("CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) ON \(TableVisits) (siteID, is_local, date)", nil)
+                "DROP INDEX IF EXISTS \(IndexVisitsSiteIDDate)",
+                "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) ON \(TableVisits) (siteID, is_local, date)",
             ]) {
                 return false
             }
         }
 
         if from < 7 && to >= 7 {
-            let queries: [(String?, Args?)] = [
-                (getDomainsTableCreationString(forVersion: to), nil),
-                ("ALTER TABLE \(TableHistory) ADD COLUMN domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE", nil)
+            let queries: [String?] = [
+                getDomainsTableCreationString(forVersion: to),
+                "ALTER TABLE \(TableHistory) ADD COLUMN domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE",
             ]
 
             if !self.runValidQueries(db, queries: queries) {
@@ -527,10 +527,10 @@ public class BrowserTable: Table {
         let dropTemp = "DROP TABLE \(tmpTable)"
 
         // Now run these.
-        if !self.run(db, queries: [(domains, nil),
-                                   (domainIDs, nil),
-                                   (updateHistory, nil),
-                                   (dropTemp, nil)]) {
+        if !self.run(db, queries: [domains,
+                                   domainIDs,
+                                   updateHistory,
+                                   dropTemp]) {
             log.error("Unable to migrate domains.")
             return false
         }
@@ -551,13 +551,13 @@ public class BrowserTable: Table {
 
     func drop(db: SQLiteDBConnection) -> Bool {
         log.debug("Dropping all browser tables.")
-        let additional: [(String, Args?)] = [
-            ("DROP TABLE IF EXISTS faviconSites", nil) // We renamed it to match naming convention.
+        let additional = [
+            "DROP TABLE IF EXISTS faviconSites" // We renamed it to match naming convention.
         ]
 
-        let queries: [(String, Args?)] = AllViews.map { ("DROP VIEW IF EXISTS \($0!)", nil) } as [(String, Args?)] +
-                      AllIndices.map { ("DROP INDEX IF EXISTS \($0!)", nil) } as [(String, Args?)] +
-                      AllTables.map { ("DROP TABLE IF EXISTS \($0!)", nil) } as [(String, Args?)] +
+        let queries = AllViews.map { "DROP VIEW IF EXISTS \($0!)" } +
+                      AllIndices.map { "DROP INDEX IF EXISTS \($0!)" } +
+                      AllTables.map { "DROP TABLE IF EXISTS \($0!)" } +
                       additional
 
         return self.run(db, queries: queries)

--- a/Storage/SQL/FaviconsTable.swift
+++ b/Storage/SQL/FaviconsTable.swift
@@ -8,7 +8,7 @@ import Foundation
 class FaviconsTable<T>: GenericTable<Favicon> {
     override var name: String { return TableFavicons }
     override var rows: String { return "" }
-    override func create(db: SQLiteDBConnection, version: Int) -> Bool {
+    override func create(db: SQLiteDBConnection) -> Bool {
         // Nothing to do: BrowserTable does it all.
         return true
     }

--- a/Storage/SQL/GenericTable.swift
+++ b/Storage/SQL/GenericTable.swift
@@ -25,12 +25,20 @@ class TableInfoWrapper: TableInfo {
 }
 
 /**
- * Something that knows how to build and maintain part of a database.
+ * Something that knows how to construct part of a database.
+ */
+protocol SectionCreator: TableInfo {
+    func create(db: SQLiteDBConnection) -> Bool
+}
+
+protocol SectionUpdater: TableInfo {
+    func updateTable(db: SQLiteDBConnection, from: Int) -> Bool
+}
+
+/*
  * This should really be called "Section" or something like that.
  */
-protocol Table: TableInfo {
-    func create(db: SQLiteDBConnection, version: Int) -> Bool
-    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool
+protocol Table: SectionCreator, SectionUpdater {
     func exists(db: SQLiteDBConnection) -> Bool
     func drop(db: SQLiteDBConnection) -> Bool
 }
@@ -117,7 +125,7 @@ class GenericTable<T>: BaseTable {
         return nil
     }
 
-    func create(db: SQLiteDBConnection, version: Int) -> Bool {
+    func create(db: SQLiteDBConnection) -> Bool {
         if let err = db.executeChange("CREATE TABLE IF NOT EXISTS \(name) (\(rows))") {
             log.error("Error creating \(self.name) - \(err)")
             return false
@@ -125,7 +133,8 @@ class GenericTable<T>: BaseTable {
         return true
     }
 
-    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
+    func updateTable(db: SQLiteDBConnection, from: Int) -> Bool {
+        let to = self.version
         log.debug("Update table \(self.name) from \(from) to \(to)")
         return false
     }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -105,14 +105,14 @@ public class SQLiteHistory {
     let favicons: FaviconsTable<Favicon>
     let prefs: Prefs
 
-    required public init?(db: BrowserDB, prefs: Prefs, version: Int? = nil) {
+    required public init?(db: BrowserDB, prefs: Prefs) {
         self.db = db
         self.favicons = FaviconsTable<Favicon>()
         self.prefs = prefs
 
         // BrowserTable exists only to perform create/update etc. operations -- it's not
         // a queryable thing that needs to stick around.
-        if !db.createOrUpdate(BrowserTable(version: version ?? BrowserTable.DefaultVersion)) {
+        if !db.createOrUpdate(BrowserTable()) {
             return nil
         }
     }

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -36,9 +36,7 @@ private class LoginsTable: Table {
         return true
     }
 
-    func create(db: SQLiteDBConnection, version: Int) -> Bool {
-        // We ignore the version.
-
+    func create(db: SQLiteDBConnection) -> Bool {
         let common =
         "id INTEGER PRIMARY KEY AUTOINCREMENT" +
         ", hostname TEXT NOT NULL" +
@@ -72,7 +70,8 @@ private class LoginsTable: Table {
         return self.run(db, queries: [mirror, local])
     }
 
-    func updateTable(db: SQLiteDBConnection, from: Int, to: Int) -> Bool {
+    func updateTable(db: SQLiteDBConnection, from: Int) -> Bool {
+        let to = self.version
         if from == to {
             log.debug("Skipping update from \(from) to \(to).")
             return true
@@ -81,12 +80,12 @@ private class LoginsTable: Table {
         if from == 0 {
             // This is likely an upgrade from before Bug 1160399.
             log.debug("Updating logins tables from zero. Assuming drop and recreate.")
-            return drop(db) && create(db, version: to)
+            return drop(db) && create(db)
         }
 
         // TODO: real update!
         log.debug("Updating logins table from \(from) to \(to).")
-        return drop(db) && create(db, version: to)
+        return drop(db) && create(db)
     }
 
     func exists(db: SQLiteDBConnection) -> Bool {

--- a/StorageTests/TestFaviconsTable.swift
+++ b/StorageTests/TestFaviconsTable.swift
@@ -72,7 +72,7 @@ class TestFaviconsTable : XCTestCase {
 
         var err: NSError?
         self.db.withConnection(flags: SwiftData.Flags.ReadWriteCreate, err: &err) { (db, err) -> Bool in
-            let result = f.create(db, version: 1)
+            let result = f.create(db)
             XCTAssertTrue(result)
             return result
         }

--- a/StorageTests/TestSQLiteBookmarks.swift
+++ b/StorageTests/TestSQLiteBookmarks.swift
@@ -11,7 +11,7 @@ private func getBrowserDB(filename: String, files: FileAccessor) -> BrowserDB? {
 
     // BrowserTable exists only to perform create/update etc. operations -- it's not
     // a queryable thing that needs to stick around.
-    if !db.createOrUpdate(BrowserTable(version: BrowserTable.DefaultVersion)) {
+    if !db.createOrUpdate(BrowserTable()) {
         return nil
     }
     return db

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -793,7 +793,7 @@ extension BrowserTableV10: SectionCreator, TableInfo {
 class TestSQLiteHistory: XCTestCase {
     let files = MockFiles()
 
-    override func tearDown() {
+    private func deleteDatabases() {
         for v in ["6", "7", "8", "10", "6-data"] {
             do { try
                 files.remove("browser-v\(v).db")
@@ -801,9 +801,16 @@ class TestSQLiteHistory: XCTestCase {
         }
     }
 
+    override func tearDown() {
+        super.tearDown()
+        self.deleteDatabases()
+    }
+
     override func setUp() {
+        super.setUp()
+
         // Just in case tearDown didn't run or succeed last time!
-        self.tearDown()
+        self.deleteDatabases()
     }
 
     // Test that our visit partitioning for frecency is correct.

--- a/StorageTests/TestSQLiteHistory.swift
+++ b/StorageTests/TestSQLiteHistory.swift
@@ -12,10 +12,802 @@ extension Site {
     }
 }
 
+class BaseHistoricalBrowserTable {
+    func updateTable(db: SQLiteDBConnection, from: Int) -> Bool {
+        assert(false, "Should never be called.")
+    }
+
+    func exists(db: SQLiteDBConnection) -> Bool {
+        return false
+    }
+
+    func drop(db: SQLiteDBConnection) -> Bool {
+        return false
+    }
+
+    var supportsPartialIndices: Bool {
+        let v = sqlite3_libversion_number()
+        return v >= 3008000          // 3.8.0.
+    }
+
+    let oldFaviconsSQL =
+        "CREATE TABLE IF NOT EXISTS favicons (" +
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+        "url TEXT NOT NULL UNIQUE, " +
+        "width INTEGER, " +
+        "height INTEGER, " +
+        "type INTEGER NOT NULL, " +
+        "date REAL NOT NULL" +
+        ") "
+
+    func run(db: SQLiteDBConnection, sql: String?, args: Args? = nil) -> Bool {
+        if let sql = sql {
+            let err = db.executeChange(sql, withArgs: args)
+            return err == nil
+        }
+        return true
+    }
+
+    func run(db: SQLiteDBConnection, queries: [String?]) -> Bool {
+        for sql in queries {
+            if let sql = sql {
+                if !run(db, sql: sql) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    func run(db: SQLiteDBConnection, queries: [String]) -> Bool {
+        for sql in queries {
+            if !run(db, sql: sql) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+// Versions of BrowserTable that we care about:
+// v6, prior to 001c73ea1903c238be1340950770879b40c41732, July 2015.
+// This is when we first started caring about database versions.
+//
+// v7, 81e22fa6f7446e27526a5a9e8f4623df159936c3. History tiles.
+//
+// v8, 02c08ddc6d805d853bbe053884725dc971ef37d7. Favicons.
+//
+// v10, 4428c7d181ff4779ab1efb39e857e41bdbf4de67. Mirroring. We skipped v9.
+//
+// These tests snapshot the table creation code at each of these points.
+
+class BrowserTableV6: BaseHistoricalBrowserTable {
+    var name: String { return "BROWSER" }
+    var version: Int { return 6 }
+
+    func prepopulateRootFolders(db: SQLiteDBConnection) -> Bool {
+        let type = BookmarkNodeType.Folder.rawValue
+        let root = BookmarkRoots.RootID
+
+        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+
+        let args: Args = [
+            root, BookmarkRoots.RootGUID, type, "Root", root,
+            BookmarkRoots.MobileID, BookmarkRoots.MobileFolderGUID, type, titleMobile, root,
+            BookmarkRoots.MenuID, BookmarkRoots.MenuFolderGUID, type, titleMenu, root,
+            BookmarkRoots.ToolbarID, BookmarkRoots.ToolbarFolderGUID, type, titleToolbar, root,
+            BookmarkRoots.UnfiledID, BookmarkRoots.UnfiledFolderGUID, type, titleUnsorted, root,
+        ]
+
+        let sql =
+        "INSERT INTO bookmarks (id, guid, type, url, title, parent) VALUES " +
+            "(?, ?, ?, NULL, ?, ?), " +    // Root
+            "(?, ?, ?, NULL, ?, ?), " +    // Mobile
+            "(?, ?, ?, NULL, ?, ?), " +    // Menu
+            "(?, ?, ?, NULL, ?, ?), " +    // Toolbar
+        "(?, ?, ?, NULL, ?, ?)  "      // Unsorted
+
+        return self.run(db, sql: sql, args: args)
+    }
+
+    func CreateHistoryTable() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableHistory) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +       // Not null, but the value might be replaced by the server's.
+            "url TEXT UNIQUE, " +                 // May only be null for deleted records.
+            "title TEXT NOT NULL, " +
+            "server_modified INTEGER, " +         // Can be null. Integer milliseconds.
+            "local_modified INTEGER, " +          // Can be null. Client clock. In extremis only.
+            "is_deleted TINYINT NOT NULL, " +     // Boolean. Locally deleted.
+            "should_upload TINYINT NOT NULL, " +  // Boolean. Set when changed or visits added.
+            "domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE, " +
+            "CONSTRAINT urlOrDeleted CHECK (url IS NOT NULL OR is_deleted = 1)" +
+        ")"
+    }
+
+    func CreateDomainsTable() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableDomains) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "domain TEXT NOT NULL UNIQUE, " +
+            "showOnTopSites TINYINT NOT NULL DEFAULT 1" +
+        ")"
+    }
+
+    func CreateQueueTable() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableQueuedTabs) (" +
+            "url TEXT NOT NULL UNIQUE, " +
+            "title TEXT" +
+        ") "
+    }
+}
+
+extension BrowserTableV6: Table {
+    func create(db: SQLiteDBConnection) -> Bool {
+        let visits =
+        "CREATE TABLE IF NOT EXISTS \(TableVisits) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES \(TableHistory)(id) ON DELETE CASCADE, " +
+            "date REAL NOT NULL, " +           // Microseconds since epoch.
+            "type INTEGER NOT NULL, " +
+            "is_local TINYINT NOT NULL, " +    // Some visits are local. Some are remote ('mirrored'). This boolean flag is the split.
+            "UNIQUE (siteID, date, type) " +
+        ") "
+
+        let indexShouldUpload: String
+        if self.supportsPartialIndices {
+            // There's no point tracking rows that are not flagged for upload.
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON \(TableHistory) (should_upload) WHERE should_upload = 1"
+        } else {
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON \(TableHistory) (should_upload)"
+        }
+
+        let indexSiteIDDate =
+        "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) " +
+        "ON \(TableVisits) (siteID, is_local, date)"
+
+        let faviconSites =
+        "CREATE TABLE IF NOT EXISTS \(TableFaviconSites) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES \(TableHistory)(id) ON DELETE CASCADE, " +
+            "faviconID INTEGER NOT NULL REFERENCES \(TableFavicons)(id) ON DELETE CASCADE, " +
+            "UNIQUE (siteID, faviconID) " +
+        ") "
+
+        let widestFavicons =
+        "CREATE VIEW IF NOT EXISTS \(ViewWidestFaviconsForSites) AS " +
+            "SELECT " +
+            "\(TableFaviconSites).siteID AS siteID, " +
+            "\(TableFavicons).id AS iconID, " +
+            "\(TableFavicons).url AS iconURL, " +
+            "\(TableFavicons).date AS iconDate, " +
+            "\(TableFavicons).type AS iconType, " +
+            "MAX(\(TableFavicons).width) AS iconWidth " +
+            "FROM \(TableFaviconSites), \(TableFavicons) WHERE " +
+            "\(TableFaviconSites).faviconID = \(TableFavicons).id " +
+        "GROUP BY siteID "
+
+        let historyIDsWithIcon =
+        "CREATE VIEW IF NOT EXISTS \(ViewHistoryIDsWithWidestFavicons) AS " +
+            "SELECT \(TableHistory).id AS id, " +
+            "iconID, iconURL, iconDate, iconType, iconWidth " +
+            "FROM \(TableHistory) " +
+            "LEFT OUTER JOIN " +
+        "\(ViewWidestFaviconsForSites) ON history.id = \(ViewWidestFaviconsForSites).siteID "
+
+        let iconForURL =
+        "CREATE VIEW IF NOT EXISTS \(ViewIconForURL) AS " +
+            "SELECT history.url AS url, icons.iconID AS iconID FROM " +
+            "\(TableHistory), \(ViewWidestFaviconsForSites) AS icons WHERE " +
+        "\(TableHistory).id = icons.siteID "
+
+        let bookmarks =
+        "CREATE TABLE IF NOT EXISTS bookmarks (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +
+            "type TINYINT NOT NULL, " +
+            "url TEXT, " +
+            "parent INTEGER REFERENCES bookmarks(id) NOT NULL, " +
+            "faviconID INTEGER REFERENCES favicons(id) ON DELETE SET NULL, " +
+            "title TEXT" +
+        ") "
+
+        let queries = [
+            // This used to be done by FaviconsTable.
+            self.oldFaviconsSQL,
+            CreateDomainsTable(),
+            CreateHistoryTable(),
+            visits, bookmarks, faviconSites,
+            indexShouldUpload, indexSiteIDDate,
+            widestFavicons, historyIDsWithIcon, iconForURL,
+            CreateQueueTable(),
+        ]
+
+        return self.run(db, queries: queries) &&
+               self.prepopulateRootFolders(db)
+    }
+}
+
+class BrowserTableV7: BaseHistoricalBrowserTable {
+    var name: String { return "BROWSER" }
+    var version: Int { return 7 }
+
+    func prepopulateRootFolders(db: SQLiteDBConnection) -> Bool {
+        let type = BookmarkNodeType.Folder.rawValue
+        let root = BookmarkRoots.RootID
+
+        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+
+        let args: Args = [
+            root, BookmarkRoots.RootGUID, type, "Root", root,
+            BookmarkRoots.MobileID, BookmarkRoots.MobileFolderGUID, type, titleMobile, root,
+            BookmarkRoots.MenuID, BookmarkRoots.MenuFolderGUID, type, titleMenu, root,
+            BookmarkRoots.ToolbarID, BookmarkRoots.ToolbarFolderGUID, type, titleToolbar, root,
+            BookmarkRoots.UnfiledID, BookmarkRoots.UnfiledFolderGUID, type, titleUnsorted, root,
+        ]
+
+        let sql =
+        "INSERT INTO bookmarks (id, guid, type, url, title, parent) VALUES " +
+            "(?, ?, ?, NULL, ?, ?), " +    // Root
+            "(?, ?, ?, NULL, ?, ?), " +    // Mobile
+            "(?, ?, ?, NULL, ?, ?), " +    // Menu
+            "(?, ?, ?, NULL, ?, ?), " +    // Toolbar
+        "(?, ?, ?, NULL, ?, ?)  "      // Unsorted
+
+        return self.run(db, sql: sql, args: args)
+    }
+
+    func getHistoryTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS history (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +       // Not null, but the value might be replaced by the server's.
+            "url TEXT UNIQUE, " +                 // May only be null for deleted records.
+            "title TEXT NOT NULL, " +
+            "server_modified INTEGER, " +         // Can be null. Integer milliseconds.
+            "local_modified INTEGER, " +          // Can be null. Client clock. In extremis only.
+            "is_deleted TINYINT NOT NULL, " +     // Boolean. Locally deleted.
+            "should_upload TINYINT NOT NULL, " +  // Boolean. Set when changed or visits added.
+            "domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE, " +
+            "CONSTRAINT urlOrDeleted CHECK (url IS NOT NULL OR is_deleted = 1)" +
+        ")"
+    }
+
+    func getDomainsTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableDomains) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "domain TEXT NOT NULL UNIQUE, " +
+            "showOnTopSites TINYINT NOT NULL DEFAULT 1" +
+        ")"
+    }
+
+    func getQueueTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableQueuedTabs) (" +
+            "url TEXT NOT NULL UNIQUE, " +
+            "title TEXT" +
+        ") "
+    }
+}
+
+extension BrowserTableV7: SectionCreator, TableInfo {
+    func create(db: SQLiteDBConnection) -> Bool {
+        // Right now we don't need to track per-visit deletions: Sync can't
+        // represent them! See Bug 1157553 Comment 6.
+        // We flip the should_upload flag on the history item when we add a visit.
+        // If we ever want to support logic like not bothering to sync if we added
+        // and then rapidly removed a visit, then we need an 'is_new' flag on each visit.
+        let visits =
+        "CREATE TABLE IF NOT EXISTS \(TableVisits) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "date REAL NOT NULL, " +           // Microseconds since epoch.
+            "type INTEGER NOT NULL, " +
+            "is_local TINYINT NOT NULL, " +    // Some visits are local. Some are remote ('mirrored'). This boolean flag is the split.
+            "UNIQUE (siteID, date, type) " +
+        ") "
+
+        let indexShouldUpload: String
+        if self.supportsPartialIndices {
+            // There's no point tracking rows that are not flagged for upload.
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON history (should_upload) WHERE should_upload = 1"
+        } else {
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON history (should_upload)"
+        }
+
+        let indexSiteIDDate =
+        "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) " +
+        "ON \(TableVisits) (siteID, is_local, date)"
+
+        let faviconSites =
+        "CREATE TABLE IF NOT EXISTS \(TableFaviconSites) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "faviconID INTEGER NOT NULL REFERENCES favicons(id) ON DELETE CASCADE, " +
+            "UNIQUE (siteID, faviconID) " +
+        ") "
+
+        let widestFavicons =
+        "CREATE VIEW IF NOT EXISTS \(ViewWidestFaviconsForSites) AS " +
+            "SELECT " +
+            "\(TableFaviconSites).siteID AS siteID, " +
+            "favicons.id AS iconID, " +
+            "favicons.url AS iconURL, " +
+            "favicons.date AS iconDate, " +
+            "favicons.type AS iconType, " +
+            "MAX(favicons.width) AS iconWidth " +
+            "FROM \(TableFaviconSites), favicons WHERE " +
+            "\(TableFaviconSites).faviconID = favicons.id " +
+        "GROUP BY siteID "
+
+        let historyIDsWithIcon =
+        "CREATE VIEW IF NOT EXISTS \(ViewHistoryIDsWithWidestFavicons) AS " +
+            "SELECT history.id AS id, " +
+            "iconID, iconURL, iconDate, iconType, iconWidth " +
+            "FROM history " +
+            "LEFT OUTER JOIN " +
+        "\(ViewWidestFaviconsForSites) ON history.id = \(ViewWidestFaviconsForSites).siteID "
+
+        let iconForURL =
+        "CREATE VIEW IF NOT EXISTS \(ViewIconForURL) AS " +
+            "SELECT history.url AS url, icons.iconID AS iconID FROM " +
+            "\(TableHistory), \(ViewWidestFaviconsForSites) AS icons WHERE " +
+        "\(TableHistory).id = icons.siteID "
+
+        let bookmarks =
+        "CREATE TABLE IF NOT EXISTS bookmarks (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +
+            "type TINYINT NOT NULL, " +
+            "url TEXT, " +
+            "parent INTEGER REFERENCES bookmarks(id) NOT NULL, " +
+            "faviconID INTEGER REFERENCES favicons(id) ON DELETE SET NULL, " +
+            "title TEXT" +
+        ") "
+
+        let queries = [
+            // This used to be done by FaviconsTable.
+            self.oldFaviconsSQL,
+            getDomainsTableCreationString(),
+            getHistoryTableCreationString(),
+            visits, bookmarks, faviconSites,
+            indexShouldUpload, indexSiteIDDate,
+            widestFavicons, historyIDsWithIcon, iconForURL,
+            getQueueTableCreationString(),
+        ]
+
+        return self.run(db, queries: queries) &&
+               self.prepopulateRootFolders(db)
+    }
+}
+
+class BrowserTableV8: BaseHistoricalBrowserTable {
+    var name: String { return "BROWSER" }
+    var version: Int { return 8 }
+
+    func prepopulateRootFolders(db: SQLiteDBConnection) -> Bool {
+        let type = BookmarkNodeType.Folder.rawValue
+        let root = BookmarkRoots.RootID
+
+        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+
+        let args: Args = [
+            root, BookmarkRoots.RootGUID, type, "Root", root,
+            BookmarkRoots.MobileID, BookmarkRoots.MobileFolderGUID, type, titleMobile, root,
+            BookmarkRoots.MenuID, BookmarkRoots.MenuFolderGUID, type, titleMenu, root,
+            BookmarkRoots.ToolbarID, BookmarkRoots.ToolbarFolderGUID, type, titleToolbar, root,
+            BookmarkRoots.UnfiledID, BookmarkRoots.UnfiledFolderGUID, type, titleUnsorted, root,
+        ]
+
+        let sql =
+        "INSERT INTO bookmarks (id, guid, type, url, title, parent) VALUES " +
+            "(?, ?, ?, NULL, ?, ?), " +    // Root
+            "(?, ?, ?, NULL, ?, ?), " +    // Mobile
+            "(?, ?, ?, NULL, ?, ?), " +    // Menu
+            "(?, ?, ?, NULL, ?, ?), " +    // Toolbar
+        "(?, ?, ?, NULL, ?, ?)  "      // Unsorted
+
+        return self.run(db, sql: sql, args: args)
+    }
+
+    func getHistoryTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableHistory) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +       // Not null, but the value might be replaced by the server's.
+            "url TEXT UNIQUE, " +                 // May only be null for deleted records.
+            "title TEXT NOT NULL, " +
+            "server_modified INTEGER, " +         // Can be null. Integer milliseconds.
+            "local_modified INTEGER, " +          // Can be null. Client clock. In extremis only.
+            "is_deleted TINYINT NOT NULL, " +     // Boolean. Locally deleted.
+            "should_upload TINYINT NOT NULL, " +  // Boolean. Set when changed or visits added.
+            "domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE, " +
+            "CONSTRAINT urlOrDeleted CHECK (url IS NOT NULL OR is_deleted = 1)" +
+        ")"
+    }
+
+    func getDomainsTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableDomains) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "domain TEXT NOT NULL UNIQUE, " +
+            "showOnTopSites TINYINT NOT NULL DEFAULT 1" +
+        ")"
+    }
+
+    func getQueueTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableQueuedTabs) (" +
+            "url TEXT NOT NULL UNIQUE, " +
+            "title TEXT" +
+        ") "
+    }
+}
+
+extension BrowserTableV8: SectionCreator, TableInfo {
+    func create(db: SQLiteDBConnection) -> Bool {
+        let favicons =
+        "CREATE TABLE IF NOT EXISTS favicons (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "url TEXT NOT NULL UNIQUE, " +
+            "width INTEGER, " +
+            "height INTEGER, " +
+            "type INTEGER NOT NULL, " +
+            "date REAL NOT NULL" +
+        ") "
+
+        // Right now we don't need to track per-visit deletions: Sync can't
+        // represent them! See Bug 1157553 Comment 6.
+        // We flip the should_upload flag on the history item when we add a visit.
+        // If we ever want to support logic like not bothering to sync if we added
+        // and then rapidly removed a visit, then we need an 'is_new' flag on each visit.
+        let visits =
+        "CREATE TABLE IF NOT EXISTS visits (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "date REAL NOT NULL, " +           // Microseconds since epoch.
+            "type INTEGER NOT NULL, " +
+            "is_local TINYINT NOT NULL, " +    // Some visits are local. Some are remote ('mirrored'). This boolean flag is the split.
+            "UNIQUE (siteID, date, type) " +
+        ") "
+
+        let indexShouldUpload: String
+        if self.supportsPartialIndices {
+            // There's no point tracking rows that are not flagged for upload.
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON \(TableHistory) (should_upload) WHERE should_upload = 1"
+        } else {
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON \(TableHistory) (should_upload)"
+        }
+
+        let indexSiteIDDate =
+        "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) " +
+        "ON \(TableVisits) (siteID, is_local, date)"
+
+        let faviconSites =
+        "CREATE TABLE IF NOT EXISTS \(TableFaviconSites) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "faviconID INTEGER NOT NULL REFERENCES favicons(id) ON DELETE CASCADE, " +
+            "UNIQUE (siteID, faviconID) " +
+        ") "
+
+        let widestFavicons =
+        "CREATE VIEW IF NOT EXISTS \(ViewWidestFaviconsForSites) AS " +
+            "SELECT " +
+            "\(TableFaviconSites).siteID AS siteID, " +
+            "favicons.id AS iconID, " +
+            "favicons.url AS iconURL, " +
+            "favicons.date AS iconDate, " +
+            "favicons.type AS iconType, " +
+            "MAX(favicons.width) AS iconWidth " +
+            "FROM \(TableFaviconSites), favicons WHERE " +
+            "\(TableFaviconSites).faviconID = favicons.id " +
+        "GROUP BY siteID "
+
+        let historyIDsWithIcon =
+        "CREATE VIEW IF NOT EXISTS \(ViewHistoryIDsWithWidestFavicons) AS " +
+            "SELECT history.id AS id, " +
+            "iconID, iconURL, iconDate, iconType, iconWidth " +
+            "FROM history " +
+            "LEFT OUTER JOIN " +
+        "\(ViewWidestFaviconsForSites) ON history.id = \(ViewWidestFaviconsForSites).siteID "
+
+        let iconForURL =
+        "CREATE VIEW IF NOT EXISTS \(ViewIconForURL) AS " +
+            "SELECT history.url AS url, icons.iconID AS iconID FROM " +
+            "history, \(ViewWidestFaviconsForSites) AS icons WHERE " +
+        "history.id = icons.siteID "
+
+        let bookmarks =
+        "CREATE TABLE IF NOT EXISTS bookmarks (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +
+            "type TINYINT NOT NULL, " +
+            "url TEXT, " +
+            "parent INTEGER REFERENCES bookmarks(id) NOT NULL, " +
+            "faviconID INTEGER REFERENCES favicons(id) ON DELETE SET NULL, " +
+            "title TEXT" +
+        ") "
+
+        let queries: [String] = [
+            getDomainsTableCreationString(),
+            getHistoryTableCreationString(),
+            favicons,
+            visits,
+            bookmarks,
+            faviconSites,
+            indexShouldUpload,
+            indexSiteIDDate,
+            widestFavicons,
+            historyIDsWithIcon,
+            iconForURL,
+            getQueueTableCreationString(),
+        ]
+
+        return self.run(db, queries: queries) &&
+               self.prepopulateRootFolders(db)
+    }
+}
+
+class BrowserTableV10: BaseHistoricalBrowserTable {
+    var name: String { return "BROWSER" }
+    var version: Int { return 10 }
+
+    func prepopulateRootFolders(db: SQLiteDBConnection) -> Bool {
+        let type = BookmarkNodeType.Folder.rawValue
+        let root = BookmarkRoots.RootID
+
+        let titleMobile = NSLocalizedString("Mobile Bookmarks", tableName: "Storage", comment: "The title of the folder that contains mobile bookmarks. This should match bookmarks.folder.mobile.label on Android.")
+        let titleMenu = NSLocalizedString("Bookmarks Menu", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the menu. This should match bookmarks.folder.menu.label on Android.")
+        let titleToolbar = NSLocalizedString("Bookmarks Toolbar", tableName: "Storage", comment: "The name of the folder that contains desktop bookmarks in the toolbar. This should match bookmarks.folder.toolbar.label on Android.")
+        let titleUnsorted = NSLocalizedString("Unsorted Bookmarks", tableName: "Storage", comment: "The name of the folder that contains unsorted desktop bookmarks. This should match bookmarks.folder.unfiled.label on Android.")
+
+        let args: Args = [
+            root, BookmarkRoots.RootGUID, type, "Root", root,
+            BookmarkRoots.MobileID, BookmarkRoots.MobileFolderGUID, type, titleMobile, root,
+            BookmarkRoots.MenuID, BookmarkRoots.MenuFolderGUID, type, titleMenu, root,
+            BookmarkRoots.ToolbarID, BookmarkRoots.ToolbarFolderGUID, type, titleToolbar, root,
+            BookmarkRoots.UnfiledID, BookmarkRoots.UnfiledFolderGUID, type, titleUnsorted, root,
+        ]
+
+        let sql =
+        "INSERT INTO bookmarks (id, guid, type, url, title, parent) VALUES " +
+            "(?, ?, ?, NULL, ?, ?), " +    // Root
+            "(?, ?, ?, NULL, ?, ?), " +    // Mobile
+            "(?, ?, ?, NULL, ?, ?), " +    // Menu
+            "(?, ?, ?, NULL, ?, ?), " +    // Toolbar
+        "(?, ?, ?, NULL, ?, ?)  "      // Unsorted
+
+        return self.run(db, sql: sql, args: args)
+    }
+
+    func getHistoryTableCreationString(forVersion version: Int = BrowserTable.DefaultVersion) -> String {
+        return "CREATE TABLE IF NOT EXISTS history (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +       // Not null, but the value might be replaced by the server's.
+            "url TEXT UNIQUE, " +                 // May only be null for deleted records.
+            "title TEXT NOT NULL, " +
+            "server_modified INTEGER, " +         // Can be null. Integer milliseconds.
+            "local_modified INTEGER, " +          // Can be null. Client clock. In extremis only.
+            "is_deleted TINYINT NOT NULL, " +     // Boolean. Locally deleted.
+            "should_upload TINYINT NOT NULL, " +  // Boolean. Set when changed or visits added.
+            "domain_id INTEGER REFERENCES \(TableDomains)(id) ON DELETE CASCADE, " +
+            "CONSTRAINT urlOrDeleted CHECK (url IS NOT NULL OR is_deleted = 1)" +
+        ")"
+    }
+
+    func getDomainsTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableDomains) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "domain TEXT NOT NULL UNIQUE, " +
+            "showOnTopSites TINYINT NOT NULL DEFAULT 1" +
+        ")"
+    }
+
+    func getQueueTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableQueuedTabs) (" +
+            "url TEXT NOT NULL UNIQUE, " +
+            "title TEXT" +
+        ") "
+    }
+
+    func getBookmarksMirrorTableCreationString() -> String {
+        // The stupid absence of naming conventions here is thanks to pre-Sync Weave. Sorry.
+        // For now we have the simplest possible schema: everything in one.
+        let sql =
+        "CREATE TABLE IF NOT EXISTS \(TableBookmarksMirror) " +
+
+            // Shared fields.
+            "( id INTEGER PRIMARY KEY AUTOINCREMENT" +
+            ", guid TEXT NOT NULL UNIQUE" +
+            ", type TINYINT NOT NULL" +                    // Type enum. TODO: BookmarkNodeType needs to be extended.
+
+            // Record/envelope metadata that'll allow us to do merges.
+            ", server_modified INTEGER NOT NULL" +         // Milliseconds.
+            ", is_deleted TINYINT NOT NULL DEFAULT 0" +    // Boolean
+
+            ", hasDupe TINYINT NOT NULL DEFAULT 0" +       // Boolean, 0 (false) if deleted.
+            ", parentid TEXT" +                            // GUID
+            ", parentName TEXT" +
+
+            // Type-specific fields. These should be NOT NULL in many cases, but we're going
+            // for a sparse schema, so this'll do for now. Enforce these in the application code.
+            ", feedUri TEXT, siteUri TEXT" +               // LIVEMARKS
+            ", pos INT" +                                  // SEPARATORS
+            ", title TEXT, description TEXT" +             // FOLDERS, BOOKMARKS, QUERIES
+            ", bmkUri TEXT, tags TEXT, keyword TEXT" +     // BOOKMARKS, QUERIES
+            ", folderName TEXT, queryId TEXT" +            // QUERIES
+            ", CONSTRAINT parentidOrDeleted CHECK (parentid IS NOT NULL OR is_deleted = 1)" +
+            ", CONSTRAINT parentNameOrDeleted CHECK (parentName IS NOT NULL OR is_deleted = 1)" +
+        ")"
+
+        return sql
+    }
+
+    /**
+     * We need to explicitly store what's provided by the server, because we can't rely on
+     * referenced child nodes to exist yet!
+     */
+    func getBookmarksMirrorStructureTableCreationString() -> String {
+        return "CREATE TABLE IF NOT EXISTS \(TableBookmarksMirrorStructure) " +
+            "( parent TEXT NOT NULL REFERENCES \(TableBookmarksMirror)(guid) ON DELETE CASCADE" +
+            ", child TEXT NOT NULL" +      // Should be the GUID of a child.
+            ", idx INTEGER NOT NULL" +     // Should advance from 0.
+        ")"
+    }
+}
+
+extension BrowserTableV10: SectionCreator, TableInfo {
+    func create(db: SQLiteDBConnection) -> Bool {
+        let favicons =
+        "CREATE TABLE IF NOT EXISTS favicons (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "url TEXT NOT NULL UNIQUE, " +
+            "width INTEGER, " +
+            "height INTEGER, " +
+            "type INTEGER NOT NULL, " +
+            "date REAL NOT NULL" +
+        ") "
+
+        // Right now we don't need to track per-visit deletions: Sync can't
+        // represent them! See Bug 1157553 Comment 6.
+        // We flip the should_upload flag on the history item when we add a visit.
+        // If we ever want to support logic like not bothering to sync if we added
+        // and then rapidly removed a visit, then we need an 'is_new' flag on each visit.
+        let visits =
+        "CREATE TABLE IF NOT EXISTS visits (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "date REAL NOT NULL, " +           // Microseconds since epoch.
+            "type INTEGER NOT NULL, " +
+            "is_local TINYINT NOT NULL, " +    // Some visits are local. Some are remote ('mirrored'). This boolean flag is the split.
+            "UNIQUE (siteID, date, type) " +
+        ") "
+
+        let indexShouldUpload: String
+        if self.supportsPartialIndices {
+            // There's no point tracking rows that are not flagged for upload.
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON history (should_upload) WHERE should_upload = 1"
+        } else {
+            indexShouldUpload =
+                "CREATE INDEX IF NOT EXISTS \(IndexHistoryShouldUpload) " +
+            "ON history (should_upload)"
+        }
+
+        let indexSiteIDDate =
+        "CREATE INDEX IF NOT EXISTS \(IndexVisitsSiteIDIsLocalDate) " +
+        "ON visits (siteID, is_local, date)"
+
+        let faviconSites =
+        "CREATE TABLE IF NOT EXISTS \(TableFaviconSites) (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "siteID INTEGER NOT NULL REFERENCES history(id) ON DELETE CASCADE, " +
+            "faviconID INTEGER NOT NULL REFERENCES favicons(id) ON DELETE CASCADE, " +
+            "UNIQUE (siteID, faviconID) " +
+        ") "
+
+        let widestFavicons =
+        "CREATE VIEW IF NOT EXISTS \(ViewWidestFaviconsForSites) AS " +
+            "SELECT " +
+            "\(TableFaviconSites).siteID AS siteID, " +
+            "favicons.id AS iconID, " +
+            "favicons.url AS iconURL, " +
+            "favicons.date AS iconDate, " +
+            "favicons.type AS iconType, " +
+            "MAX(favicons.width) AS iconWidth " +
+            "FROM \(TableFaviconSites), favicons WHERE " +
+            "\(TableFaviconSites).faviconID = favicons.id " +
+        "GROUP BY siteID "
+
+        let historyIDsWithIcon =
+        "CREATE VIEW IF NOT EXISTS \(ViewHistoryIDsWithWidestFavicons) AS " +
+            "SELECT history.id AS id, " +
+            "iconID, iconURL, iconDate, iconType, iconWidth " +
+            "FROM history " +
+            "LEFT OUTER JOIN " +
+        "\(ViewWidestFaviconsForSites) ON history.id = \(ViewWidestFaviconsForSites).siteID "
+
+        let iconForURL =
+        "CREATE VIEW IF NOT EXISTS \(ViewIconForURL) AS " +
+            "SELECT history.url AS url, icons.iconID AS iconID FROM " +
+            "history, \(ViewWidestFaviconsForSites) AS icons WHERE " +
+        "history.id = icons.siteID "
+
+        let bookmarks =
+        "CREATE TABLE IF NOT EXISTS bookmarks (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "guid TEXT NOT NULL UNIQUE, " +
+            "type TINYINT NOT NULL, " +
+            "url TEXT, " +
+            "parent INTEGER REFERENCES bookmarks(id) NOT NULL, " +
+            "faviconID INTEGER REFERENCES favicons(id) ON DELETE SET NULL, " +
+            "title TEXT" +
+        ") "
+
+        let bookmarksMirror = getBookmarksMirrorTableCreationString()
+        let bookmarksMirrorStructure = getBookmarksMirrorStructureTableCreationString()
+
+        let indexStructureParentIdx = "CREATE INDEX IF NOT EXISTS \(IndexBookmarksMirrorStructureParentIdx) " +
+        "ON \(TableBookmarksMirrorStructure) (parent, idx)"
+
+        let queries: [String] = [
+            getDomainsTableCreationString(),
+            getHistoryTableCreationString(),
+            favicons,
+            visits,
+            bookmarks,
+            bookmarksMirror,
+            bookmarksMirrorStructure,
+            indexStructureParentIdx,
+            faviconSites,
+            indexShouldUpload,
+            indexSiteIDDate,
+            widestFavicons,
+            historyIDsWithIcon,
+            iconForURL,
+            getQueueTableCreationString(),
+        ]
+
+        return self.run(db, queries: queries) &&
+               self.prepopulateRootFolders(db)
+    }
+}
+
 class TestSQLiteHistory: XCTestCase {
+    let files = MockFiles()
+
+    override func tearDown() {
+        for v in ["6", "7", "8", "10", "6-data"] {
+            do { try
+                files.remove("browser-v\(v).db")
+            } catch {}
+        }
+    }
+
+    override func setUp() {
+        // Just in case tearDown didn't run or succeed last time!
+        self.tearDown()
+    }
+
     // Test that our visit partitioning for frecency is correct.
     func testHistoryLocalAndRemoteVisits() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!
@@ -85,53 +877,59 @@ class TestSQLiteHistory: XCTestCase {
     }
 
     func testUpgrades() {
-        let files = MockFiles()
-        let db = BrowserDB(filename: "browser.db", files: files)
+        let sources: [(Int, SectionCreator)] = [
+            (6, BrowserTableV6()),
+            (7, BrowserTableV7()),
+            (8, BrowserTableV8()),
+            (10, BrowserTableV10()),
+        ]
 
-        // This calls createOrUpdate. i.e. it may fail, but should not crash and should always return a valid SQLiteHistory object.
-        let prefs = MockProfilePrefs()
-        let history = SQLiteHistory(db: db, prefs: prefs)!
-        XCTAssertNotNil(history)
+        let destination = BrowserTable()
 
-        // Insert some basic data that we'll have to upgrade
-        let expectation = self.expectationWithDescription("First.")
-        db.run([("INSERT INTO history (guid, url, title, server_modified, local_modified, is_deleted, should_upload) VALUES (guid, http://www.example.com, title, 5, 10, 0, 1)", nil),
-                ("INSERT INTO visits (siteID, date, type, is_local) VALUES (1, 15, 1, 1)", nil),
-                ("INSERT INTO favicons (url, width, height, type, date) VALUES (http://www.example.com/favicon.ico, 10, 10, 1, 20)", nil),
-                ("INSERT INTO faviconSites (siteID, faviconID) VALUES (1, 1)", nil),
-                ("INSERT INTO bookmarks (guid, type, url, parent, faviconID, title) VALUES (guid, 1, http://www.example.com, 0, 1, title)", nil)
-        ]).upon { result in
-            for i in 1...BrowserTable.DefaultVersion {
-                let history = SQLiteHistory(db: db, prefs: prefs, version: i)
-                XCTAssertNotNil(history)
-            }
+        for (version, table) in sources {
+            let db = BrowserDB(filename: "browser-v\(version).db", files: files)
+            XCTAssertTrue(
+                db.runWithConnection { (conn, err) in
+                    XCTAssertTrue(table.create(conn), "Creating browser table version \(version)")
 
-            // This checks to make sure updates actually work (or at least that they don't crash :))
-            var err: NSError? = nil
-            db.transaction(&err, callback: { (connection, err) -> Bool in
-                for i in 0...BrowserTable.DefaultVersion {
-                    let table = BrowserTable(version: i)
-                    switch db.updateTable(connection, table: table) {
-                    case .Updated:
-                        XCTAssertTrue(true, "Update to \(i) succeeded")
-                    default:
-                        XCTFail("Update to version \(i) failed")
-                        return false
-                    }
-                }
-                return true
-            })
-
-            if err != nil {
-                XCTFail("Error creating a transaction \(err)")
-            }
-            expectation.fulfill()
+                    // And we can upgrade to the current version.
+                    XCTAssertTrue(destination.updateTable(conn, from: table.version), "Upgrading browser table from version \(version)")
+                }.value.isSuccess
+            )
+            db.close()
         }
-        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testUpgradesWithData() {
+        let db = BrowserDB(filename: "browser-v6-data.db", files: files)
+
+        XCTAssertTrue(db.createOrUpdate(BrowserTableV6()), "Creating browser table version 6")
+
+        // Insert some data.
+        let queries = [
+            "INSERT INTO domains (id, domain) VALUES (1, 'example.com')",
+            "INSERT INTO history (id, guid, url, title, server_modified, local_modified, is_deleted, should_upload, domain_id) VALUES (5, 'guid', 'http://www.example.com', 'title', 5, 10, 0, 1, 1)",
+            "INSERT INTO visits (siteID, date, type, is_local) VALUES (5, 15, 1, 1)",
+            "INSERT INTO favicons (url, width, height, type, date) VALUES ('http://www.example.com/favicon.ico', 10, 10, 1, 20)",
+            "INSERT INTO favicon_sites (siteID, faviconID) VALUES (5, 1)",
+            "INSERT INTO bookmarks (guid, type, url, parent, faviconID, title) VALUES ('guid', 1, 'http://www.example.com', 0, 1, 'title')"
+        ]
+
+        XCTAssertTrue(db.run(queries).value.isSuccess)
+
+        // And we can upgrade to the current version.
+        XCTAssertTrue(db.createOrUpdate(BrowserTable()), "Upgrading browser table from version 6")
+
+        let prefs = MockProfilePrefs()
+        let history = SQLiteHistory(db: db, prefs: prefs)
+        let results = history?.getSitesByLastVisit(10).value.successValue
+        XCTAssertNotNil(results)
+        XCTAssertEqual(results![0]?.url, "http://www.example.com")
+
+        db.close()
     }
 
     func testDomainUpgrade() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!
@@ -139,7 +937,7 @@ class TestSQLiteHistory: XCTestCase {
         let site = Site(url: "http://www.example.com/test1.1", title: "title one")
         var err: NSError? = nil
 
-        // Insert something with an invalid domainId. We have to manually do this since domains are usually hidden.
+        // Insert something with an invalid domain ID. We have to manually do this since domains are usually hidden.
         db.withWritableConnection(&err, callback: { (connection, err) -> Int in
             let insert = "INSERT INTO \(TableHistory) (guid, url, title, local_modified, is_deleted, should_upload, domain_id) " +
                          "?, ?, ?, ?, ?, ?, ?"
@@ -161,7 +959,6 @@ class TestSQLiteHistory: XCTestCase {
     }
 
     func testDomains() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!
@@ -201,7 +998,6 @@ class TestSQLiteHistory: XCTestCase {
     // This is a very basic test. Adds an entry, retrieves it, updates it,
     // and then clears the database.
     func testHistoryTable() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!
@@ -338,7 +1134,6 @@ class TestSQLiteHistory: XCTestCase {
     }
 
     func testFaviconTable() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!
@@ -402,7 +1197,6 @@ class TestSQLiteHistory: XCTestCase {
     }
 
     func testTopSitesCache() {
-        let files = MockFiles()
         let db = BrowserDB(filename: "browser.db", files: files)
         let prefs = MockProfilePrefs()
         let history = SQLiteHistory(db: db, prefs: prefs)!

--- a/StorageTests/TestSwiftData.swift
+++ b/StorageTests/TestSwiftData.swift
@@ -30,8 +30,8 @@ class TestSwiftData: XCTestCase {
 
         swiftData!.withConnection(SwiftData.Flags.ReadWriteCreate) { db in
             let f = FaviconsTable<Favicon>()
-            f.create(db, version: 1)    // Because BrowserTable needs it.
-            table.create(db, version: 1)
+            f.create(db)    // Because BrowserTable needs it.
+            table.create(db)
             return nil
         }
 

--- a/Utils/Functions.swift
+++ b/Utils/Functions.swift
@@ -115,7 +115,7 @@ public func optDictionaryEqual<K: Equatable, V: Equatable>(lhs: [K: V]?, rhs: [K
  * Return members of `a` that aren't nil, changing the type of the sequence accordingly.
  */
 public func optFilter<T>(a: [T?]) -> [T] {
-    return a.filter { $0 != nil }.map { $0! }
+    return a.flatMap { $0 }
 }
 
 /**


### PR DESCRIPTION
This removes the concepts of creating at a particular version and upgrading to a particular version from `BrowserTable`; we only support creating and upgrading to the current version.

The upgrade tests now include *the code that we shipped* for a particular schema version directly in the tests, and we verify that we can upgrade to the current version. We also verify that the same ol' chunk of data from v6 will upgrade, though I'm pretty confident that the tests used to not actually work…

This is now nice and simple and gives me more confidence in our upgrade flow.