### PR TITLE
Bug 1234835 - (WIP) WebViewPanel Prototyping

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		E69BEA5E1BC6A7F300EA6D04 /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEA371BC6A79B00EA6D04 /* ArrayExtensions.swift */; };
 		E6A118F31C32DE98008989E8 /* SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A118F21C32DE98008989E8 /* SettingsTests.swift */; };
 		E6B8963A1C3C1A9500D9B05B /* topdomains.txt in Resources */ = {isa = PBXBuildFile; fileRef = E6B896391C3C1A9500D9B05B /* topdomains.txt */; };
+		E6BF499F1C23676300E2D6C4 /* WebViewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF499E1C23676300E2D6C4 /* WebViewPanel.swift */; };
 		E6C05DB21BA1CDAB00CDDD08 /* Breakpad.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E69E4E2A1B9F709A00646EDB /* Breakpad.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E6D749011C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */; };
 		E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */; };
@@ -1818,6 +1819,7 @@
 		E6A99D761B20D95800006EDD /* GeometryExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryExtensions.swift; sourceTree = "<group>"; };
 		E6B896391C3C1A9500D9B05B /* topdomains.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = topdomains.txt; sourceTree = "<group>"; };
 		E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLProtectionSpaceExtensions.swift; sourceTree = "<group>"; };
+		E6BF499E1C23676300E2D6C4 /* WebViewPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewPanel.swift; sourceTree = "<group>"; };
 		E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserTrayAnimators.swift; sourceTree = "<group>"; };
 		E6E4A9621BF0FA85008162D5 /* NSFileManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSFileManagerExtensions.swift; sourceTree = "<group>"; };
 		E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = scrollablePage.html; sourceTree = "<group>"; };
@@ -3326,6 +3328,7 @@
 				0BF648101A9C54E900BA963C /* TopSitesPanel.swift */,
 				59A685F4EAD19EDEC854BCA4 /* ReaderPanel.swift */,
 				2FDE87FD1ABB3817005317B1 /* RemoteTabsPanel.swift */,
