### PR TITLE
Bug 1229047 - Fixed TopSitesPanel relayout on rotation

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -112,6 +112,7 @@ class BrowserViewController: UIViewController {
     }
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
         displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
 
         coordinator.animateAlongsideTransition(nil) { context in


### PR DESCRIPTION
viewWillTransitionToSize was not being called in TopSitesPanel because further up the view controller hierarchy there was a missing call to super.viewWillTransitionToSize.