### PR TITLE
Bug 1227857 - Make Browser Logger a rolling file logger

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -60,11 +60,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         KeyboardHelper.defaultHelper.startObserving()
 
         log.debug("Creating Sync log file…")
+        let logDate = NSDate()
         // Create a new sync log file on cold app launch. Note that this doesn't roll old logs.
-        Logger.syncLogger.newLogWithDate(NSDate())
+        Logger.syncLogger.newLogWithDate(logDate)
 
         log.debug("Creating corrupt DB logger…")
-        Logger.corruptLogger.newLogWithDate(NSDate())
+        Logger.corruptLogger.newLogWithDate(logDate)
+
+        log.debug("Creating Browser log file…")
+        Logger.browserLogger.newLogWithDate(logDate)
 
         log.debug("Getting profile…")
         let profile = getProfile(application)
@@ -158,9 +162,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Now roll logs.
         log.debug("Triggering log roll.")
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),
-            Logger.syncLogger.deleteOldLogsDownToSizeLimit
-        )
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+            Logger.syncLogger.deleteOldLogsDownToSizeLimit()
+            Logger.browserLogger.deleteOldLogsDownToSizeLimit()
+        }
 
 
         if #available(iOS 9, *) {

--- a/Utils/Logger.swift
+++ b/Utils/Logger.swift
@@ -15,7 +15,7 @@ public extension Logger {
     static let syncLogger = RollingFileLogger(filenameRoot: "sync", logDirectoryPath: Logger.logFileDirectoryPath())
 
     /// Logger used for recording frontend/browser happenings
-    static let browserLogger: XCGLogger = Logger.fileLoggerWithName("browser")
+    static let browserLogger = RollingFileLogger(filenameRoot: "browser", logDirectoryPath: Logger.logFileDirectoryPath())
 
     /// Logger used for recording interactions with the keychain
     static let keychainLogger: XCGLogger = Logger.fileLoggerWithName("keychain")
@@ -82,6 +82,7 @@ public extension Logger {
         do {
             filenamesAndURLs += try syncLogger.logFilenamesAndURLs()
             filenamesAndURLs += try corruptLogger.logFilenamesAndURLs()
+            filenamesAndURLs += try browserLogger.logFilenamesAndURLs()
         } catch _ {
         }
 


### PR DESCRIPTION
* Ensure that all rolling loggers have the same date so we can easily match up connected logs
* Ensure that we clean up old logs just like we do with sync