+				E6BF499E1C23676300E2D6C4 /* WebViewPanel.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -4824,6 +4827,7 @@
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
+				E6BF499F1C23676300E2D6C4 /* WebViewPanel.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				7B0B1B9D1C1B6A3F00DF4AB5 /* InstructionsViewController.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,

--- a/Client/Application/DebugSettingsBundleOptions.swift
+++ b/Client/Application/DebugSettingsBundleOptions.swift
@@ -32,4 +32,9 @@ struct DebugSettingsBundleOptions {
     static var attachLogsToDebugEmail: Bool {
         return NSUserDefaults.standardUserDefaults().boolForKey("SettingsBundleEmailLogsOnLaunch") ?? false
     }
+
+    /// When set, Top Sites is replaced with a web view panel.
+    static var webPanelURL: String? {
+        return NSUserDefaults.standardUserDefaults().stringForKey("WebPanelURL")
+    }
 }

--- a/Client/Application/Settings.bundle/Root.plist
+++ b/Client/Application/Settings.bundle/Root.plist
@@ -8,6 +8,14 @@
 	<array>
 		<dict>
 			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Web Panel URL</string>
+			<key>Key</key>
+			<string>WebPanelURL</string>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>Debug Settings</string>

--- a/Client/Assets/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Client/Assets/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -115,6 +115,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
       "size" : "24x24",
       "idiom" : "watch",
       "scale" : "2x",

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -98,7 +98,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
             make.left.right.bottom.equalTo(self.view)
         }
 
-        self.panels = HomePanels().enabledPanels
+        self.panels = HomePanels.enabledPanels
         updateButtons()
 
         // Gesture recognizer to dismiss the keyboard in the URLBarView when the buttonContainerView is tapped

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -22,7 +22,7 @@ class HomePanels {
             panels.append(
                 HomePanelDescriptor(
                     makeViewController: { (profile) -> UIViewController in
-                        WebViewPanel(url: url)
+                        WebViewPanel(profile: profile, url: url)
                     },
                     imageName: "TopSites",
                     accessibilityLabel: "Web Panel"

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -15,55 +15,76 @@ struct HomePanelDescriptor {
 }
 
 class HomePanels {
-    let enabledPanels = [
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                TopSitesPanel(profile: profile)
-            },
-            imageName: "TopSites",
-            accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label")),
+    static var enabledPanels: [HomePanelDescriptor] {
+        var panels = [HomePanelDescriptor]()
 
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let bookmarks = BookmarksPanel()
-                bookmarks.profile = profile
-                let controller = UINavigationController(rootViewController: bookmarks)
-                controller.setNavigationBarHidden(true, animated: false)
-                // this re-enables the native swipe to pop gesture on UINavigationController for embedded, navigation bar-less UINavigationControllers
-                // don't ask me why it works though, I've tried to find an answer but can't.
-                // found here, along with many other places: 
-                // http://luugiathuy.com/2013/11/ios7-interactivepopgesturerecognizer-for-uinavigationcontroller-with-hidden-navigation-bar/
-                controller.interactivePopGestureRecognizer?.delegate = nil
-                return controller
-            },
-            imageName: "Bookmarks",
-            accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label")),
+        if let url = DebugSettingsBundleOptions.webPanelURL where url != "" {
+            panels.append(
+                HomePanelDescriptor(
+                    makeViewController: { (profile) -> UIViewController in
+                        UIViewController()
+                    },
+                    imageName: "TopSites",
+                    accessibilityLabel: "Web Panel"
+                )
+            )
+        } else {
+            panels.append(
+                HomePanelDescriptor(
+                    makeViewController: { profile in
+                        TopSitesPanel(profile: profile)
+                    },
+                    imageName: "TopSites",
+                    accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label")
+                )
+            )
+        }
 
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = HistoryPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "History",
-            accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label")),
+        panels += [
+            HomePanelDescriptor(
+                makeViewController: { profile in
+                    let bookmarks = BookmarksPanel()
+                    bookmarks.profile = profile
+                    let controller = UINavigationController(rootViewController: bookmarks)
+                    controller.setNavigationBarHidden(true, animated: false)
+                    // this re-enables the native swipe to pop gesture on UINavigationController for embedded, navigation bar-less UINavigationControllers
+                    // don't ask me why it works though, I've tried to find an answer but can't.
+                    // found here, along with many other places: 
+                    // http://luugiathuy.com/2013/11/ios7-interactivepopgesturerecognizer-for-uinavigationcontroller-with-hidden-navigation-bar/
+                    controller.interactivePopGestureRecognizer?.delegate = nil
+                    return controller
+                },
+                imageName: "Bookmarks",
+                accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label")),
 
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = RemoteTabsPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "SyncedTabs",
-            accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label")),
+            HomePanelDescriptor(
+                makeViewController: { profile in
+                    let controller = HistoryPanel()
+                    controller.profile = profile
+                    return controller
+                },
+                imageName: "History",
+                accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label")),
 
-        HomePanelDescriptor(
-            makeViewController: { profile in
-                let controller = ReadingListPanel()
-                controller.profile = profile
-                return controller
-            },
-            imageName: "ReadingList",
-            accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label")),
-    ]
+            HomePanelDescriptor(
+                makeViewController: { profile in
+                    let controller = RemoteTabsPanel()
+                    controller.profile = profile
+                    return controller
+                },
+                imageName: "SyncedTabs",
+                accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label")),
+
+            HomePanelDescriptor(
+                makeViewController: { profile in
+                    let controller = ReadingListPanel()
+                    controller.profile = profile
+                    return controller
+                },
+                imageName: "ReadingList",
+                accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label")),
+        ]
+
+        return panels
+    }
 }

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -22,7 +22,7 @@ class HomePanels {
             panels.append(
                 HomePanelDescriptor(
                     makeViewController: { (profile) -> UIViewController in
-                        UIViewController()
+                        WebViewPanel(url: url)
                     },
                     imageName: "TopSites",
                     accessibilityLabel: "Web Panel"

--- a/Client/Frontend/Home/WebViewPanel.swift
+++ b/Client/Frontend/Home/WebViewPanel.swift
@@ -44,13 +44,16 @@ private enum DataMethod: String {
     case getTopSites                = "getTopSites"
 
     /* 
-    getClientsAndTabs
+    getLocalBookmarks
         {
-            method: "getClientsAndTabs",
+            method: "getLocalBookmarks",
+            params: {
+                limit: <Int>
+            },
             callback: <CallbackFunc>
         }
     */
