### PR TITLE
Bug 1223124 - Constrain top site deletions to single items at a time

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -670,6 +670,7 @@
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
 		E66464911C10CA9C00AF05CE /* SearchInputViewRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66464901C10CA9C00AF05CE /* SearchInputViewRefTests.swift */; };
+		E66464EE1C10D98000AF05CE /* AssertionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66464ED1C10D98000AF05CE /* AssertionUtils.swift */; };
 		E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
@@ -1888,6 +1889,7 @@
 		E6639F171BF11E17002D0853 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
 		E66464901C10CA9C00AF05CE /* SearchInputViewRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchInputViewRefTests.swift; sourceTree = "<group>"; };
+		E66464ED1C10D98000AF05CE /* AssertionUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionUtils.swift; sourceTree = "<group>"; };
 		E66C5B461BDA81050051AA93 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
 		E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
@@ -2834,6 +2836,7 @@
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
 				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
+				E66464ED1C10D98000AF05CE /* AssertionUtils.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
 				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
 				281B2C071ADF4F29002917DC /* DeferredUtils.swift */,
@@ -4646,6 +4649,7 @@
 				E69966991B72674B0036F797 /* RollingFileLogger.swift in Sources */,
 				288A2DAB1AB8B3700023ABC3 /* BoxType.swift in Sources */,
 				28C328021AD387E00005149C /* KeychainWrapper.swift in Sources */,
+				E66464EE1C10D98000AF05CE /* AssertionUtils.swift in Sources */,
 				28158BAC1ABC7C0E00C56FC8 /* Bytes.swift in Sources */,
 				288A2DB11AB8B37E0023ABC3 /* LockProtected.swift in Sources */,
 				2FDE87511ABA3E9A005317B1 /* HashExtensions.swift in Sources */,

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -43,7 +43,7 @@ class TopSitesPanel: UIViewController {
                     homePanelDelegate?.homePanelWillEnterEditingMode?(self)
                 }
 
-                updateRemoveButtonStates()
+                updateAllRemoveButtonStates()
             }
         }
     }
@@ -125,16 +125,9 @@ class TopSitesPanel: UIViewController {
         }
     }
 
