### PR TITLE
Bug 1224849 - Extract Authenticator handling from LoginsHelper

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 		D38B2D8B1A8D98D10040E6B5 /* SearchEngines.swift in Sources */ = {isa = PBXBuildFile; fileRef = D308E4E31A5306F500842685 /* SearchEngines.swift */; };
 		D38B2D8C1A8D98D90040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
+		D38F02D11C05127100175932 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F02D01C05127100175932 /* Authenticator.swift */; };
 		D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; };
 		D39FA16C1A83E17800EE869C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39FA16B1A83E17800EE869C /* CoreGraphics.framework */; };
 		D39FA1811A83E84900EE869C /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1801A83E84900EE869C /* Global.swift */; };
@@ -1644,6 +1645,7 @@
 		D38B2D2D1A8D96D00040E6B5 /* GCDWebServerStreamedResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDWebServerStreamedResponse.m; sourceTree = "<group>"; };
 		D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KIF.xcodeproj; path = Carthage/Checkouts/KIF/KIF.xcodeproj; sourceTree = "<group>"; };
 		D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SWXMLHash.xcodeproj; path = Carthage/Checkouts/SWXMLHash/SWXMLHash.xcodeproj; sourceTree = "<group>"; };
+		D38F02D01C05127100175932 /* Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		D3968F241A38FE8500CEFD3B /* TabManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 		D39999A81AA01D65005AED21 /* KeyboardHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardHelper.swift; sourceTree = "<group>"; };
 		D39FA15F1A83E0EC00EE869C /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2708,6 +2710,7 @@
 			isa = PBXGroup;
 			children = (
 				0B3E7D931B27A7CE00E2E84D /* AboutHomeHandler.swift */,
+				D38F02D01C05127100175932 /* Authenticator.swift */,
 				0AE491A51A41C88C0046C724 /* BackForwardListViewController.swift */,
 				D3A994961A3686BD008AD1AC /* Browser.swift */,
 				E4CD9F2C1A6DC91200318571 /* BrowserLocationView.swift */,
@@ -2735,10 +2738,10 @@
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
+				E4A85CE61BF2600B008BD381 /* TitleActivityItemProvider.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */,
-				E4A85CE61BF2600B008BD381 /* TitleActivityItemProvider.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -4832,6 +4835,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				39C5750E1BE28BAE00E1C4B1 /* OnePasswordExtension.h in Sources */,
+				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
 				39C5750F1BE28BAE00E1C4B1 /* OnePasswordExtension.m in Sources */,
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		D38B2D8C1A8D98D90040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D38F02D11C05127100175932 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F02D01C05127100175932 /* Authenticator.swift */; };
+		D38F03701C06387900175932 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F036F1C06387900175932 /* AuthenticationTests.swift */; };
 		D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; };
 		D39FA16C1A83E17800EE869C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39FA16B1A83E17800EE869C /* CoreGraphics.framework */; };
 		D39FA1811A83E84900EE869C /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1801A83E84900EE869C /* Global.swift */; };
@@ -1646,6 +1647,7 @@
 		D38B2D621A8D976A0040E6B5 /* KIF.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KIF.xcodeproj; path = Carthage/Checkouts/KIF/KIF.xcodeproj; sourceTree = "<group>"; };
 		D38B2D761A8D98380040E6B5 /* SWXMLHash.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SWXMLHash.xcodeproj; path = Carthage/Checkouts/SWXMLHash/SWXMLHash.xcodeproj; sourceTree = "<group>"; };
 		D38F02D01C05127100175932 /* Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
+		D38F036F1C06387900175932 /* AuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
 		D3968F241A38FE8500CEFD3B /* TabManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 		D39999A81AA01D65005AED21 /* KeyboardHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardHelper.swift; sourceTree = "<group>"; };
 		D39FA15F1A83E0EC00EE869C /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2678,6 +2680,7 @@
 				4F9757391AFA6F37006ECC24 /* readerContent.html */,
 				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
 				D3E171C11A841EAD00AB44CD /* KIFHelper.js */,
+				D38F036F1C06387900175932 /* AuthenticationTests.swift */,
 				0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */,
 				7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */,
 				D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */,
@@ -4698,6 +4701,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0B5A93221B1EB4C8004F47A2 /* ReadingListTest.swift in Sources */,
+				D38F03701C06387900175932 /* AuthenticationTests.swift in Sources */,
 				0BB5B3601AC0D6360052877D /* BookmarkingTests.swift in Sources */,
 				D39FA1811A83E84900EE869C /* Global.swift in Sources */,
 				D33B5B7C1AF1AFC100F4DDE6 /* SearchTests.swift in Sources */,