-    case getClientsAndTabs          = "getClientsAndTabs"
+    case getLocalBookmarks          = "getLocalBookmarks"
     case Undefined
 }
 
@@ -185,6 +188,7 @@ class WebViewPanel: UIViewController, HomePanel {
                 self.webView.evaluateJavaScript(callbackInvocation, completionHandler: nil)
             }
         }
+
         return webView
     }()
 

--- a/Client/Frontend/Home/WebViewPanel.swift
+++ b/Client/Frontend/Home/WebViewPanel.swift
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import SnapKit
+
+class WebViewPanel: UIViewController, HomePanel {
+
+    weak var homePanelDelegate: HomePanelDelegate?
+
+    private let url: NSURL
+
+    private lazy var webView: WKWebView = {
+        return WKWebView()
+    }()
+
+    init(url: String) {
+        self.url = url.asURL!
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(webView)
+        webView.snp_makeConstraints { make in
+            make.edges.equalTo(view)
+        }
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+
+        let request = NSURLRequest(URL: url)
+        webView.loadRequest(request)
+    }
+}

--- a/Client/Frontend/Home/WebViewPanel.swift
+++ b/Client/Frontend/Home/WebViewPanel.swift
@@ -4,18 +4,182 @@
 
 import UIKit
 import SnapKit
