### PR TITLE
Bug 1230504 - RDS should not be available in reader mode

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1117,7 +1117,7 @@ extension BrowserViewController: BrowserToolbarDelegate {
             return
         }
 
-        guard let tab = tabManager.selectedTab where tab.webView?.URL != nil else {
+        guard let tab = tabManager.selectedTab where tab.webView?.URL != nil && (tab.getHelper(name: ReaderMode.name()) as? ReaderMode)?.state != .Active else {
             return
         }
 


### PR DESCRIPTION
This makes the long-tap event handler ignore events when reader mode is enabled.