### PR TITLE
Bug 1229956, Bug 1229954 — Improved sync scheduling

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -267,17 +267,17 @@ private class SyncNowSetting: WithAccountSetting {
     }
 
     override var status: NSAttributedString? {
-        if let timestamp = profile.prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime) {
-            let label = NSLocalizedString("Last synced: %@", comment: "Last synced time label beside Sync Now setting option. Argument is the relative date string.")
-            let formattedLabel = String(format: label, NSDate.fromTimestamp(timestamp).toRelativeTimeString())
-            let attributedString = NSMutableAttributedString(string: formattedLabel)
-            let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
-            let range = NSMakeRange(0, attributedString.length)
-            attributedString.setAttributes(attributes, range: range)
-            return attributedString
+        guard let timestamp = profile.syncManager.lastSyncFinishTime else {
+            return nil
         }
 
-        return nil
+        let label = NSLocalizedString("Last synced: %@", comment: "Last synced time label beside Sync Now setting option. Argument is the relative date string.")
+        let formattedLabel = String(format: label, NSDate.fromTimestamp(timestamp).toRelativeTimeString())
+        let attributedString = NSMutableAttributedString(string: formattedLabel)
+        let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
+        let range = NSMakeRange(0, attributedString.length)
+        attributedString.setAttributes(attributes, range: range)
+        return attributedString
     }
 
     override func onConfigureCell(cell: UITableViewCell) {

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -12,6 +12,7 @@ import XCTest
 
 public class MockSyncManager: SyncManager {
     public var isSyncing = false
+    public var lastSyncFinishTime: Timestamp? = nil
 
     public func syncClients() -> SyncResult { return deferMaybe(.Completed) }
     public func syncClientsThenTabs() -> SyncResult { return deferMaybe(.Completed) }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -534,6 +534,15 @@ public class BrowserProfile: Profile {
         func applicationDidBecomeActive() {
             self.backgrounded = false
             self.beginTimedSyncs()
+
+            // Sync now if it's been more than our threshold.
+            let now = NSDate.now()
+            let then = self.lastSyncFinishTime ?? 0
+            let since = now - then
+            log.debug("\(since)msec since last sync.")
+            if since > SyncConstants.SyncOnForegroundMinimumDelayMillis {
+                self.syncEverythingSoon()
+            }
         }
 
         /**
@@ -888,6 +897,12 @@ public class BrowserProfile: Profile {
             ) >>> succeed
         }
 
+        func syncEverythingSoon() {
+            self.doInBackgroundAfter(millis: SyncConstants.SyncOnForegroundAfterMillis) {
+                log.debug("Running delayed startup sync.")
+                self.syncEverything()
+            }
+        }
 
         @objc func syncOnTimer() {
             self.syncEverything()

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -871,30 +871,7 @@ public class BrowserProfile: Profile {
 
 
         @objc func syncOnTimer() {
-            log.debug("Running timed logins sync.")
-
-            // Note that we use .upon here rather than chaining with >>> precisely
-            // to allow us to sync subsequent engines regardless of earlier failures.
-            // We don't fork them in parallel because we want to limit perf impact
-            // due to background syncs, and because we're cautious about correctness.
-            self.syncLogins().upon { result in
-                if let success = result.successValue {
-                    log.debug("Timed logins sync succeeded. Status: \(success.description).")
-                } else {
-                    let reason = result.failureValue?.description ?? "none"
-                    log.debug("Timed logins sync failed. Reason: \(reason).")
-                }
-
-                log.debug("Running timed history sync.")
-                self.syncHistory().upon { result in
-                    if let success = result.successValue {
-                        log.debug("Timed history sync succeeded. Status: \(success.description).")
-                    } else {
-                        let reason = result.failureValue?.description ?? "none"
-                        log.debug("Timed history sync failed. Reason: \(reason).")
-                    }
-                }
-            }
+            self.syncEverything()
         }
 
         func syncClients() -> SyncResult {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -18,6 +18,7 @@ public let ProfileRemoteTabsSyncDelay: NSTimeInterval = 0.1
 
 public protocol SyncManager {
     var isSyncing: Bool { get }
+    var lastSyncFinishTime: Timestamp? { get set }
 
     func syncClients() -> SyncResult
     func syncClientsThenTabs() -> SyncResult
@@ -642,8 +643,22 @@ public class BrowserProfile: Profile {
             }
         }
 
+        var lastSyncFinishTime: Timestamp? {
+            get {
+                return self.prefs.timestampForKey(PrefsKeys.KeyLastSyncFinishTime)
+            }
+
+            set(value) {
+                if let value = value {
+                    self.prefs.setTimestamp(value, forKey: PrefsKeys.KeyLastSyncFinishTime)
+                } else {
+                    self.prefs.removeObjectForKey(PrefsKeys.KeyLastSyncFinishTime)
+                }
+            }
+        }
+
         @objc func onFinishSyncing(notification: NSNotification) {
-            self.prefs.setTimestamp(NSDate.now(), forKey: PrefsKeys.KeyLastSyncFinishTime)
+            self.lastSyncFinishTime = NSDate.now()
         }
 
         var prefsForSync: Prefs {

--- a/Sync/SyncConstants.swift
+++ b/Sync/SyncConstants.swift
@@ -7,4 +7,6 @@ import Foundation
 public struct SyncConstants {
     // Suitable for use in dispatch_time().
     public static let SyncDelayTriggered: Int64 = 3 * Int64(NSEC_PER_SEC)
+    public static let SyncOnForegroundMinimumDelayMillis: UInt64 = 5 * 60 * 1000
+    public static let SyncOnForegroundAfterMillis: Int64 = 5000
 }


### PR DESCRIPTION
With these commits, we now sync everything (not just logins and history), and:

* When you foreground the app
* If it's been more than five minutes since your last sync
* Kick off a sync five seconds later.

We still have a fifteen-minute sync timer and a post-change logins sync timer.