### PR TITLE
Bug 1227112 tab tray peek pop

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		7B0E83B51BF2196E00D12554 /* Alamofire.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
 		7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */; };
+		7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */; };
 		7BA8D1C71BA037F500C8AE9E /* OpenPdfHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */; };
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; };
@@ -1577,6 +1578,7 @@
 		7B60B0071BDE3AE10090C984 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
 		7B60B0091BDE3B460090C984 /* MarketingSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarketingSnapshotTests.swift; path = snapshot/MarketingSnapshotTests.swift; sourceTree = "<group>"; };
 		7B844E3C1BBDDB9D00E733A2 /* ChevronView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChevronView.swift; sourceTree = "<group>"; };
+		7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabPeekViewController.swift; sourceTree = "<group>"; };
 		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
@@ -2753,6 +2755,7 @@
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
+				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
 				E4A85CE61BF2600B008BD381 /* TitleActivityItemProvider.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
@@ -4967,6 +4970,7 @@
 				D38B2D4F1A8D96D00040E6B5 /* GCDWebServerFileResponse.m in Sources */,
 				E43A4E551A96B88100E25676 /* GCDWebServerDataRequest.m in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
+				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
 				E4B334581BBF2393004E2BFF /* ADJDeviceInfo.m in Sources */,
 				E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -332,6 +332,8 @@
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		74E36E151B716BAF00D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
+		7B0B1B791C1B69C900DF4AB5 /* ClientPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */; };
+		7B0B1B9D1C1B6A3F00DF4AB5 /* InstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BCAAB81B0537E300855D82 /* InstructionsViewController.swift */; };
 		7B0E83B41BF2196E00D12554 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; };
 		7B0E83B51BF2196E00D12554 /* Alamofire.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D31FC2311A8D908900BAF7EC /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B24DC9C1B67B3590005766B /* ClearPrivateDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */; };
