### PR TITLE
Bug 1229460 - Fixed top sites displaying wrong favicons/blurring

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -88,6 +88,7 @@ class TopSitesPanel: UIViewController {
         }
         self.collection = collection
 
+        self.dataSource.collectionView = self.collection
         self.profile.history.setTopSitesCacheSize(Int32(maxFrecencyLimit))
         self.refreshTopSites(maxFrecencyLimit)
     }
@@ -432,6 +433,8 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
     var profile: Profile
     var editingThumbnails: Bool = false
 
+    weak var collectionView: UICollectionView?
+
     private let blurQueue = dispatch_queue_create("FaviconBlurQueue", DISPATCH_QUEUE_CONCURRENT)
     private let BackgroundFadeInDuration: NSTimeInterval = 0.3
 
@@ -473,22 +476,20 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         }
     }
 
-    private func getFaviconForCell(cell:ThumbnailCell, site: Site, profile: Profile) {
-        setDefaultThumbnailBackgroundForCell(cell)
-        guard let url = site.url.asURL else { return }
+    private func downloadFaviconsAndUpdateForSite(site: Site) {
+        guard let siteURL = site.url.asURL else { return }
 
-        FaviconFetcher.getForURL(url, profile: profile) >>== { icons in
-            if icons.count == 0 { return }
-            guard let url = icons[0].url.asURL else { return }
+        FaviconFetcher.getForURL(siteURL, profile: profile).uponQueue(dispatch_get_main_queue()) { result in
+            guard let favicons = result.successValue where favicons.count > 0 else { return }
+            guard let url = favicons.first?.url.asURL else { return }
+            guard let indexOfSite = (self.data.asArray().indexOf { $0 == site }) else {
+                return
+            }
 
+            let indexPathToUpdate = NSIndexPath(forItem: indexOfSite, inSection: 0)
+            guard let cell = self.collectionView?.cellForItemAtIndexPath(indexPathToUpdate) as? ThumbnailCell else { return }
             cell.imageView.sd_setImageWithURL(url) { (img, err, type, url) -> Void in
-                guard let img = img else {
-                    let icon = Favicon(url: "", date: NSDate(), type: IconType.NoneFound)
-                    profile.favicons.addFavicon(icon, forSite: site)
-                    self.setDefaultThumbnailBackgroundForCell(cell)
-                    return
-                }
-
+                guard let img = img else { return }
                 cell.image = img
                 self.setBlurredBackground(img, withURL: url, forCell: cell)
             }
@@ -515,7 +516,8 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         cell.removeButton.hidden = !editing
 
         guard let icon = site.icon else {
-            getFaviconForCell(cell, site: site, profile: profile)
+            setDefaultThumbnailBackgroundForCell(cell)
+            downloadFaviconsAndUpdateForSite(site)
             return
         }
 
@@ -529,7 +531,8 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
                     cell.image = img
                     self.setBlurredBackground(img, withURL: url, forCell: cell)
                 } else {
-                    self.getFaviconForCell(cell, site: site, profile: profile)
+                    self.setDefaultThumbnailBackgroundForCell(cell)
+                    self.downloadFaviconsAndUpdateForSite(site)
                 }
             })
         }

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -480,9 +480,9 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
         guard let siteURL = site.url.asURL else { return }
 
         FaviconFetcher.getForURL(siteURL, profile: profile).uponQueue(dispatch_get_main_queue()) { result in
-            guard let favicons = result.successValue where favicons.count > 0 else { return }
-            guard let url = favicons.first?.url.asURL else { return }
-            guard let indexOfSite = (self.data.asArray().indexOf { $0 == site }) else {
+            guard let favicons = result.successValue where favicons.count > 0,
+                  let url = favicons.first?.url.asURL,
+                  let indexOfSite = (self.data.asArray().indexOf { $0 == site }) else {
                 return
             }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -489,7 +489,10 @@ private class TopSitesDataSource: NSObject, UICollectionViewDataSource {
             let indexPathToUpdate = NSIndexPath(forItem: indexOfSite, inSection: 0)
             guard let cell = self.collectionView?.cellForItemAtIndexPath(indexPathToUpdate) as? ThumbnailCell else { return }
             cell.imageView.sd_setImageWithURL(url) { (img, err, type, url) -> Void in
-                guard let img = img else { return }
+                guard let img = img else {
+                    self.setDefaultThumbnailBackgroundForCell(cell)
+                    return
+                }
                 cell.image = img
                 self.setBlurredBackground(img, withURL: url, forCell: cell)
             }

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -5,8 +5,12 @@
 import UIKit
 import Shared
 
-protocol Identifiable {
+public protocol Identifiable: Equatable {
     var id: Int? { get set }
+}
+
+public func ==<T where T: Identifiable>(lhs: T, rhs: T) -> Bool {
+    return lhs.id == rhs.id
 }
 
 public enum IconType: Int {
@@ -40,7 +44,7 @@ public enum IconType: Int {
 }
 
 public class Favicon: Identifiable {
-    var id: Int? = nil
+    public var id: Int? = nil
 
     public let url: String
     public let date: NSDate
@@ -58,7 +62,7 @@ public class Favicon: Identifiable {
 // TODO: Site shouldn't have all of these optional decorators. Include those in the
 // cursor results, perhaps as a tuple.
 public class Site : Identifiable {
-    var id: Int? = nil
+    public var id: Int? = nil
     var guid: String? = nil
 
     public let url: String


### PR DESCRIPTION
By the time the FaviconFetcher's async download call finishes, the cell that we intended to fetch images for might have been recycled since we are reusuing the collection view cells. Instead of relying on the original cell that's requested, I rewrote it to be data-centric and requery for the cell on favicon fetch completion based on the site we just downloaded.