### PR TITLE
Bug 1229129 - finshed fixing paragraph highlight when VoiceOver isnt activated

### DIFF
--- a/Client/Assets/ContextMenu.js
+++ b/Client/Assets/ContextMenu.js
@@ -78,7 +78,6 @@ function handleTouchEnd(event) {
   cancel();
 
   removeEventListener("touchend", handleTouchEnd);
-  removeEventListener("mouseup", handleTouchEnd);
   removeEventListener("touchmove", handleTouchMove);
 
   // If we're showing the context menu, prevent the page from handling the click event.
@@ -99,10 +98,7 @@ addEventListener("touchstart", function (event) {
   var element = event.target;
 
   // Listen for touchend or move events to cancel the context menu timeout.
-  // Also listen for mouseup due to touchend not being fired with VoiceOver enabled.
-  // Open bug filed as rdar://22256909.
   element.addEventListener("touchend", handleTouchEnd);
-  element.addEventListener("mouseup", handleTouchEnd);
   element.addEventListener("touchmove", handleTouchMove);
 
   do {

--- a/Client/Frontend/Browser/ContextMenuHelper.swift
+++ b/Client/Frontend/Browser/ContextMenuHelper.swift
@@ -23,11 +23,11 @@ class ContextMenuHelper: NSObject, BrowserHelper, UIGestureRecognizerDelegate {
         return "ContextMenuHelper"
     }
 
-    /// On iOS <9, clicking an element with VoiceOver fires touchstart, but not touchend, causing the context
+    /// Clicking an element with VoiceOver fires touchstart, but not touchend, causing the context
     /// menu to appear when it shouldn't (filed as rdar://22256909). As a workaround, disable the custom
-    /// context menu for VoiceOver users on iOS <9.
+    /// context menu for VoiceOver users.
     private var showCustomContextMenu: Bool {
-        return NSProcessInfo.processInfo().operatingSystemVersion.majorVersion >= 9 || !UIAccessibilityIsVoiceOverRunning()
+        return !UIAccessibilityIsVoiceOverRunning()
     }
 
     required init(browser: Browser) {


### PR DESCRIPTION
1. removed custom context menu altogether when voiceover is enabled
2. tested on iPhone 5 and it works yey