### PR TITLE
Fixes 1228538 - Shared URL includes reader view decorations

### DIFF
--- a/Client/Frontend/Browser/ShareExtensionHelper.swift
+++ b/Client/Frontend/Browser/ShareExtensionHelper.swift
@@ -64,7 +64,7 @@ class ShareExtensionHelper: NSObject {
 
 extension ShareExtensionHelper: UIActivityItemSource {
     func activityViewControllerPlaceholderItem(activityViewController: UIActivityViewController) -> AnyObject {
-        return selectedTab.displayURL!
+        return NSURL() // Placeholder, does not have to contain the actual URL
     }
 
     func activityViewController(activityViewController: UIActivityViewController, itemForActivityType activityType: String) -> AnyObject? {
@@ -72,8 +72,12 @@ extension ShareExtensionHelper: UIActivityItemSource {
             // Return the 1Password extension item
             return onePasswordExtensionItem
         } else {
-            // Return the selected tab's URL
-            return selectedTab.displayURL!
+            // Return the URL for the selected tab. If we are in reader view then decode
+            // it so that we copy the original and not the internal localhost one.
+            if let url = selectedTab.displayURL where ReaderModeUtils.isReaderModeURL(url) {
+                return ReaderModeUtils.decodeURL(url)
+            }
+            return selectedTab.displayURL
         }
     }
 


### PR DESCRIPTION
This patch recognizes Reading View URLs and decodes them when shared via the Share Sheet.