### PR TITLE
Bug 1229087, Bug 1228607, most of Bug 1228611, Bug 1228908, Bug 1229078

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -63,9 +63,6 @@ public class MockProfile: Profile {
     }
 
     func shutdown() {
-        if dbCreated {
-            db.close()
-        }
     }
 
     private var dbCreated = false

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -386,14 +386,22 @@ public class BrowserProfile: Profile {
 
     private lazy var loginsKey: String? = {
         let key = "sqlcipher.key.logins.db"
-        if KeychainWrapper.hasValueForKey(key) {
-            return KeychainWrapper.stringForKey(key)
+        struct Singleton {
+            static var token: dispatch_once_t = 0
+            static var instance: String!
         }
-
-        let Length: UInt = 256
-        let secret = Bytes.generateRandomBytes(Length).base64EncodedString
-        KeychainWrapper.setString(secret, forKey: key)
-        return secret
+        dispatch_once(&Singleton.token) {
+            if KeychainWrapper.hasValueForKey(key) {
+                let value = KeychainWrapper.stringForKey(key)
+                Singleton.instance = value
+            } else {
+                let Length: UInt = 256
+                let secret = Bytes.generateRandomBytes(Length).base64EncodedString
+                KeychainWrapper.setString(secret, forKey: key)
+                Singleton.instance = secret
+            }
+        }
+        return Singleton.instance
     }()
 
     private var loginsDBCreated = false

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -220,12 +220,14 @@ public class BrowserProfile: Profile {
     }
 
     func shutdown() {
+        log.debug("Shutting down profile.")
+
         if self.dbCreated {
-            db.close()
+            db.forceClose()
         }
 
         if self.loginsDBCreated {
-            loginsDB.close()
+            loginsDB.forceClose()
         }
     }
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -384,7 +384,10 @@ public class BrowserProfile: Profile {
         return SQLiteLogins(db: self.loginsDB)
     }()
 
-    private lazy var loginsKey: String? = {
+    // This is currently only used within the dispatch_once block in loginsDB, so we don't
+    // have to worry about races giving us two keys. But if this were ever to be used
+    // elsewhere, it'd be unsafe, so we wrap this in a dispatch_once, too.
+    private var loginsKey: String? {
         let key = "sqlcipher.key.logins.db"
         struct Singleton {
             static var token: dispatch_once_t = 0
@@ -402,7 +405,7 @@ public class BrowserProfile: Profile {
             }
         }
         return Singleton.instance
-    }()
+    }
 
     private var loginsDBCreated = false
     private lazy var loginsDB: BrowserDB = {

--- a/Storage/FileAccessor.swift
+++ b/Storage/FileAccessor.swift
@@ -79,6 +79,27 @@ public class FileAccessor {
         try NSFileManager.defaultManager().moveItemAtPath(fromPath, toPath: toPath as String)
     }
 
+    public func copyMatching(fromRelativeDirectory relativePath: String, toAbsoluteDirectory absolutePath: String, matching: String -> Bool) throws {
+        let fileManager = NSFileManager.defaultManager()
+        let path = rootPath.stringByAppendingPathComponent(relativePath)
+        let pathURL = NSURL.fileURLWithPath(path)
+        let destURL = NSURL.fileURLWithPath(absolutePath, isDirectory: true)
+
+        let files = try fileManager.contentsOfDirectoryAtPath(path)
+        for file in files {
+            if !matching(file) {
+                continue
+            }
+
+            let from = pathURL.URLByAppendingPathComponent(file, isDirectory: false).path!
+            let to = destURL.URLByAppendingPathComponent(file, isDirectory: false).path!
+            do {
+                try fileManager.copyItemAtPath(from, toPath: to)
+            } catch {
+            }
+        }
+    }
+
     public func copy(fromRelativePath: String, toAbsolutePath: String) throws -> Bool {
         let fromPath = rootPath.stringByAppendingPathComponent(fromRelativePath)
         guard let dest = NSURL.fileURLWithPath(toAbsolutePath).URLByDeletingLastPathComponent?.path else {

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -167,7 +167,7 @@ public class BrowserDB {
             log.debug("Attempting to move \(self.filename) to another location.")
 
             // Make sure that we don't still have open the files that we want to move!
-            db.close()
+            db.forceClose()
 
             // Note that a backup file might already exist! We append a counter to avoid this.
             var bakCounter = 0
@@ -347,8 +347,8 @@ extension BrowserDB {
         }
     }
 
-    public func close() {
-        db.close()
+    public func forceClose() {
+        db.forceClose()
     }
 
     func run(sql: String, withArgs args: Args? = nil) -> Success {

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -167,6 +167,8 @@ public class BrowserDB {
             log.debug("Attempting to move \(self.filename) to another location.")
 
             // Make sure that we don't still have open the files that we want to move!
+            // Note that we use sqlite3_close_v2, which might actually _not_ close the
+            // database file yet. For this reason we move the -shm and -wal files, too.
             db.forceClose()
 
             // Note that a backup file might already exist! We append a counter to avoid this.

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -104,11 +104,11 @@ public class BrowserDB {
     // creation of the table in the database.
     func createOrUpdate(tables: Table...) -> Bool {
         var success = true
+
         let doCreate = { (table: Table, connection: SQLiteDBConnection) -> () in
             switch self.createTable(connection, table: table) {
             case .Created:
                 success = true
-                connection.checkpoint()
                 return
             case .Exists:
                 log.debug("Table already exists.")
@@ -133,7 +133,6 @@ public class BrowserDB {
                     case .Updated:
                         log.debug("Updated table \(table.name).")
                         success = true
-                        connection.checkpoint()
                         break
                     case .Exists:
                         log.debug("Table \(table.name) already exists.")

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -534,10 +534,16 @@ public class SQLiteDBConnection {
 
             logger.error("Integrity check:")
             let messages = self.executeQueryUnsafe("PRAGMA integrity_check", factory: StringFactory)
-            for message in messages {
-                logger.error(message)
+            defer { messages.close() }
+
+            if messages.status == CursorStatus.Success {
+                for message in messages {
+                    logger.error(message)
+                }
+                logger.error("----")
+            } else {
+                logger.error("Couldn't run integrity check: \(messages.statusMessage).")
             }
-            logger.error("----")
 
             // Write call stack.
             logger.error("Call stack: \(NSThread.callStackSymbols())")

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -539,12 +539,16 @@ public class SQLiteDBConnection {
             }
             logger.error("----")
 
-            // Write call stack
+            // Write call stack.
             logger.error("Call stack: \(NSThread.callStackSymbols())")
 
-            // Write open file handles
+            // Write open file handles.
             let openDescriptors = FSUtils.openFileDescriptors()
-            logger.error("Open file descriptors: \(openDescriptors)")
+            logger.error("Open file descriptors: ")
+            for (k, v) in openDescriptors {
+                logger.error("  \(k): \(v)")
+            }
+            logger.error("----")
 
             SwiftData.corruptionLogsWritten.insert(dbFilename)
         }

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -527,14 +527,17 @@ public class SQLiteDBConnection {
         dispatch_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             guard !SwiftData.corruptionLogsWritten.contains(dbFilename) else { return }
 
-            logger.error("Corrupt DB Detected! - DB Filename: \(dbFilename)")
+            logger.error("Corrupt DB detected! DB filename: \(dbFilename)")
 
             let dbFileSize = ("file://\(dbFilename)".asURL)?.allocatedFileSize() ?? 0
             logger.error("DB file size: \(dbFileSize) bytes")
 
-            if let message = self.pragma("integrity_check", factory: StringFactory) {
-                logger.error("Integrity check message: \(message)")
+            logger.error("Integrity check:")
+            let messages = self.executeQueryUnsafe("PRAGMA integrity_check", factory: StringFactory)
+            for message in messages {
+                logger.error(message)
             }
+            logger.error("----")
 
             // Write call stack
             logger.error("Call stack: \(NSThread.callStackSymbols())")

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -335,12 +335,18 @@ public class SQLiteDBConnection {
             }
         }
 
+        // If we just created the DB -- i.e., no tables have been created yet -- then
+        // we can set the page size right now and save a vacuum.
         //
         // For where these values come from, see Bug 1213623.
         //
+        // Note that sqlcipher uses cipher_page_size instead, but we don't set that
+        // because it needs to be set from day one.
+
+        let desiredPageSize = 32 * 1024
+        pragma("page_size=\(desiredPageSize)", factory: IntFactory)
 
         let currentPageSize = pragma("page_size", factory: IntFactory)
-        let desiredPageSize = 32 * 1024
 
         // This has to be done without WAL, so we always hop into rollback/delete journal mode.
         if currentPageSize != desiredPageSize {

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -323,9 +323,12 @@ public class SQLiteDBConnection {
             return nil
         }
 
-        // Setting the key need to be the first thing done with the database.
+        // Setting the key needs to be the first thing done with the database.
         if let _ = setKey(key) {
-            closeCustomConnection()
+            if let err = closeCustomConnection(immediately: true) {
+                log.error("Couldn't close connection: \(err). Failing to open.")
+                return nil
+            }
             if let _ = openWithFlags(flags) {
                 return nil
             }
@@ -441,21 +444,25 @@ public class SQLiteDBConnection {
     }
 
     /// Closes a connection. This is called via deinit. Do not call this yourself.
-    private func closeCustomConnection() -> NSError? {
+    private func closeCustomConnection(immediately immediately: Bool=false) -> NSError? {
         log.debug("Closing custom connection for \(self.filename) on \(NSThread.currentThread()).")
-        // Make sure we don't try to call sqlite3_close multiple times.
         // TODO: add a lock here?
-        guard self.sqliteDB != nil else {
+        let db = self.sqliteDB
+        self.sqliteDB = nil
+
+        // Don't bother trying to call sqlite3_close multiple times.
+        guard db != nil else {
             log.warning("Connection was nil.")
             return nil
         }
 
-        let status = sqlite3_close(self.sqliteDB)
+        let status = immediately ? sqlite3_close(db) : sqlite3_close_v2(db)
         log.debug("Closed \(self.filename).")
-        self.sqliteDB = nil
 
+        // Note that if we use sqlite3_close_v2, this will still return SQLITE_OK even if
+        // there are outstanding prepared statements
         if status != SQLITE_OK {
-            log.error("Got \(status) while closing.")
+            log.error("Got status \(status) while closing.")
             return createErr("During: closing database with flags", status: Int(status))
         }
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -396,7 +396,7 @@ public class SQLiteDBConnection {
     /**
      * Blindly attempts a WAL checkpoint on all attached databases.
      */
-    func checkpoint(mode: Int32 = SQLITE_CHECKPOINT_PASSIVE) {
+    func checkpoint(mode: Int32 = SQLITE_CHECKPOINT_FULL) {
         guard sqliteDB != nil else {
             log.warning("Trying to checkpoint a nil DB!")
             return

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -462,15 +462,15 @@ public class SQLiteDBConnection {
         }
 
         let status = immediately ? sqlite3_close(db) : sqlite3_close_v2(db)
-        log.debug("Closed \(self.filename).")
 
         // Note that if we use sqlite3_close_v2, this will still return SQLITE_OK even if
         // there are outstanding prepared statements
         if status != SQLITE_OK {
-            log.error("Got status \(status) while closing.")
+            log.error("Got status \(status) while attempting to close.")
             return createErr("During: closing database with flags", status: Int(status))
         }
 
+        log.debug("Closed \(self.filename).")
         return nil
     }
 
@@ -559,7 +559,11 @@ public class SQLiteDBConnection {
             }
 
             // Write call stack.
-            logger.error("Call stack: \(NSThread.callStackSymbols())")
+            logger.error("Call stack: ")
+            for message in NSThread.callStackSymbols() {
+                logger.error(" >> \(message)")
+            }
+            logger.error("----")
 
             // Write open file handles.
             let openDescriptors = FSUtils.openFileDescriptors()

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -154,13 +154,10 @@ public class SwiftData {
         }
     }
 
-    func close() {
-        dispatch_sync(sharedConnectionQueue) {
-            if self.sharedConnection != nil {
-                self.sharedConnection?.closeCustomConnection()
-            }
-            self.sharedConnection = nil
-        }
+    // Don't use this unless you know what you're doing. The deinitializer
+    // should be used to achieve refcounting semantics.
+    func forceClose() {
+        self.sharedConnection = nil
     }
 
     public enum Flags {
@@ -385,7 +382,9 @@ public class SQLiteDBConnection {
 
     deinit {
         log.debug("deinit: closing connection on thread \(NSThread.currentThread()).")
-        closeCustomConnection()
+        dispatch_sync(self.queue) {
+            self.closeCustomConnection()
+        }
     }
 
     var lastInsertedRowID: Int {


### PR DESCRIPTION
These avoid the reproducible logins.db corruption, and fix a bunch of other issues along the way (including the things needed to debug this kind of issue).

Apparently sometimes sqlcipher will corrupt the output DB if you adjust the page size, so let's not do that.

I'll file another bug for the lifecycle change that I implemented in Bug 1228611. Stefan reported seeing browser.db corruption once; if we still see that, we might need to resurrect that commit.