### PR TITLE
Bug 1224855 - Pasteboard image fixes

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -297,8 +297,8 @@ class BrowserViewController: UIViewController {
             return false
         })
         copyAddressAction = AccessibleAction(name: NSLocalizedString("Copy Address", comment: "Copy the URL from the location bar"), handler: { () -> Bool in
-            if let urlString = self.urlBar.currentURL?.absoluteString {
-                UIPasteboard.generalPasteboard().string = urlString
+            if let url = self.urlBar.currentURL {
+                UIPasteboard.generalPasteboard().URL = url
             }
             return true
         })
@@ -2105,7 +2105,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
             let copyTitle = NSLocalizedString("Copy Link", comment: "Context menu item for copying a link URL to the clipboard")
             let copyAction = UIAlertAction(title: copyTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) -> Void in
                 let pasteBoard = UIPasteboard.generalPasteboard()
-                pasteBoard.string = url.absoluteString
+                pasteBoard.URL = url
             }
             actionSheetController.addAction(copyAction)
         }
@@ -2136,10 +2136,10 @@ extension BrowserViewController: ContextMenuHelperDelegate {
 
             let copyImageTitle = NSLocalizedString("Copy Image", comment: "Context menu item for copying an image to the clipboard")
             let copyAction = UIAlertAction(title: copyImageTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) -> Void in
-                let pasteBoard = UIPasteboard.generalPasteboard()
-                pasteBoard.string = url.absoluteString
                 // put the actual image on the clipboard
                 // do this asynchronously just in case we're in a low bandwidth situation
+                let pasteboard = UIPasteboard.generalPasteboard()
+                pasteboard.URL = url
                 let application = UIApplication.sharedApplication()
                 var taskId: UIBackgroundTaskIdentifier = 0
                 taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
@@ -2152,7 +2152,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         // only set the image onto pasteboard if the thing currently in pasteboard is
                         // the URL of this image, otherwise, in low bandwidth situations,
                         // we might be overwriting something that the user has subsequently added
-                        if pasteBoard.string == url.absoluteString,
+                        if pasteBoard.URL == url,
                            let imageData = responseData where responseError == nil,
                            let image = UIImage.imageFromDataThreadSafe(imageData) {
                             // Using addItems allows the pasteboard to include both an image and text representation.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2147,6 +2147,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 }
 
                 Alamofire.request(.GET, url)
+                    .validate(statusCode: 200..<300)
                     .response { responseRequest, responseResponse, responseData, responseError in
                         // only set the image onto pasteboard if the thing currently in pasteboard is
                         // the URL of this image, otherwise, in low bandwidth situations,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2154,7 +2154,8 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         if pasteBoard.string == url.absoluteString,
                            let imageData = responseData where responseError == nil,
                            let image = UIImage.imageFromDataThreadSafe(imageData) {
-                            pasteBoard.image = image
+                            // Using addItems allows the pasteboard to include both an image and text representation.
+                            pasteBoard.addItems([[kUTTypeImage as String: image]])
                         }
 
                         application.endBackgroundTask(taskId)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2156,8 +2156,11 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         if changeCount == pasteboard.changeCount,
                            let imageData = responseData where responseError == nil,
                            let image = UIImage.imageFromDataThreadSafe(imageData) {
-                            // Using addItems allows the pasteboard to include both an image and text representation.
-                            pasteBoard.addItems([[kUTTypeImage as String: image]])
+                            // Setting pasteboard.items allows us to set multiple representations for the same item.
+                            pasteboard.items = [[
+                                kUTTypeURL as String: url,
+                                kUTTypePNG as String: image
+                            ]]
                         }
 
                         application.endBackgroundTask(taskId)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2139,7 +2139,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let pasteBoard = UIPasteboard.generalPasteboard()
                 pasteBoard.string = url.absoluteString
                 // put the actual image on the clipboard
-                // do this be asyncronously just in case we're in a low bandwidth situation
+                // do this asynchronously just in case we're in a low bandwidth situation
                 let application = UIApplication.sharedApplication()
                 var taskId: UIBackgroundTaskIdentifier = 0
                 taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
@@ -2154,8 +2154,9 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         if pasteBoard.string == url.absoluteString {
                             guard let imageData = responseData where responseError == nil else { return }
                             pasteBoard.image = UIImage.imageFromDataThreadSafe(imageData)
-                            application.endBackgroundTask(taskId)
                         }
+
+                        application.endBackgroundTask(taskId)
                 }
             }
             actionSheetController.addAction(copyAction)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2151,9 +2151,10 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                         // only set the image onto pasteboard if the thing currently in pasteboard is
                         // the URL of this image, otherwise, in low bandwidth situations,
                         // we might be overwriting something that the user has subsequently added
-                        if pasteBoard.string == url.absoluteString {
-                            guard let imageData = responseData where responseError == nil else { return }
-                            pasteBoard.image = UIImage.imageFromDataThreadSafe(imageData)
+                        if pasteBoard.string == url.absoluteString,
+                           let imageData = responseData where responseError == nil,
+                           let image = UIImage.imageFromDataThreadSafe(imageData) {
+                            pasteBoard.image = image
                         }
 
                         application.endBackgroundTask(taskId)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2140,6 +2140,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 // do this asynchronously just in case we're in a low bandwidth situation
                 let pasteboard = UIPasteboard.generalPasteboard()
                 pasteboard.URL = url
+                let changeCount = pasteboard.changeCount
                 let application = UIApplication.sharedApplication()
                 var taskId: UIBackgroundTaskIdentifier = 0
                 taskId = application.beginBackgroundTaskWithExpirationHandler { _ in
@@ -2149,10 +2150,10 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 Alamofire.request(.GET, url)
                     .validate(statusCode: 200..<300)
                     .response { responseRequest, responseResponse, responseData, responseError in
-                        // only set the image onto pasteboard if the thing currently in pasteboard is
-                        // the URL of this image, otherwise, in low bandwidth situations,
-                        // we might be overwriting something that the user has subsequently added
-                        if pasteBoard.URL == url,
+                        // Only set the image onto the pasteboard if the pasteboard hasn't changed since
+                        // fetching the image; otherwise, in low-bandwidth situations,
+                        // we might be overwriting something that the user has subsequently added.
+                        if changeCount == pasteboard.changeCount,
                            let imageData = responseData where responseError == nil,
                            let image = UIImage.imageFromDataThreadSafe(imageData) {
                             // Using addItems allows the pasteboard to include both an image and text representation.


### PR DESCRIPTION
Looking at our Copy Image code, I see a few different issues:
 1. In the Alamofire response, we do `application.endBackgroundTask()` only if the pasteboard string equals the copied string. We do this check to prevent replacing the pasteboard contents in case it's changed after any long-running image fetching, but ending the background task should be done unconditionally.
 2. `UIImage(data: NSData)` can return `nil` if the image creation fails for whatever reason, and we don't guard against this. I tested explicitly assigning `pasteBoard.image = nil`, and that caused the same crash reported in the bug, so I'm guessing that's the issue. Not sure why iOS allows setting a `nil` image if it's not supported!
 3. Setting the image replaces the image URL text in the pasteboard. The iOS pasteboard supports multiple representations simultaneously for an item on the pasteboard, so in this case, the pasteboard should hold both the image *and* its URL (e.g., for when pasting into text fields). This is consistent with Safari.