### PR TITLE
Bug 1233418 - Added strings needed for login manager

### DIFF
--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -100,6 +100,25 @@ private struct TempStrings {
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
     let accessLogins            = NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")
+
+    // Bug 1233418 - Login Manager Strings
+    let loginsListTitle                 = NSLocalizedString("Logins", tableName: "LoginManager", comment: "Title for Logins List View screen")
+    let loginSearchFieldTitle           = NSLocalizedString("Search", tableName: "LoginManager", comment: "Title for the search field at the top of the Logins list screen")
+    let clearSearchAccessibilityLabel   = NSLocalizedString("Clear Search", tableName: "LoginManager", comment: "Clears the search input field and exits out of input mode")
+    let searchOverlayAccessibilityLabel = NSLocalizedString("Enter Search Mode", tableName: "LoginManager", comment: "Accessibility label for entering search mode for logins")
+    let detailUsernameRowTitle          = NSLocalizedString("username", tableName: "LoginManager", comment: "Title for username row in Login Detail View")
+    let detailPasswordRowTitle          = NSLocalizedString("password", tableName: "LoginManager", comment: "Title for password row in Login Detail View")
+    let detailWebsiteRowTitle           = NSLocalizedString("website", tableName: "LoginManager", comment: "Title for website row in Login Detail View")
+    let deleteLoginDetail               = NSLocalizedString("Delete", tableName: "LoginManager", comment: "Button in login detail screen that deletes the current login")
+    let lastLoginModified               = NSLocalizedString("Last modified %@", tableName: "LoginManager", comment: "Footer label describing when the login was last modified with the timestamp as the parameter")
+    let revealPassword                  = NSLocalizedString("Reveal", tableName: "LoginManager", comment: "Reveal password text selection menu item")
+    let openAndFill                     = NSLocalizedString("Open & Fill", tableName: "LoginManager", comment: "Open and Fill website text selection menu item")
+    let deselectAll                     = NSLocalizedString("Deselect All", tableName: "LoginManager", comment: "Title for deselecting all selected logins")
+    let selectAll                       = NSLocalizedString("Select All", tableName: "LoginManager", comment: "Title for selecting all logins")
+    let areYouSure                      = NSLocalizedString("Are you sure?", tableName: "LoginManager", comment: "Prompt title when deleting logins")
+    let deleteLocal                     = NSLocalizedString("Logins will be permanently removed.", tableName: "LoginManager", comment: "Prompt message warning the user that deleting non-synced logins will permanently remove them")
+    let deleteSyncedDevices             = NSLocalizedString("Logins will be removed from all connected devices.", tableName: "LoginManager", comment: "Prompt message warning the user that deleted logins will remove logins from all connected devices")
+    let noLoginsFound                   = NSLocalizedString("No logins found", tableName: "LoginManager", comment: "Title displayed when no logins are found after searching")
 }
 
 /// Old strings that will be removed when we kill 1.0. We need to keep them around for now for l10n export.


### PR DESCRIPTION
* Adds strings for the login manager
* Includes "No Results Found" string to display when no search results appear
* Added 'Deleted logins will be removed from all your connected devices.' message to mirror similar messaging from Bug 1233281.
* All login manager strings are part of the LoginManager table