-    private func updateRemoveButtonStates() {
-        for i in 0..<layout.thumbnailCount {
-            if let cell = collection?.cellForItemAtIndexPath(NSIndexPath(forItem: i, inSection: 0)) as? ThumbnailCell {
-                //TODO: Only toggle the remove button for non-suggested tiles for now
-                if i < dataSource.data.count {
-                    cell.toggleRemoveButton(editingThumbnails)
-                } else {
-                    cell.toggleRemoveButton(false)
-                }
-            }
+    private func updateAllRemoveButtonStates() {
+        collection?.indexPathsForVisibleItems().forEach { indexPath in
+            updateRemoveButtonStateForIndexPath(indexPath)
         }
     }
 
@@ -150,6 +143,13 @@ class TopSitesPanel: UIViewController {
         >>> self.profile.history.refreshTopSitesCache
         >>> reloadThumbnails
     }
+    private func updateRemoveButtonStateForIndexPath(indexPath: NSIndexPath, forCell cell: ThumbnailCell? = nil) {
+        // If we have a cell passed in, use it. If not, then use the indexPath to get it.
+        let cell = cell ?? (collection?.cellForItemAtIndexPath(indexPath) as? ThumbnailCell)
+        dataSource[indexPath.row] is SuggestedSite ?
+            cell?.toggleRemoveButton(false) :
+            cell?.toggleRemoveButton(editingThumbnails)
+     }
 
     private func refreshTopSites(frecencyLimit: Int) {
         // Reload right away with whatever is in the cache, then check to see if the cache is invalid. If it's invalid,

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -301,10 +301,13 @@ private class TopSitesCollectionView: UICollectionView {
 private class TopSitesLayout: UICollectionViewLayout {
 
     private var thumbnailRows: Int {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
         return max(2, Int((self.collectionView?.frame.height ?? self.thumbnailHeight) / self.thumbnailHeight))
     }
 
     private var thumbnailCols: Int {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+
         let size = collectionView?.bounds.size ?? CGSizeZero
         let traitCollection = collectionView!.traitCollection
         if traitCollection.horizontalSizeClass == .Compact {
@@ -333,12 +336,19 @@ private class TopSitesLayout: UICollectionViewLayout {
     }
 
     private var thumbnailCount: Int {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
         return thumbnailRows * thumbnailCols
     }
-    private var width: CGFloat { return self.collectionView?.frame.width ?? 0 }
+
+    private var width: CGFloat {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+        return self.collectionView?.frame.width ?? 0
+    }
 
     // The width and height of the thumbnail here are the width and height of the tile itself, not the image inside the tile.
     private var thumbnailWidth: CGFloat {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+
         let size = collectionView?.bounds.size ?? CGSizeZero
         let insets = ThumbnailCellUX.insetsForCollectionViewSize(size,
             traitCollection:  collectionView!.traitCollection)
@@ -348,6 +358,8 @@ private class TopSitesLayout: UICollectionViewLayout {
     // The tile's height is determined the aspect ratio of the thumbnails width. We also take into account
     // some padding between the title and the image.
     private var thumbnailHeight: CGFloat {
+        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+
         return floor(thumbnailWidth / CGFloat(ThumbnailCellUX.ImageAspectRatio))
     }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -136,7 +136,7 @@ class TopSitesPanel: UIViewController {
             .bindQueue(mainQueue) { _ in
                 return self.profile.history.refreshTopSitesCache()
             }.bindQueue(mainQueue) { _ in
-                return self.profile.history.getTopSitesWithLimit(self.layout.thumbnailCount)
+                return self.profile.history.getTopSitesWithLimit(self.maxFrecencyLimit)
             }.uponQueue(mainQueue) { result in
                 self.deleteOrUpdateSites(result, indexPath: indexPath)
                 self.collection?.userInteractionEnabled = true

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -126,9 +126,7 @@ class TopSitesPanel: UIViewController {
     }
 
     private func updateAllRemoveButtonStates() {
-        collection?.indexPathsForVisibleItems().forEach { indexPath in
-            updateRemoveButtonStateForIndexPath(indexPath)
-        }
+        collection?.indexPathsForVisibleItems().forEach { updateRemoveButtonStateForIndexPath($0) }
     }
 
     private func deleteHistoryTileForSite(site: Site, atIndexPath indexPath: NSIndexPath) {
@@ -145,11 +143,14 @@ class TopSitesPanel: UIViewController {
     }
     private func updateRemoveButtonStateForIndexPath(indexPath: NSIndexPath, forCell cell: ThumbnailCell? = nil) {
         // If we have a cell passed in, use it. If not, then use the indexPath to get it.
-        let cell = cell ?? (collection?.cellForItemAtIndexPath(indexPath) as? ThumbnailCell)
+        guard let cell = cell ?? (collection?.cellForItemAtIndexPath(indexPath) as? ThumbnailCell) else {
+            return
+        }
+
         dataSource[indexPath.row] is SuggestedSite ?
-            cell?.toggleRemoveButton(false) :
-            cell?.toggleRemoveButton(editingThumbnails)
-     }
+            cell.toggleRemoveButton(false) :
+            cell.toggleRemoveButton(editingThumbnails)
+    }
 
     private func refreshTopSites(frecencyLimit: Int) {
         // Reload right away with whatever is in the cache, then check to see if the cache is invalid. If it's invalid,
@@ -267,7 +268,6 @@ extension TopSitesPanel: UICollectionViewDelegate {
     func collectionView(collectionView: UICollectionView, willDisplayCell cell: UICollectionViewCell, forItemAtIndexPath indexPath: NSIndexPath) {
         if let thumbnailCell = cell as? ThumbnailCell {
             thumbnailCell.delegate = self
-
             if editingThumbnails && indexPath.item < dataSource.data.count && thumbnailCell.removeButton.hidden {
                 thumbnailCell.removeButton.hidden = false
             }
@@ -336,18 +336,18 @@ private class TopSitesLayout: UICollectionViewLayout {
     }
 
     private var thumbnailCount: Int {
-        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+        assertIsMainThread("layout.thumbnailCount interacts with UIKit components - cannot call from background thread.")
         return thumbnailRows * thumbnailCols
     }
 
     private var width: CGFloat {
-        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+        assertIsMainThread("layout.width interacts with UIKit components - cannot call from background thread.")
         return self.collectionView?.frame.width ?? 0
     }
 
     // The width and height of the thumbnail here are the width and height of the tile itself, not the image inside the tile.
     private var thumbnailWidth: CGFloat {
-        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+        assertIsMainThread("layout.thumbnailWidth interacts with UIKit components - cannot call from background thread.")
 
         let size = collectionView?.bounds.size ?? CGSizeZero
         let insets = ThumbnailCellUX.insetsForCollectionViewSize(size,
@@ -358,7 +358,7 @@ private class TopSitesLayout: UICollectionViewLayout {
     // The tile's height is determined the aspect ratio of the thumbnails width. We also take into account
     // some padding between the title and the image.
     private var thumbnailHeight: CGFloat {
-        assert(NSThread.isMainThread(), "Interacts with UIKit components - not thread-safe.")
+        assertIsMainThread("layout.thumbnailHeight interacts with UIKit components - cannot call from background thread.")
 
         return floor(thumbnailWidth / CGFloat(ThumbnailCellUX.ImageAspectRatio))
     }

--- a/Client/Frontend/Widgets/ThumbnailCell.swift
+++ b/Client/Frontend/Widgets/ThumbnailCell.swift
@@ -157,6 +157,7 @@ class ThumbnailCell: UICollectionViewCell {
 
     lazy var removeButton: UIButton = {
         let removeButton = UIButton()
+        removeButton.exclusiveTouch = true
         removeButton.setImage(UIImage(named: "TileCloseButton"), forState: UIControlState.Normal)
         removeButton.addTarget(self, action: "SELdidRemove", forControlEvents: UIControlEvents.TouchUpInside)
         removeButton.accessibilityLabel = NSLocalizedString("Remove page", comment: "Button shown in editing mode to remove this site from the top sites panel.")

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -122,6 +122,7 @@ extension SQLiteHistory: BrowserHistory {
     public func removeSiteFromTopSites(site: Site) -> Success {
         if let host = site.url.asURL?.normalizedHost() {
             return db.run([("UPDATE \(TableDomains) set showOnTopSites = 0 WHERE domain = ?", [host])])
+                >>> { return self.refreshTopSitesCache() }
         }
         return deferMaybe(DatabaseError(description: "Invalid url for site \(site.url)"))
     }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -289,8 +289,7 @@ extension SQLiteHistory: BrowserHistory {
 
     public func refreshTopSitesCache() -> Success {
         let cacheSize = Int(prefs.intForKey(PrefsKeys.KeyTopSitesCacheSize) ?? 0)
-        return self.clearTopSitesCache()
-            >>> { self.updateTopSitesCacheWithLimit(cacheSize) }
+        return updateTopSitesCacheWithLimit(cacheSize)
     }
 
     private func updateTopSitesCacheWithLimit(limit : Int) -> Success {
@@ -298,10 +297,10 @@ extension SQLiteHistory: BrowserHistory {
         let (query, args) = self.filteredSitesByFrecencyQueryWithLimit(limit, groupClause: groupBy, whereData: whereData)
         let insertQuery = "INSERT INTO \(TableCachedTopSites) \(query)"
         return self.clearTopSitesCache() >>> {
-            self.db.run(insertQuery, withArgs: args) >>> {
-                self.prefs.setBool(true, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
-                return succeed()
-            }
+            return self.db.run(insertQuery, withArgs: args)
+        } >>> {
+            self.prefs.setBool(true, forKey: PrefsKeys.KeyTopSitesCacheIsValid)
+            return succeed()
         }
     }
 

--- a/Utils/AssertionUtils.swift
+++ b/Utils/AssertionUtils.swift
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ Assertion for checking that the call is being made on the main thread.
+
+ - parameter message: Message to display in case of assertion.
+ */
+public func assertIsMainThread(message: String) {
+    assert(NSThread.isMainThread(), message)
+}


### PR DESCRIPTION
This PR includes a simpler, strict approach to https://github.com/mozilla/firefox-ios/pull/1283. The key here is setting the exclusiveTouch flag on the removeButton to true. The main issue before and in the complicated patch was that multi touch events would trigger multiple deletes at the same time which was causing duplicates to appear in the refreshed query. On top of forcing the touches to be exclusive, user interaction is temporarily disabled until the DB query and refresh finishes to prevent any race conditions from occurring. 

Instead of being able to delete multiple items at the same time I think the proper fix for this problem is to add a 'Clear All' button in the toolbar to allow users to delete all of the tiles. Theres a good chance that if the user was furiously deleting tiles in Top Sites they intend to remove everything.

Note that this patch resolves the current top crash related to Top Site deletion.