### PR TITLE
Bug 1228419 - Added Login Manager flag to AppConstants

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -797,7 +797,12 @@ class SettingsTableViewController: UITableViewController {
             SettingSection(title: NSAttributedString(string: NSLocalizedString("General", comment: "General settings section title")), children: generalSettings)
         ]
 
-        var privacySettings: [Setting] = [LoginsSetting(settings: self, delegate: settingsDelegate), ClearPrivateDataSetting(settings: self)]
+        var privacySettings: [Setting]
+        if AppConstants.MOZ_LOGIN_MANAGER {
+            privacySettings = [LoginsSetting(settings: self, delegate: settingsDelegate), ClearPrivateDataSetting(settings: self)]
+        } else {
+            privacySettings = [ClearPrivateDataSetting(settings: self)]
+        }
 
         if #available(iOS 9, *) {
             privacySettings += [
@@ -954,8 +959,14 @@ class SettingsTableViewController: UITableViewController {
         }
 
         if #available(iOS 9, *) {
-            if indexPath.section == 2 && indexPath.row == 2 {
-                return 64
+            if AppConstants.MOZ_LOGIN_MANAGER {
+                if indexPath.section == 2 && indexPath.row == 2 {
+                    return 64
+                }
+            } else {
+                if indexPath.section == 2 && indexPath.row == 1 {
+                    return 64
+                }
             }
         }
 

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -11,19 +11,40 @@ public enum AppBuildChannel {
 }
 
 public struct AppConstants {
-#if MOZ_CHANNEL_AURORA
-    public static let BuildChannel = AppBuildChannel.Aurora
-#elseif MOZ_CHANNEL_RELEASE
-    public static let BuildChannel = AppBuildChannel.Release
-#else
-    public static let BuildChannel = AppBuildChannel.Developer
-#endif
-
-#if MOZ_CHANNEL_DEBUG
-    public static let IsDebug = true
-#else
-    public static let IsDebug = false
-#endif
 
     public static let IsRunningTest = NSClassFromString("XCTestCase") != nil
+
+
+    /// Build Channel.
+    public static let BuildChannel: AppBuildChannel = {
+#if MOZ_CHANNEL_AURORA
+    return AppBuildChannel.Aurora
+#elseif MOZ_CHANNEL_RELEASE
+    return AppBuildChannel.Release
+#else
+    return AppBuildChannel.Developer
+#endif
+    }()
+
+
+    /// Flag indiciating if we are running in Debug mode or not.
+    public static let isDebug: Bool = {
+#if MOZ_CHANNEL_DEBUG
+    return true
+#else
+    return false
+#endif
+    }()
+
+
+    /// Enables/disables the Login manager UI by hiding the 'Logins' setting item.
+    public static let MOZ_LOGIN_MANAGER: Bool = {
+#if MOZ_CHANNEL_AURORA
+    return false
+#elseif MOZ_CHANNEL_RELEASE
+    return false
+#else
+    return true
+#endif
+    }()
 }


### PR DESCRIPTION
Alternative to https://github.com/mozilla/firefox-ios/pull/1373.

Flags live in AppConstants instead of .xcconfig files.