### PR TITLE
Fixes 1237149 - Incorrect search engines are shown for zh-CN

### DIFF
--- a/ClientTests/SearchEnginesTests.swift
+++ b/ClientTests/SearchEnginesTests.swift
@@ -140,4 +140,23 @@ class SearchEnginesTests: XCTestCase {
         XCTAssertFalse(engines2.shouldShowSearchSuggestionsOptIn)
         XCTAssertTrue(engines2.shouldShowSearchSuggestions)
     }
+
+    func testDirectoriesForLanguageIdentifier() {
+        XCTAssertEqual(
+            SearchEngines.directoriesForLanguageIdentifier("nl", basePath: "/tmp", fallbackIdentifier: "en"),
+            ["/tmp/nl", "/tmp/en"]
+        )
+        XCTAssertEqual(
+            SearchEngines.directoriesForLanguageIdentifier("en-US", basePath: "/tmp", fallbackIdentifier: "en"),
+            ["/tmp/en-US", "/tmp/en"]
+        )
+        XCTAssertEqual(
+            SearchEngines.directoriesForLanguageIdentifier("es-MX", basePath: "/tmp", fallbackIdentifier: "en"),
+            ["/tmp/es-MX", "/tmp/es", "/tmp/en"]
+        )
+        XCTAssertEqual(
+            SearchEngines.directoriesForLanguageIdentifier("zh-Hans-CN", basePath: "/tmp", fallbackIdentifier: "en"),
+            ["/tmp/zh-Hans-CN", "/tmp/zh-CN", "/tmp/zh", "/tmp/en"]
+        )
+    }
 }


### PR DESCRIPTION
This patch introduces a `directoriesForLanguageIdentifier()` function that returns a list of `SearchPlugins` directories that match for the given *language identifier*.

It return all possible paths for a language identifier in the order of most specific to least specific. For example, zh-Hans-CN with a default of en will return `["base/zh-Hans-CN", "base/zh-CN", "base/zh", "base/en"]`.

These directories, except the fallback, are not guaranteed to exist. The calling code will try them all and use the first one that exists.

This change was made so that we correctly handle the `zh-Hans-CN` *language identifier* which does not map to any of the `SearchPlugins` subdirectories but should default to the `zh-CN` one.