### PR TITLE
Bug 1230288 - Forcibly shut down the profile in applicationWillTerminate, rather than closing the database connection when backgrounding.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -130,6 +130,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    func applicationWillTerminate(application: UIApplication) {
+        log.debug("Application will terminate.")
+
+        // We have only five seconds here, so let's hope this doesn't take too long.
+        self.profile?.shutdown()
+
+        // Allow deinitializers to close our database connections.
+        self.profile = nil
+        self.tabManager = nil
+        self.browserViewController = nil
+        self.rootViewController = nil
+    }
+
     /**
      * We maintain a weak reference to the profile so that we can pause timed
      * syncs when we're backgrounded.
@@ -240,7 +253,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
-            self.profile?.shutdown()
+            self.profile?.background()
             application.endBackgroundTask(taskId)
         }
     }

--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -63,6 +63,9 @@ public class MockProfile: Profile {
         return name
     }
 
+    func background() {
+    }
+
     func shutdown() {
     }
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -138,6 +138,7 @@ protocol Profile: class {
     var readingList: ReadingListService? { get }
     var logins: protocol<BrowserLogins, SyncableLogins, ResettableSyncStorage> { get }
 
+    func background()
     func shutdown()
 
     // I got really weird EXC_BAD_ACCESS errors on a non-null reference when I made this a getter.
@@ -218,6 +219,25 @@ public class BrowserProfile: Profile {
     // Extensions don't have a UIApplication.
     convenience init(localName: String) {
         self.init(localName: localName, app: nil)
+    }
+
+    private func logProfileFDs() {
+        let openDescriptors = FSUtils.openFileDescriptors()
+        log.debug("Open file descriptors: ")
+        log.debug("----")
+        for (k, v) in openDescriptors {
+            if v.containsString(self.name) {
+                log.debug("  \(k): \(v)")
+            }
+        }
+        log.debug("----")
+    }
+
+    func background() {
+        log.debug("Backgrounding profile.")
+        if AppConstants.IsDebug {
+            self.logProfileFDs()
+        }
     }
 
     func shutdown() {


### PR DESCRIPTION
This is a follow-up from Bug 1228611.

Just dropping all references to the BVC and profile isn't enough — something is still holding a reference. So we forcibly close during `applicationWillTerminate`.

In the newly introduced `background()` call we log our open file descriptors. If we see more than one reference to a DB, we might be in trouble.

The big change here is that we don't routinely close the database connection when backgrounding. This avoids some flapping. Because we close the connection in `applicationWillTerminate`, this also makes sure that we close any connection we open _in the background_ due to a delayed sync.

We might consider doing the latter regardless.