### PR TITLE
Bug 1212327 - remove non iOS Alamofire targets

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire"        "swift-2.0"
+github "fluffyemily/Alamofire"      "alamofire-ios-only"
 github "mozilla/Base32"             "swift-2.0"        # So we don't have to tag a release for Emily's fixes.
 github "mozilla/Deferred"           "master"           # Making Deferred extensible in swift 2.0
 github "swisspol/GCDWebServer"                         # Implicit: latest tag.

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "1bc35abfa7c167ba54af4e87158af7945cc9984e"
+github "fluffyemily/Alamofire" "d50ae7f268777c14fa2e51c74e2daa8f81707a7f"
 github "mozilla/Base32" "d2136486487a77336ae18b1bd2f9a3f689ec44e5"
 github "mozilla/Deferred" "f3d9a179cfa96a0d9b82dd575c95c29c026248bd"
 github "swisspol/GCDWebServer" "ae88198f2001226ef6d7b7a0b53cb42078ff910c"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1212327
this prevents us from picking up the products of these targets when doing a command line build.

This is really only a temporary fix. Eventually we'll be using Carthage correctly and then only the iOS version of Alamofire will be linked in the project and the clashing between targets will not occur