### PR TITLE
Bug 1228547 - Don't reset the UA when reloading tabs or navigating on the same host

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -704,8 +704,15 @@ class BrowserViewController: UIViewController {
         urlBar.currentURL = url
         urlBar.leaveOverlayMode()
 
-        if let tab = tabManager.selectedTab,
-           let nav = tab.loadRequest(NSURLRequest(URL: url)) {
+        guard let tab = tabManager.selectedTab else {
+            return
+        }
+
+        if let webView = tab.webView {
+            resetSpoofedUserAgentIfRequired(webView, newURL: url)
+        }
+
+        if let nav = tab.loadRequest(NSURLRequest(URL: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }
@@ -890,6 +897,17 @@ class BrowserViewController: UIViewController {
     func openBlankNewTabAndFocus(isPrivate isPrivate: Bool = false) {
         openURLInNewTab(nil, isPrivate: isPrivate)
         urlBar.browserLocationViewDidTapLocation(urlBar.locationView)
+    }
+
+    private func resetSpoofedUserAgentIfRequired(webView: WKWebView, newURL: NSURL) {
+        guard #available(iOS 9.0, *) else {
+            return
+        }
+
+        // Reset the UA when a different domain is being loaded
+        if webView.URL?.host != newURL.host {
+            webView.customUserAgent = nil
+        }
     }
 }
 
@@ -1600,7 +1618,6 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
-
         guard let url = navigationAction.request.URL else {
             decisionHandler(WKNavigationActionPolicy.Cancel)
             return
@@ -1614,6 +1631,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 openExternal(url, prompt: navigationAction.navigationType == WKNavigationType.Other)
                 decisionHandler(WKNavigationActionPolicy.Cancel)
             } else {
+                if navigationAction.navigationType == .LinkActivated {
+                    resetSpoofedUserAgentIfRequired(webView, newURL: url)
+                }
                 decisionHandler(WKNavigationActionPolicy.Allow)
             }
         case "tel":
@@ -1683,10 +1703,9 @@ extension BrowserViewController: WKNavigationDelegate {
 
         addOpenInViewIfNeccessary(webView.URL)
 
-        // Remember whether or not a desktop site was requested and reset potentially spoofed user agent
+        // Remember whether or not a desktop site was requested
         if #available(iOS 9.0, *) {
             tab.desktopSite = webView.customUserAgent?.isEmpty == false
-            webView.customUserAgent = nil
         }
     }
 

--- a/UITests/NavigationTests.swift
+++ b/UITests/NavigationTests.swift
@@ -142,7 +142,7 @@ class NavigationTests: KIFTestCase, UITextFieldDelegate {
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 
-    func testNewNavigationLoadsMobileSite() {
+    func testNavigationPreservesDesktopSiteOnSameHost() {
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webRoot)/numberedPage.html?page=1\n")
         tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
@@ -159,15 +159,63 @@ class NavigationTests: KIFTestCase, UITextFieldDelegate {
         tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
         tester().waitForViewWithAccessibilityLabel("Request Mobile Site")
 
-        // Navigate to different URL
+        // Navigate to different URL on the same host
         tester().tapViewWithAccessibilityLabel("Cancel")
         tester().tapViewWithAccessibilityIdentifier("url")
         tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webRoot)/numberedPage.html?page=2\n")
         tester().waitForWebViewElementWithAccessibilityLabel("Page 2")
 
-        // The new navigation should load the mobile site with an offer to request the desktop site
+        // The new navigation (on the same host) should preserve the desktop site with an offer to request the mobile site
+        tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Request Mobile Site")
+
+        // Navigate to different URL on a different host
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("http://localhost\n")
+        tester().waitForTimeInterval(5)
+
+        // The new navigation (on a different host) should load the mobile site with an offer to request the desktop site
         tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
         tester().waitForViewWithAccessibilityLabel("Request Desktop Site")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+    }
+
+    func testReloadPreservesMobileOrDesktopSite() {
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webRoot)/numberedPage.html?page=1\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // Initially the mobile site should be loaded with an offer to request the desktop site
+        tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Request Desktop Site")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+
+        // Reload
+        tester().tapViewWithAccessibilityLabel("Reload")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // After reloading we should still be on the mobile site
+        tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Request Desktop Site")
+
+        // Request desktop site
+        tester().tapViewWithAccessibilityLabel("Request Desktop Site")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // After requesting the desktop site we should offer to request the mobile site
+        tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Request Mobile Site")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+
+        // Reload
+        tester().tapViewWithAccessibilityLabel("Reload")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // After reloading we should still be on the desktop site
+        tester().longPressViewWithAccessibilityLabel("Reload", duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Request Mobile Site")
 
         tester().tapViewWithAccessibilityLabel("Cancel")
     }


### PR DESCRIPTION
The user agent spoofing for requesting desktop sites was moved into the reload
method. As a result, any calls to reload will automatically preserve the last
spoofed user agent.

In addition, the user agent is not reset on *every* navigation anymore but only
on navigations that change the host.