### PR TITLE
Bug 1224388 – Make the FaviconFetcher more selective in its downloading

### DIFF
--- a/Client/Assets/Favicons.js
+++ b/Client/Assets/Favicons.js
@@ -20,17 +20,18 @@
 
     for (selector in this.selectors) {
       var icons = document.querySelectorAll(selector)
+      if (icons.length) {
+        res = {}
+      }
       for (var i = 0; i < icons.length; i++) {
         var href = icons[i].href;
         res[href] = this.selectors[selector];
-        if (!foundIcons && this.selectors[selector] == ICON) {
           foundIcons = true
         }
       }
-    }
 
     // If we didn't find anything in the page, look to see if a favicon.ico file exists for the domain
-    if (res) {
+    if (!foundIcons) {
       var href = document.location.origin + "/favicon.ico";
       res[href] = GUESS;
     }

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -10,6 +10,27 @@ protocol Identifiable {
 }
 
 public enum IconType: Int {
+    public func isPreferredTo (other: IconType) -> Bool {
+        return rank > other.rank
+    }
+
+    private var rank: Int {
+        switch self {
+        case .AppleIconPrecomposed:
+            return 5
+        case .AppleIcon:
+            return 4
+        case .Icon:
+            return 3
+        case .Local:
+            return 2
+        case .Guess:
+            return 1
+        case .NoneFound:
+            return 0
+        }
+    }
+
     case Icon = 0
     case AppleIcon = 1
     case AppleIconPrecomposed = 2


### PR DESCRIPTION
The `FaviconFetcher` is parsing the page looking for `head.link` tags.

It is then downloading all of them. In some cases, the icons being used are being naïvely selected, and we get scaling artifacts (both up and down).

This bug is to minimize the downloading to just the one we're going to need.