--- a/Client/Frontend/Browser/Authenticator.swift
+++ b/Client/Frontend/Browser/Authenticator.swift
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Storage
+
+private let CancelButtonTitle = NSLocalizedString("Cancel", comment: "Authentication prompt cancel button")
+private let LogInButtonTitle  = NSLocalizedString("Log in", comment: "Authentication prompt log in button")
+
+class Authenticator {
+    private static let MaxAuthenticationAttempts = 3
+
+    static func handleAuthRequest(viewController: UIViewController, challenge: NSURLAuthenticationChallenge, loginsHelper: LoginsHelper?) -> Deferred<Maybe<LoginData>> {
+        // If there have already been too many login attempts, we'll just fail.
+        if challenge.previousFailureCount >= Authenticator.MaxAuthenticationAttempts {
+            return deferMaybe(LoginDataError(description: "Too many attempts to open site"))
+        }
+
+        var credential = challenge.proposedCredential
+
+        // If we were passed an initial set of credentials from iOS, try and use them.
+        if let proposed = credential {
+            if !(proposed.user?.isEmpty ?? true) {
+                if challenge.previousFailureCount == 0 {
+                    return deferMaybe(Login.createWithCredential(credential!, protectionSpace: challenge.protectionSpace))
+                }
+            } else {
+                credential = nil
+            }
+        }
+
+        // If we have some credentials, we'll show a prompt with them.
+        if let credential = credential {
+            return promptForUsernamePassword(viewController, credentials: credential, protectionSpace: challenge.protectionSpace, loginsHelper: loginsHelper)
+        }
+
+        // Otherwise, try to look them up and show the prompt.
+        if let loginsHelper = loginsHelper {
+            return loginsHelper.getLoginsForProtectionSpace(challenge.protectionSpace).bindQueue(dispatch_get_main_queue()) { res in
+                let credentials = res.successValue?[0]?.credentials
+                return self.promptForUsernamePassword(viewController, credentials: credentials, protectionSpace: challenge.protectionSpace, loginsHelper: loginsHelper)
+            }
+        }
+
+        // No credentials, so show an empty prompt.
+        return self.promptForUsernamePassword(viewController, credentials: nil, protectionSpace: challenge.protectionSpace, loginsHelper: nil)
+    }
+
+    private static func promptForUsernamePassword(viewController: UIViewController, credentials: NSURLCredential?, protectionSpace: NSURLProtectionSpace, loginsHelper: LoginsHelper?) -> Deferred<Maybe<LoginData>> {
+        if protectionSpace.host.isEmpty {
+            print("Unable to show a password prompt without a hostname")
+            return deferMaybe(LoginDataError(description: "Unable to show a password prompt without a hostname"))
+        }
+
+        let deferred = Deferred<Maybe<LoginData>>()
+        let alert: UIAlertController
+        let title = NSLocalizedString("Authentication required", comment: "Authentication prompt title")
+        if !(protectionSpace.realm?.isEmpty ?? true) {
+            let msg = NSLocalizedString("A username and password are being requested by %@. The site says: %@", comment: "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string")
+            let formatted = NSString(format: msg, protectionSpace.host, protectionSpace.realm ?? "") as String
+            alert = UIAlertController(title: title, message: formatted, preferredStyle: UIAlertControllerStyle.Alert)
+        } else {
+            let msg = NSLocalizedString("A username and password are being requested by %@.", comment: "Authentication prompt message with no realm. Parameter is the hostname of the site")
+            let formatted = NSString(format: msg, protectionSpace.host) as String
+            alert = UIAlertController(title: title, message: formatted, preferredStyle: UIAlertControllerStyle.Alert)
+        }
+
+        // Add a button to log in.
+        let action = UIAlertAction(title: LogInButtonTitle,
+            style: UIAlertActionStyle.Default) { (action) -> Void in
+                guard let user = alert.textFields?[0].text, pass = alert.textFields?[1].text else { deferred.fill(Maybe(failure: LoginDataError(description: "Username and Password required"))); return }
+
+                let login = Login.createWithCredential(NSURLCredential(user: user, password: pass, persistence: .ForSession), protectionSpace: protectionSpace)
+                deferred.fill(Maybe(success: login))
+                loginsHelper?.setCredentials(login)
+        }
+        alert.addAction(action)
+
+        // Add a cancel button.
+        let cancel = UIAlertAction(title: CancelButtonTitle, style: UIAlertActionStyle.Cancel) { (action) -> Void in
+            deferred.fill(Maybe(failure: LoginDataError(description: "Save password cancelled")))
+        }
+        alert.addAction(cancel)
+
+        // Add a username textfield.
+        alert.addTextFieldWithConfigurationHandler { (textfield) -> Void in
+            textfield.placeholder = NSLocalizedString("Username", comment: "Username textbox in Authentication prompt")
+            textfield.text = credentials?.user
+        }
+
+        // Add a password textfield.
+        alert.addTextFieldWithConfigurationHandler { (textfield) -> Void in
+            textfield.placeholder = NSLocalizedString("Password", comment: "Password textbox in Authentication prompt")
+            textfield.secureTextEntry = true
+            textfield.text = credentials?.password
+        }
+
+        viewController.presentViewController(alert, animated: true) { () -> Void in }
+        return deferred
+    }
+
+}