@@ -1777,8 +1779,8 @@
 		E4BA8AA51B4B15EF00BC2E95 /* Firefox.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Firefox.entitlements; sourceTree = "<group>"; };
 		E4BA8AA61B4B15EF00BC2E95 /* ViewLater.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ViewLater.xcassets; sourceTree = "<group>"; };
 		E4BA8AA71B4B15EF00BC2E95 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E4BCAAB81B0537E300855D82 /* InstructionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstructionsViewController.swift; sourceTree = "<group>"; };
-		E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientPickerViewController.swift; sourceTree = "<group>"; };
+		E4BCAAB81B0537E300855D82 /* InstructionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InstructionsViewController.swift; path = ../../Extensions/SendTo/InstructionsViewController.swift; sourceTree = "<group>"; };
+		E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientPickerViewController.swift; path = ../../Extensions/SendTo/ClientPickerViewController.swift; sourceTree = "<group>"; };
 		E4C358531AF1440B00299F7E /* Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Swizzling.h; sourceTree = "<group>"; };
 		E4C358541AF144BA00299F7E /* FSReadingList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSReadingList.m; sourceTree = "<group>"; };
 		E4C358561AF1467A00299F7E /* FSReadingList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FSReadingList.h; sourceTree = "<group>"; };
@@ -2542,6 +2544,15 @@
 			name = OnePasswordExtension;
 			sourceTree = "<group>";
 		};
+		7B0B1B9C1C1B69F500DF4AB5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */,
+				E4BCAAB81B0537E300855D82 /* InstructionsViewController.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
 		7B60AFD61BDE3A8B0090C984 /* ClientUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -3278,6 +3289,7 @@
 		F84B21F11A0910F600AAB793 /* Frontend */ = {
 			isa = PBXGroup;
 			children = (
+				7B0B1B9C1C1B69F500DF4AB5 /* Extensions */,
 				D3A994941A368691008AD1AC /* Browser */,
 				E49943F31AE6879C00BF9DE4 /* Intro */,
 				F84B21F51A0910F600AAB793 /* Reader */,
@@ -3365,8 +3377,6 @@
 				E4988B6E1A9B964B008B8B92 /* FennecNightly.entitlements */,
 				E448FC9B1AEE7A1900869B6C /* Firefox.entitlements */,
 				F8708D201A0970990051AB07 /* ActionViewController.swift */,
-				E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */,
-				E4BCAAB81B0537E300855D82 /* InstructionsViewController.swift */,
 				F8708D211A0970990051AB07 /* Info.plist */,
 				F8708D221A0970990051AB07 /* MainInterface.storyboard */,
 				E4F21AA51A13C4A300B0FAAA /* Images.xcassets */,
@@ -4897,6 +4907,7 @@
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
+				7B0B1B9D1C1B6A3F00DF4AB5 /* InstructionsViewController.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
 				E42475E51AB73B9B00B23D33 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
@@ -5011,6 +5022,7 @@
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
 				E4B334541BBF2393004E2BFF /* ADJAdjustFactory.m in Sources */,
 				59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */,
+				7B0B1B791C1B69C900DF4AB5 /* ClientPickerViewController.swift in Sources */,
 				0B5B51AF1B4CDB9E00E3B6E9 /* RXMLElement.m in Sources */,
 				7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */,
 				D38B2D491A8D96D00040E6B5 /* GCDWebServerDataResponse.m in Sources */,

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -46,8 +46,8 @@ struct QuickActions {
     static let TabURLKey = "url"
     static let TabTitleKey = "title"
 
-    private let lastBookmarkTitle = NSLocalizedString("Open Last Bookmark", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
-    private let lastTabTitle = NSLocalizedString("Open Last Tab", comment: "String describing the action of opening the last tab sent to Firefox from the home screen Quick Actions via 3D Touch")
+    private let lastBookmarkTitle = NSLocalizedString("Open Last Bookmark", tableName: "3D Touch Actions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
+    private let lastTabTitle = NSLocalizedString("Open Last Tab", tableName: "3D Touch Actions", comment: "String describing the action of opening the last tab sent to Firefox from the home screen Quick Actions via 3D Touch")
 
     static var sharedInstance = QuickActions()
 

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -46,8 +46,8 @@ struct QuickActions {
     static let TabURLKey = "url"
     static let TabTitleKey = "title"
 
-    private let lastBookmarkTitle = NSLocalizedString("Open Last Bookmark", tableName: "3D Touch Actions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
-    private let lastTabTitle = NSLocalizedString("Open Last Tab", tableName: "3D Touch Actions", comment: "String describing the action of opening the last tab sent to Firefox from the home screen Quick Actions via 3D Touch")
+    private let lastBookmarkTitle = NSLocalizedString("Open Last Bookmark", tableName: "3DTouchActions", comment: "String describing the action of opening the last added bookmark from the home screen Quick Actions via 3D Touch")
+    private let lastTabTitle = NSLocalizedString("Open Last Tab", tableName: "3DTouchActions", comment: "String describing the action of opening the last tab sent to Firefox from the home screen Quick Actions via 3D Touch")
 
     static var sharedInstance = QuickActions()
 

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -80,8 +80,7 @@ private extension TrayToBrowserAnimator {
             container.layoutIfNeeded()
             cell.title.transform = CGAffineTransformMakeTranslation(0, -cell.title.frame.height)
 
-            resetTransformsForViews([bvc.header, bvc.footer, bvc.readerModeBar, bvc.footerBackdrop, bvc.headerBackdrop])
-            bvc.urlBar.updateAlphaForSubviews(1)
+            bvc.tabTrayDidDismiss(tabTray)
 
             tabCollectionViewSnapshot.transform = CGAffineTransformMakeScale(0.9, 0.9)
             tabCollectionViewSnapshot.alpha = 0

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2426,18 +2426,18 @@ extension BrowserViewController: TabTrayDelegate {
         }
     }
 
-    func addBookmark(tab: Browser) {
+    func tabTrayDidAddBookmark(tab: Browser) {
         guard let url = tab.url?.absoluteString where url.characters.count > 0 else { return }
         self.addBookmark(url, title: tab.title)
     }
 
 
-    func addToReadingList(tab: Browser) -> ReadingListClientRecord? {
+    func tabTrayDidAddToReadingList(tab: Browser) -> ReadingListClientRecord? {
         guard let url = tab.url?.absoluteString where url.characters.count > 0 else { return nil }
         return profile.readingList?.createRecordWithURL(url, title: tab.title ?? url, addedBy: UIDevice.currentDevice().name).successValue
     }
 
-    func present(viewController viewController: UIViewController) {
+    func tabTrayRequestsPresentationOf(viewController viewController: UIViewController) {
         self.presentViewController(viewController, animated: false, completion: nil)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -906,7 +906,7 @@ class BrowserViewController: UIViewController {
         } else {
             request = nil
         }
-        let tabTrayController = self.tabTrayController ?? TabTrayController(tabManager: tabManager, profile: profile)
+        let tabTrayController = self.tabTrayController ?? TabTrayController(tabManager: tabManager, profile: profile, browserViewController: self)
         tabTrayController.changePrivacyMode(isPrivate)
         self.tabTrayController = tabTrayController
         tabManager.addTabAndSelect(request, isPrivate: isPrivate)
@@ -982,7 +982,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressTabs(urlBar: URLBarView) {
         self.webViewContainerToolbar.hidden = true
-        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile)
+        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, browserViewController: self)
 
         if let tab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(tab)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -12,6 +12,7 @@ import SnapKit
 import XCGLogger
 import Alamofire
 import Account
+import ReadingList
 
 private let log = Logger.browserLogger
 
@@ -736,6 +737,10 @@ class BrowserViewController: UIViewController {
             self.toolbar?.updateBookmarkStatus(true)
             self.urlBar.updateBookmarkStatus(true)
         }
+    }
+
+    func addToReadingList(url: String, title: String) -> ReadingListClientRecord? {
+        return profile.readingList?.createRecordWithURL(url, title: title, addedBy: UIDevice.currentDevice().name).successValue
     }
 
     private func animateBookmarkStar() {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -739,10 +739,6 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    func addToReadingList(url: String, title: String) -> ReadingListClientRecord? {
-        return profile.readingList?.createRecordWithURL(url, title: title, addedBy: UIDevice.currentDevice().name).successValue
-    }
-
     private func animateBookmarkStar() {
         let offset: CGFloat
         let button: UIButton!
@@ -911,7 +907,7 @@ class BrowserViewController: UIViewController {
         } else {
             request = nil
         }
-        let tabTrayController = self.tabTrayController ?? TabTrayController(tabManager: tabManager, profile: profile, browserViewController: self)
+        let tabTrayController = self.tabTrayController ?? TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
         tabTrayController.changePrivacyMode(isPrivate)
         self.tabTrayController = tabTrayController
         tabManager.addTabAndSelect(request, isPrivate: isPrivate)
@@ -987,7 +983,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressTabs(urlBar: URLBarView) {
         self.webViewContainerToolbar.hidden = true
-        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, browserViewController: self)
+        let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
 
         if let tab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(tab)
@@ -2411,6 +2407,38 @@ extension BrowserViewController: SessionRestoreHelperDelegate {
         if let tab = tabManager.selectedTab where tab.webView === browser.webView {
             updateUIForReaderHomeStateForTab(tab)
         }
+    }
+}
+
+extension BrowserViewController: TabTrayDelegate {
+    // This function animates and resets the browser chrome transforms when
+    // the tab tray dismisses.
+    func tabTrayDidDismiss(tabTray: TabTrayController) {
+        // animate and reset transform for browser chrome
+        urlBar.updateAlphaForSubviews(1)
+
+        [header,
+            footer,
+            readerModeBar,
+            footerBackdrop,
+            headerBackdrop].forEach { view in
+                view?.transform = CGAffineTransformIdentity
+        }
+    }
+
+    func addBookmark(tab: Browser) {
+        guard let url = tab.url?.absoluteString where url.characters.count > 0 else { return }
+        self.addBookmark(url, title: tab.title)
+    }
+
+
+    func addToReadingList(tab: Browser) -> ReadingListClientRecord? {
+        guard let url = tab.url?.absoluteString where url.characters.count > 0 else { return nil }
+        return profile.readingList?.createRecordWithURL(url, title: tab.title ?? url, addedBy: UIDevice.currentDevice().name).successValue
+    }
+
+    func present(viewController viewController: UIViewController) {
+        self.presentViewController(viewController, animated: false, completion: nil)
     }
 }
 

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -8,11 +8,11 @@ import Storage
 @available(iOS 9.0, *)
 class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
-    let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", comment: "")
-    let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", comment: "")
-    let PreviewActionSendToDevice = NSLocalizedString("Send to Device", comment: "")
-    let PreviewActionCopyURL = NSLocalizedString("Copy URL", comment: "")
-    let PreviewActionCloseTab = NSLocalizedString("Close Tab", comment: "")
+    let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
+    let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
+    let PreviewActionSendToDevice = NSLocalizedString("Send to Device", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+    let PreviewActionCopyURL = NSLocalizedString("Copy URL", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
+    let PreviewActionCloseTab = NSLocalizedString("Close Tab", comment: "Label for preview action on Tab Tray Tab to close the current tab")
 
     let tab: Browser
 
@@ -25,6 +25,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
     private var ignoreURL: Bool = false
 
     private var screenShot: UIImageView?
+    private var previewAccessibilityLabel: String!
 
     // Preview action items.
     lazy var previewActions: [UIPreviewActionItem] = {
@@ -74,6 +75,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        previewAccessibilityLabel = NSLocalizedString("Preview of \(tab.webView?.accessibilityLabel)", comment: "Accessibility Label for preview in Tab Tray of current tab")
         // if there is no screenshot, load the URL in a web page
         // otherwise just show the screenshot
         setupWebView(tab.webView)
@@ -90,13 +92,14 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         }
         
         screenShot = imageView
+        screenShot?.accessibilityLabel = previewAccessibilityLabel
     }
 
     private func setupWebView(webView: WKWebView?) {
         guard let webView = webView else { return }
         let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
         clonedWebView.allowsLinkPreview = false
-        webView.accessibilityLabel = NSLocalizedString("Preview of \(webView.accessibilityLabel)", comment: "")
+        webView.accessibilityLabel = previewAccessibilityLabel
         self.view.addSubview(clonedWebView)
 
         clonedWebView.snp_makeConstraints { make in

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -23,19 +23,34 @@ class TabPeekViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        if tab.webView == nil {
-            tab.createWebview()
-        }
-
-        guard let webView = tab.webView else {
-            print("Couldn't create web view!")
+        // if there is no screenshot, load the URL in a web page
+        // otherwise just show the screenshot
+        guard let screenshot = tab.screenshot else {
+            setupWebView(tab.url)
             return
         }
+        setupWithScreenshot(screenshot)
+    }
 
+    private func setupWithScreenshot(screenshot: UIImage) {
+        let imageView = UIImageView(image: screenshot)
+        self.view.addSubview(imageView)
+
+        imageView.snp_makeConstraints { make in
+            make.edges.equalTo(self.view)
+        }
+    }
+
+    private func setupWebView(url: NSURL?) {
+        let webView = WKWebView()
         self.view.addSubview(webView)
+
         webView.snp_makeConstraints { make in
             make.edges.equalTo(self.view)
+        }
+
+        if let url = url {
+            webView.loadRequest(NSURLRequest(URL: url))
         }
     }
 }

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -47,11 +47,15 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
                     self.delegate?.tabTrayRequestsPresentationOf(viewController: clientPicker)
                     })
             }
-            actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
-                guard let url = self.tab.url where url.absoluteString.characters.count > 0 else { return }
-                let pasteBoard = UIPasteboard.generalPasteboard()
-                pasteBoard.URL = url
-                })
+            // only add the copy URL action if we don't already have 3 items in our list
+            // as we are only allowed 4 in total and we always want to display close tab
+            if actions.count < 3 {
+                actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
+                    guard let url = self.tab.url where url.absoluteString.characters.count > 0 else { return }
+                    let pasteBoard = UIPasteboard.generalPasteboard()
+                    pasteBoard.URL = url
+                    })
+            }
         }
         actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCloseTab, style: .Destructive) { previewAction, viewController in
             guard let tabViewController = viewController as? TabPeekViewController else { return }

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
 import Storage
@@ -16,7 +16,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
     let tab: Browser
 
-    private let delegate: TabTrayDelegate?
+    private weak var delegate: TabTrayDelegate?
     private let tabManager: TabManager
     private var clientPicker: UINavigationController?
     private var isBookmarked: Bool = false
@@ -33,18 +33,18 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         if(!self.ignoreURL) {
             if !self.isInReadingList {
                 actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionAddToReadingList, style: .Default) { previewAction, viewController in
-                    self.delegate?.addToReadingList(self.tab)
+                    self.delegate?.tabTrayDidAddToReadingList(self.tab)
                 })
             }
             if !self.isBookmarked {
                 actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionAddToBookmarks, style: .Default) { previewAction, viewController in
-                    self.delegate?.addBookmark(self.tab)
+                    self.delegate?.tabTrayDidAddBookmark(self.tab)
                     })
             }
             if self.hasRemoteClients {
                 actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionSendToDevice, style: .Default) { previewAction, viewController in
                     guard let clientPicker = self.clientPicker else { return }
-                    self.delegate?.present(viewController: clientPicker)
+                    self.delegate?.tabTrayRequestsPresentationOf(viewController: clientPicker)
                     })
             }
             actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCopyURL, style: .Default) { previewAction, viewController in

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -100,7 +100,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
     }
 
     private func setupWebView(webView: WKWebView?) {
-        guard let webView = webView else { return }
+        guard let webView = webView, let url = webView.URL where !isIgnoredURL(url) else { return }
         let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
         clonedWebView.allowsLinkPreview = false
         webView.accessibilityLabel = previewAccessibilityLabel
@@ -112,9 +112,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
         clonedWebView.navigationDelegate = self
 
-        if let url = webView.URL {
-            clonedWebView.loadRequest(NSURLRequest(URL: url))
-        }
+        clonedWebView.loadRequest(NSURLRequest(URL: url))
     }
 
     func setState(withProfile browserProfile: BrowserProfile, clientPickerDelegate: ClientPickerViewControllerDelegate) {

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -8,11 +8,11 @@ import Storage
 @available(iOS 9.0, *)
 class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
-    private static let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
-    private static let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
-    private static let PreviewActionSendToDevice = NSLocalizedString("Send to Device", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
-    private static let PreviewActionCopyURL = NSLocalizedString("Copy URL", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
-    private static let PreviewActionCloseTab = NSLocalizedString("Close Tab", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to close the current tab")
+    private static let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
+    private static let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
+    private static let PreviewActionSendToDevice = NSLocalizedString("Send to Device", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+    private static let PreviewActionCopyURL = NSLocalizedString("Copy URL", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
+    private static let PreviewActionCloseTab = NSLocalizedString("Close Tab", tableName: "3DTouchActions", comment: "Label for preview action on Tab Tray Tab to close the current tab")
 
     let tab: Browser
 
@@ -75,7 +75,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        previewAccessibilityLabel = NSLocalizedString("Preview of \(tab.webView?.accessibilityLabel)", tableName: "3D Touch Actions", comment: "Accessibility Label for preview in Tab Tray of current tab")
+        previewAccessibilityLabel = NSLocalizedString("Preview of \(tab.webView?.accessibilityLabel)", tableName: "3DTouchActions", comment: "Accessibility Label for preview in Tab Tray of current tab")
         // if there is no screenshot, load the URL in a web page
         // otherwise just show the screenshot
         setupWebView(tab.webView)

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -134,7 +134,9 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
             }
         }
 
-        isInReadingList = browserProfile.readingList?.getRecordWithURL(displayURL).successValue != nil
+        let result = browserProfile.readingList?.getRecordWithURL(displayURL).successValue!
+        isInReadingList = (result?.url.characters.count > 0) ?? false
+
         ignoreURL = isIgnoredURL(displayURL)
     }
 

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -7,13 +7,65 @@
 //
 
 import UIKit
+import Storage
 
+@available(iOS 9.0, *)
 class TabPeekViewController: UIViewController {
 
-    let tab: Browser
+    let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", comment: "")
+    let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", comment: "")
+    let PreviewActionSendToDevice = NSLocalizedString("Send to Device", comment: "")
+    let PreviewActionCopyURL = NSLocalizedString("Copy URL", comment: "")
+    let PreviewActionCloseTab = NSLocalizedString("Close Tab", comment: "")
 
-    init(tab: Browser) {
+    let tab: Browser
+    let bvc: BrowserViewController?
+    let tabManager: TabManager
+    var clientPicker: UINavigationController?
+    var isBookmarked: Bool = false
+    var isInReadingList: Bool = false
+    var hasRemoteClients: Bool = false
+
+    // Preview action items.
+    lazy var previewActions: [UIPreviewActionItem] = {
+        var actions = [UIPreviewActionItem]()
+        if !self.isInReadingList {
+            actions.append(UIPreviewAction(title: self.PreviewActionAddToReadingList, style: .Default) { previewAction, viewController in
+                guard let displayURL = self.tab.url?.absoluteString where displayURL.characters.count > 0 else { return }
+                self.bvc?.addToReadingList(displayURL, title: self.tab.lastTitle ?? displayURL)
+            })
+        }
+        if !self.isBookmarked {
+            actions.append(UIPreviewAction(title: self.PreviewActionAddToBookmarks, style: .Default) { previewAction, viewController in
+                guard let displayURL = self.tab.url?.absoluteString where displayURL.characters.count > 0 else { return }
+
+                self.bvc?.addBookmark(displayURL, title: self.tab.lastTitle ?? displayURL)
+                })
+        }
+        if self.hasRemoteClients {
+            actions.append(UIPreviewAction(title: self.PreviewActionSendToDevice, style: .Default) { previewAction, viewController in
+                guard let clientPicker = self.clientPicker else { return }
+                self.bvc?.presentViewController(clientPicker, animated: false, completion: nil)
+                })
+        }
+        actions.append(UIPreviewAction(title: self.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
+            guard let url = self.tab.url where url.absoluteString.characters.count > 0 else { return }
+            let pasteBoard = UIPasteboard.generalPasteboard()
+            pasteBoard.URL = url
+            })
+        actions.append(UIPreviewAction(title: self.PreviewActionCloseTab, style: .Destructive) { previewAction, viewController in
+            guard let tabViewController = viewController as? TabPeekViewController else { return }
+            self.tabManager.removeTab(self.tab)
+            })
+
+        return actions
+    }()
+
+
+    init(tab: Browser, controller: BrowserViewController?, tabManager: TabManager) {
         self.tab = tab
+        self.bvc = controller
+        self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -52,5 +104,29 @@ class TabPeekViewController: UIViewController {
         if let url = url {
             webView.loadRequest(NSURLRequest(URL: url))
         }
+    }
+
+    func setState(withProfile browserProfile: BrowserProfile, clientPickerDelegate: ClientPickerViewControllerDelegate) {
+        guard let displayURL = tab.url?.absoluteString where displayURL.characters.count > 0 else { return }
+
+        browserProfile.bookmarks.isBookmarked(displayURL).upon {
+            self.isBookmarked = $0.successValue ?? false
+        }
+
+        browserProfile.remoteClientsAndTabs.getClientGUIDs().upon {
+            if let clientGUIDs = $0.successValue {
+                self.hasRemoteClients = !clientGUIDs.isEmpty
+                let clientPickerController = ClientPickerViewController()
+                clientPickerController.clientPickerDelegate = clientPickerDelegate
+                clientPickerController.profile = browserProfile
+                if let url = self.tab.url?.absoluteString {
+                    clientPickerController.shareItem = ShareItem(url: url, title: self.tab.title, favicon: nil)
+                }
+
+                self.clientPicker = UINavigationController(rootViewController: clientPickerController)
+            }
+        }
+
+        isInReadingList = browserProfile.readingList?.getRecordWithURL(displayURL).successValue != nil
     }
 }

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -8,11 +8,11 @@ import Storage
 @available(iOS 9.0, *)
 class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
-    let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
-    let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
-    let PreviewActionSendToDevice = NSLocalizedString("Send to Device", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
-    let PreviewActionCopyURL = NSLocalizedString("Copy URL", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
-    let PreviewActionCloseTab = NSLocalizedString("Close Tab", comment: "Label for preview action on Tab Tray Tab to close the current tab")
+    private static let PreviewActionAddToBookmarks = NSLocalizedString("Add to Bookmarks", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to add current tab to Bookmarks")
+    private static let PreviewActionAddToReadingList = NSLocalizedString("Add to Reading List", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to add current tab to Reading List")
+    private static let PreviewActionSendToDevice = NSLocalizedString("Send to Device", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to send the current tab to another device")
+    private static let PreviewActionCopyURL = NSLocalizedString("Copy URL", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to copy the URL of the current tab to clipboard")
+    private static let PreviewActionCloseTab = NSLocalizedString("Close Tab", tableName: "3D Touch Actions", comment: "Label for preview action on Tab Tray Tab to close the current tab")
 
     let tab: Browser
 
@@ -32,28 +32,28 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         var actions = [UIPreviewActionItem]()
         if(!self.ignoreURL) {
             if !self.isInReadingList {
-                actions.append(UIPreviewAction(title: self.PreviewActionAddToReadingList, style: .Default) { previewAction, viewController in
+                actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionAddToReadingList, style: .Default) { previewAction, viewController in
                     self.delegate?.addToReadingList(self.tab)
                 })
             }
             if !self.isBookmarked {
-                actions.append(UIPreviewAction(title: self.PreviewActionAddToBookmarks, style: .Default) { previewAction, viewController in
+                actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionAddToBookmarks, style: .Default) { previewAction, viewController in
                     self.delegate?.addBookmark(self.tab)
                     })
             }
             if self.hasRemoteClients {
-                actions.append(UIPreviewAction(title: self.PreviewActionSendToDevice, style: .Default) { previewAction, viewController in
+                actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionSendToDevice, style: .Default) { previewAction, viewController in
                     guard let clientPicker = self.clientPicker else { return }
                     self.delegate?.present(viewController: clientPicker)
                     })
             }
-            actions.append(UIPreviewAction(title: self.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
+            actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
                 guard let url = self.tab.url where url.absoluteString.characters.count > 0 else { return }
                 let pasteBoard = UIPasteboard.generalPasteboard()
                 pasteBoard.URL = url
                 })
         }
-        actions.append(UIPreviewAction(title: self.PreviewActionCloseTab, style: .Destructive) { previewAction, viewController in
+        actions.append(UIPreviewAction(title: TabPeekViewController.PreviewActionCloseTab, style: .Destructive) { previewAction, viewController in
             guard let tabViewController = viewController as? TabPeekViewController else { return }
             self.tabManager.removeTab(self.tab)
             })
@@ -75,7 +75,7 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        previewAccessibilityLabel = NSLocalizedString("Preview of \(tab.webView?.accessibilityLabel)", comment: "Accessibility Label for preview in Tab Tray of current tab")
+        previewAccessibilityLabel = NSLocalizedString("Preview of \(tab.webView?.accessibilityLabel)", tableName: "3D Touch Actions", comment: "Accessibility Label for preview in Tab Tray of current tab")
         // if there is no screenshot, load the URL in a web page
         // otherwise just show the screenshot
         setupWebView(tab.webView)

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -1,0 +1,41 @@
+//
+//  TabViewController.swift
+//  Client
+//
+//  Created by Emily Toop on 12/2/15.
+//  Copyright © 2015 Mozilla. All rights reserved.
+//
+
+import UIKit
+
+class TabPeekViewController: UIViewController {
+
+    let tab: Browser
+
+    init(tab: Browser) {
+        self.tab = tab
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if tab.webView == nil {
+            tab.createWebview()
+        }
+
+        guard let webView = tab.webView else {
+            print("Couldn't create web view!")
+            return
+        }
+
+        self.view.addSubview(webView)
+        webView.snp_makeConstraints { make in
+            make.edges.equalTo(self.view)
+        }
+    }
+}

--- a/Client/Frontend/Browser/TabPeekViewController.swift
+++ b/Client/Frontend/Browser/TabPeekViewController.swift
@@ -15,7 +15,8 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
     let PreviewActionCloseTab = NSLocalizedString("Close Tab", comment: "")
 
     let tab: Browser
-    private let bvc: BrowserViewController?
+
+    private let delegate: TabTrayDelegate?
     private let tabManager: TabManager
     private var clientPicker: UINavigationController?
     private var isBookmarked: Bool = false
@@ -31,21 +32,18 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
         if(!self.ignoreURL) {
             if !self.isInReadingList {
                 actions.append(UIPreviewAction(title: self.PreviewActionAddToReadingList, style: .Default) { previewAction, viewController in
-                    guard let displayURL = self.tab.url?.absoluteString where displayURL.characters.count > 0 else { return }
-                    self.bvc?.addToReadingList(displayURL, title: self.tab.lastTitle ?? displayURL)
+                    self.delegate?.addToReadingList(self.tab)
                 })
             }
             if !self.isBookmarked {
                 actions.append(UIPreviewAction(title: self.PreviewActionAddToBookmarks, style: .Default) { previewAction, viewController in
-                    guard let displayURL = self.tab.url?.absoluteString where displayURL.characters.count > 0 else { return }
-
-                    self.bvc?.addBookmark(displayURL, title: self.tab.lastTitle ?? displayURL)
+                    self.delegate?.addBookmark(self.tab)
                     })
             }
             if self.hasRemoteClients {
                 actions.append(UIPreviewAction(title: self.PreviewActionSendToDevice, style: .Default) { previewAction, viewController in
                     guard let clientPicker = self.clientPicker else { return }
-                    self.bvc?.presentViewController(clientPicker, animated: false, completion: nil)
+                    self.delegate?.present(viewController: clientPicker)
                     })
             }
             actions.append(UIPreviewAction(title: self.PreviewActionCopyURL, style: .Default) { previewAction, viewController in
@@ -63,9 +61,9 @@ class TabPeekViewController: UIViewController, WKNavigationDelegate {
     }()
 
 
-    init(tab: Browser, controller: BrowserViewController?, tabManager: TabManager) {
+    init(tab: Browser, delegate: TabTrayDelegate?, tabManager: TabManager) {
         self.tab = tab
-        self.bvc = controller
+        self.delegate = delegate
         self.tabManager = tabManager
         super.init(nibName: nil, bundle: nil)
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -301,6 +301,16 @@ class TabTrayController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.tabManager.removeDelegate(self)
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        tabManager.addDelegate(self)
+    }
+
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillEnterForegroundNotification, object: nil)
@@ -318,7 +328,6 @@ class TabTrayController: UIViewController {
         super.viewDidLoad()
 
         view.accessibilityLabel = NSLocalizedString("Tabs Tray", comment: "Accessibility label for the Tabs Tray view.")
-        tabManager.addDelegate(self)
 
         navBar = UIView()
         navBar.backgroundColor = TabTrayControllerUX.BackgroundColor
@@ -681,7 +690,11 @@ extension TabTrayController: TabCellDelegate {
 
 private class TabManagerDataSource: NSObject, UICollectionViewDataSource {
     unowned var cellDelegate: protocol<TabCellDelegate, SwipeAnimatorDelegate>
-    private var tabs: [Browser]
+    private var tabs: [Browser] {
+        didSet {
+            tabs.forEach { print("Tab \($0.url)) isPrivate: \($0.isPrivate)") }
+        }
+    }
 
     init(tabs: [Browser], cellDelegate: protocol<TabCellDelegate, SwipeAnimatorDelegate>) {
         self.cellDelegate = cellDelegate

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -367,7 +367,7 @@ class TabTrayController: UIViewController {
                 privateMode = true
             }
 
-            // register for previewing delegvate to enable peek and pop if force touch feature available
+            // register for previewing delegate to enable peek and pop if force touch feature available
             if traitCollection.forceTouchCapability == .Available {
                 registerForPreviewingWithDelegate(self, sourceView: view)
             }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -225,17 +225,17 @@ struct PrivateModeStrings {
     static let toggleAccessibilityValueOff = NSLocalizedString("Off", tableName: "PrivateBrowsing", comment: "Toggled OFF accessibility value")
 }
 
-protocol TabTrayDelegate {
+protocol TabTrayDelegate: class {
     func tabTrayDidDismiss(tabTray: TabTrayController)
-    func addBookmark(tab: Browser)
-    func addToReadingList(tab: Browser) -> ReadingListClientRecord?
-    func present(viewController viewController: UIViewController)
+    func tabTrayDidAddBookmark(tab: Browser)
+    func tabTrayDidAddToReadingList(tab: Browser) -> ReadingListClientRecord?
+    func tabTrayRequestsPresentationOf(viewController viewController: UIViewController)
 }
 
 class TabTrayController: UIViewController {
     let tabManager: TabManager
     let profile: Profile
-    var delegate: TabTrayDelegate?
+    weak var delegate: TabTrayDelegate?
 
     var collectionView: UICollectionView!
     var navBar: UIView!

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -5,6 +5,7 @@
 import Foundation
 import UIKit
 import SnapKit
+import Storage
 
 struct TabTrayControllerUX {
     static let CornerRadius = CGFloat(4.0)
@@ -922,7 +923,10 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
             let cell = collectionView.cellForItemAtIndexPath(indexPath) else { return nil }
 
         let tab = tabDataSource.tabs[indexPath.row]
-        let tabVC = TabPeekViewController(tab: tab)
+        let tabVC = TabPeekViewController(tab: tab, controller: browserViewController, tabManager: tabManager)
+        if let browserProfile = profile as? BrowserProfile {
+            tabVC.setState(withProfile: browserProfile, clientPickerDelegate: self)
+        }
         previewingContext.sourceRect = cell.frame
 
         return tabVC
@@ -941,5 +945,19 @@ extension TabTrayController: UIViewControllerPreviewingDelegate {
             browserViewController?.headerBackdrop].forEach { view in
             view?.transform = CGAffineTransformIdentity
         }
+    }
+}
+
+extension TabTrayController: ClientPickerViewControllerDelegate {
+
+    func clientPickerViewController(clientPickerViewController: ClientPickerViewController, didPickClients clients: [RemoteClient]) {
+        if let item = clientPickerViewController.shareItem {
+            self.profile.sendItems([item], toClients: clients)
+        }
+        clientPickerViewController.dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    func clientPickerViewControllerDidCancel(clientPickerViewController: ClientPickerViewController) {
+        clientPickerViewController.dismissViewControllerAnimated(true, completion: nil)
     }
 }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -351,6 +351,11 @@ class TabTrayController: UIViewController {
             if let tab = tabManager.selectedTab where tab.isPrivate {
                 privateMode = true
             }
+
+            // register for previewing delegvate to enable peek and pop if force touch feature available
+            if traitCollection.forceTouchCapability == .Available {
+                registerForPreviewingWithDelegate(self, sourceView: view)
+            }
         }
 
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappWillResignActiveNotification", name: UIApplicationWillResignActiveNotification, object: nil)
@@ -896,5 +901,23 @@ private class EmptyPrivateTabsView: UIView {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@available(iOS 9.0, *)
+extension TabTrayController: UIViewControllerPreviewingDelegate {
+
+    func previewingContext(previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        guard let indexPath = collectionView?.indexPathForItemAtPoint(location),
+            cell = collectionView?.cellForItemAtIndexPath(indexPath) else { return nil }
+
+        let tab = tabDataSource.tabs[indexPath.row]
+        let tabVC = TabPeekViewController(tab: tab)
+        previewingContext.sourceRect = cell.frame
+
+        return tabVC
+    }
+
+    func previewingContext(previewingContext: UIViewControllerPreviewing, commitViewController viewControllerToCommit: UIViewController) {
     }
 }

--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -36,6 +36,10 @@ class ClientPickerViewController: UITableViewController {
     var reloading = true
     var clients: [RemoteClient] = []
     var selectedClients = NSMutableSet()
+
+    // ShareItem has been added as we are now using this class outside of the ShareTo extension to provide Share To functionality
+    // And in this case we need to be able to store the item we are sharing as we may not have access to the 
+    // url later. Currently used only when sharing an item from the Tab Tray from a Preview Action.
     var shareItem: ShareItem?
 
     override func viewDidLoad() {

--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -36,6 +36,7 @@ class ClientPickerViewController: UITableViewController {
     var reloading = true
     var clients: [RemoteClient] = []
     var selectedClients = NSMutableSet()
+    var shareItem: ShareItem?
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1227112

* Add peek and pop to tabs in tab tray
* Add peek actions
* Move client picker into main Client rather than Sent To extension so it can be used to send tabs to other devices from peek actions