+import WebKit
+import Storage
+
+/**
+ Data API accessibile to pages inside a WebViewPanel
+
+ - GetBookmarkModelForID: Returns the bookmark model for the given GUID
+ - GetRootBookmarkFolder: Returns the root bookmark model
+ - getSitesByLastVisit:   Returns history items ordered by last visit
+ - getTopSites:           Returns top sites ordered by frecency limited to the given limit
+ - getClientsAndTabs:     Returns all cached remote clients and tabs
+ - Undefined:             Default case for any message not recognized
+ */
+private enum DataMethod: String {
+
+    /*
+    GetBookmarkModelForID
+        {
+            method: "getBookmarkModelForID",
+            params: {
+                id: <String>
+            },
+            callback: <CallbackFunc>
+        }
+    */
+    case GetBookmarkModelForID      = "getBookmarkModelForID"
+
+    /* 
+    GetRootBookmarkFolder
+        {
+            method: "getBookmarkModelForID",
+            callback: <CallbackFunc>
+        }
+    */
+    case GetRootBookmarkFolder      = "getRootBookmarkFolder"
+
+    /* 
+    getSitesByLastVisit
+        {
+            method: "getSitesByLastVisit",
+            params: {
+                limit: <Int>
+            },
+            callback: <CallbackFunc>
+        }
+    */
+    case getSitesByLastVisit        = "getSitesByLastVisit"
+
+    /* 
+    getTopSites
+        {
+            method: "getTopSites",
+            params: {
+                limit: <Int>
+            },
+            callback: <CallbackFunc>
+        }
+    */
+    case getTopSites                = "getTopSites"
+
+    /* 
+    getClientsAndTabs
+        {
+            method: "getClientsAndTabs",
+            callback: <CallbackFunc>
+        }
+    */
+    case getClientsAndTabs          = "getClientsAndTabs"
+    case Undefined
+}
+
+private class WebPanelDataAPI: NSObject, WKScriptMessageHandler {
+    typealias DataAPIHandler = (params: [String: AnyObject], callback: String?) -> Void
+
+    unowned let profile: Profile
+
+    unowned let webView: WKWebView
+
+    private var handlers = [DataMethod: DataAPIHandler]()
+
+    init(webView: WKWebView, profile: Profile) {
+        self.webView = webView
+        self.profile = profile
+        super.init()
+    }
+
+    func registerHandlerForMethod(method: DataMethod, handler: DataAPIHandler) {
+        handlers[method] = handler
+    }
+
+    @objc func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        guard let messageDict = message.body as? [String: AnyObject],
+              let methodName = messageDict["method"] as? String,
+        let params = messageDict["params"] as? [String: AnyObject] else {
+            return
+        }
+
+        let callback = messageDict["callback"] as? String
+        let method = DataMethod(rawValue: methodName) ?? .Undefined
+        handlers[method]?(params: params, callback: callback)
+    }
+}
+
+// MARK: DictionaryView extension for data models
+
+protocol DictionaryView {
+    func toDictionary() -> [String: AnyObject]
+}
+
+extension BookmarksModel: DictionaryView {
+    func toDictionary() -> [String: AnyObject] {
+        return [String: String]()
+    }
+}
+
+extension Site: DictionaryView {
+    func toDictionary() -> [String: AnyObject] {
+        return [
+            "title": title,
+            "url": url
+        ]
+    }
+}
+
+extension RemoteTab: DictionaryView {
+    func toDictionary() -> [String: AnyObject] {
+        return [String: String]()
+    }
+}
 
 class WebViewPanel: UIViewController, HomePanel {
 
     weak var homePanelDelegate: HomePanelDelegate?
 
     private let url: NSURL
+    private let profile: Profile
 
     private lazy var webView: WKWebView = {
-        return WKWebView()
+        let webView = WKWebView()
+        let dataAPI = WebPanelDataAPI(webView: webView, profile: self.profile)
+        webView.configuration.userContentController.addScriptMessageHandler(dataAPI, name: "mozAPI")
+
+        dataAPI.registerHandlerForMethod(DataMethod.getSitesByLastVisit) { params, callback in
+            guard let limit = params["limit"] as? Int,
+                  let callback = callback else {
+                return
+            }
+
+            self.profile.history.getSitesByLastVisit(limit).uponQueue(dispatch_get_main_queue()) { result in
+                let callbackInvocation: String
+                do {
+                    if let sites = result.successValue {
+                        let data: [NSDictionary] = sites.map { $0!.toDictionary() }
+                        let jsonData = try NSJSONSerialization.dataWithJSONObject(data, options: [])
+                        let jsonString = String(data: jsonData, encoding: NSUTF8StringEncoding)!
+                        callbackInvocation = "\(callback)(null, \(jsonString))"
+                    } else {
+                        var err = [String: AnyObject]()
+                        err["message"] = result.failureValue?.description ?? "No description"
+                        let jsonData = try NSJSONSerialization.dataWithJSONObject(err, options: [])
+                        let jsonString = String(data: jsonData, encoding: NSUTF8StringEncoding)!
+                        callbackInvocation = "\(callback)(\(jsonString)), null)"
+                    }
+                } catch _ {
+                    callbackInvocation = "\(callback)(null, null)"
+                }
+
+                self.webView.evaluateJavaScript(callbackInvocation, completionHandler: nil)
+            }
+        }
+
+        return webView
     }()
 
-    init(url: String) {
+    init(profile: Profile, url: String) {
+        self.profile = profile
         self.url = url.asURL!
         super.init(nibName: nil, bundle: nil)
     }

--- a/Client/Frontend/Home/WebViewPanel.swift
+++ b/Client/Frontend/Home/WebViewPanel.swift
@@ -121,9 +121,12 @@ extension BookmarksModel: DictionaryView {
 
 extension Site: DictionaryView {
     func toDictionary() -> [String: AnyObject] {
+        let iconURL = icon?.url != nil ? icon?.url : ""
         return [
             "title": title,
-            "url": url
+            "url": url,
+            "date": NSNumber(unsignedLongLong: (latestVisit?.date)!),
+            "iconURL": iconURL!,
         ]
     }
 }

--- a/Storage/Bookmarks.swift
+++ b/Storage/Bookmarks.swift
@@ -26,6 +26,7 @@ public protocol ShareToDestination {
 
 public protocol SearchableBookmarks {
     func bookmarksByURL(url: NSURL) -> Deferred<Maybe<Cursor<BookmarkItem>>>
+    func localBookmarksWithLimit(limit: Int) -> Deferred<Maybe<Cursor<BookmarkItem>>>
 }
 
 public struct BookmarkMirrorItem {

--- a/Storage/SQL/SQLiteBookmarks.swift
+++ b/Storage/SQL/SQLiteBookmarks.swift
@@ -370,6 +370,22 @@ extension SQLiteBookmarks: SearchableBookmarks {
         let args: Args = [url.absoluteString]
         return db.runQuery(sql, args: args, factory: LocalBookmarkNodeFactory.itemFactory)
     }
+
+    public func localBookmarksWithLimit(limit: Int) -> Deferred<Maybe<Cursor<BookmarkItem>>> {
+        let inner =
+        "SELECT id, type, guid, url, title, faviconID " +
+        "FROM \(TableBookmarks) " +
+        "WHERE type = \(BookmarkNodeType.Bookmark.rawValue) " +
+        "LIMIT ?"
+
+        let sql =
+        "SELECT bookmarks.id AS id, bookmarks.type AS type, guid, bookmarks.url AS url, title, " +
+        "favicons.url AS iconURL, favicons.date AS iconDate, favicons.type AS iconType " +
+        "FROM (\(inner)) AS bookmarks " +
+        "LEFT OUTER JOIN favicons ON bookmarks.faviconID = favicons.id"
+        let args: Args = [limit]
+        return db.runQuery(sql, args: args, factory: LocalBookmarkNodeFactory.itemFactory)
+    }
 }
 
 private extension BookmarkMirrorItem {

--- a/StorageTests/TestSQLiteBookmarks.swift
+++ b/StorageTests/TestSQLiteBookmarks.swift
@@ -165,4 +165,16 @@ class TestSQLiteBookmarks: XCTestCase {
         // We no longer have children.
         XCTAssertEqual(0, childCount("UjAHxFOGEqU8"))
     }
+
+    func testLocalBookmarksQuery() {
+        guard let db = getBrowserDB("browser.db", files: MockFiles()) else {
+            XCTFail("Unable to create browser DB.")
+            return
+        }
+        let bookmarks = SQLiteBookmarks(db: db)
+        bookmarks.addToMobileBookmarks("http://url1".asURL!, title: "url1", favicon: nil).value
+        bookmarks.addToMobileBookmarks("http://url2".asURL!, title: "url2", favicon: nil).value
+        XCTAssertEqual(2, bookmarks.localBookmarksWithLimit(2).value.successValue!.count)
+        XCTAssertEqual(1, bookmarks.localBookmarksWithLimit(1).value.successValue!.count)
+    }
 }


### PR DESCRIPTION
This branch includes a new Top Sites Panel that displays a WKWebView. To show this panel the debug settings bundle has a new option that allows you to input any URL. When a URL is set, the web view panel replaces the Top Sites Panel and loads the given URL. On top of loading the URL a data API is exposed to the web page to allow the page to access native parts of the app such as history, bookmarks, and top sites. This should only be used in prototyping and not used for general web pages in the browser.

Currently only history items are exposed through the mozAPI.