--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -3,3 +3,76 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+
+class AuthenticationTests: KIFTestCase {
+    private var webRoot: String!
+
+    override func setUp() {
+        webRoot = SimplePageServer.start()
+    }
+
+    override func tearDown() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
+
+    /**
+     * Tests HTTP authentication credentials and auto-fill.
+     */
+    func testAuthentication() {
+        loadAuthPage()
+
+        // Make sure that 3 invalid credentials result in authentication failure.
+        enterCredentials(usernameValue: "Username", passwordValue: "Password", username: "foo", password: "bar")
+        enterCredentials(usernameValue: "foo", passwordValue: "•••", username: "foo2", password: "bar2")
+        enterCredentials(usernameValue: "foo2", passwordValue: "••••", username: "foo3", password: "bar3")
+        tester().waitForWebViewElementWithAccessibilityLabel("auth fail")
+
+        // Enter valid credentials and ensure the page loads.
+        tester().tapViewWithAccessibilityLabel("Reload")
+        enterCredentials(usernameValue: "Username", passwordValue: "Password", username: "user", password: "pass")
+        tester().waitForWebViewElementWithAccessibilityLabel("logged in")
+
+        // Save the credentials.
+        tester().tapViewWithAccessibilityLabel("Yes")
+
+        logOut()
+        loadAuthPage()
+
+        // Make sure the credentials were saved and auto-filled.
+        tester().tapViewWithAccessibilityLabel("Log in")
+        tester().waitForWebViewElementWithAccessibilityLabel("logged in")
+
+        // Add a private tab.
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Private Mode")
+        tester().tapViewWithAccessibilityLabel("Add Tab")
+
+        loadAuthPage()
+
+        // Make sure the auth prompt is shown.
+        // Note that in the future, we might decide to auto-fill authentication credentials in private browsing mode,
+        // but that's not currently supported. We assume the username and password fields are empty.
+        enterCredentials(usernameValue: "Username", passwordValue: "Password", username: "user", password: "pass")
+        tester().waitForWebViewElementWithAccessibilityLabel("logged in")
+
+    }
+
+    private func loadAuthPage() {
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webRoot)/auth.html\n")
+    }
+
+    private func logOut() {
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webRoot)/auth.html?logout=1\n")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    private func enterCredentials(usernameValue usernameValue: String, passwordValue: String, username: String, password: String) {
+        let usernameField = tester().waitForViewWithAccessibilityValue(usernameValue) as! UITextField
+        let passwordField = tester().waitForViewWithAccessibilityValue(passwordValue) as! UITextField
+        usernameField.text = username
+        passwordField.text = password
+        tester().tapViewWithAccessibilityLabel("Log in")
+    }
+}

--- a/UITests/AuthenticationTests.swift
+++ b/UITests/AuthenticationTests.swift
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -353,6 +353,23 @@ class SimplePageServer {
             return GCDWebServerDataResponse(HTML: self.getPageData("loginForm"))
         }
 
+        webServer.addHandlerForMethod("GET", path: "/auth.html", requestClass: GCDWebServerRequest.self) { (request: GCDWebServerRequest!) in
+            // "user:pass", Base64-encoded.
+            let expectedAuth = "Basic dXNlcjpwYXNz"
+
+            let response: GCDWebServerDataResponse
+            if request.headers["Authorization"] as? String == expectedAuth && request.query["logout"] == nil {
+                response = GCDWebServerDataResponse(HTML: "<html><body>logged in</body></html>")
+            } else {
+                // Request credentials if the user isn't logged in.
+                response = GCDWebServerDataResponse(HTML: "<html><body>auth fail</body></html>")
+                response.statusCode = 401
+                response.setValue("Basic realm=\"test\"", forAdditionalHeader: "WWW-Authenticate")
+            }
+
+            return response
+        }
+
         if !webServer.startWithPort(0, bonjourName: nil) {
             XCTFail("Can't start the GCDWebServer")
         }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -209,7 +209,12 @@ class BrowserUtils {
 
         // Clear all private tabs if we're running iOS 9
         if #available(iOS 9, *) {
-            tester.tapViewWithAccessibilityLabel("Private Mode")
+            // Switch to Private Mode if we're not in it already.
+            do {
+                try tester.tryFindingTappableViewWithAccessibilityLabel("Private Mode", value: "Off", traits: UIAccessibilityTraitButton)
+                tester.tapViewWithAccessibilityLabel("Private Mode")
+            } catch _ {}
+
             while tabsView.numberOfItemsInSection(0) > 0 {
                 let cell = tabsView.cellForItemAtIndexPath(NSIndexPath(forItem: 0, inSection: 0))!
                 tester.swipeViewWithAccessibilityLabel(cell.accessibilityLabel, inDirection: KIFSwipeDirection.Left)


### PR DESCRIPTION
My first fix was going to just be replacing `as!` with `as?` to fix the crash, but that means we wouldn't show the HTTP authentication dialog for private tabs. We do still want to show the dialog, so I fixed this by splitting auth handling from logins.