### PR TITLE
Bug 1237499 - China edition does not display the sign-in page of China-hosted Firefox Accounts / Sync service for the first run

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -427,8 +427,8 @@ public class BrowserProfile: Profile {
     }()
 
     var accountConfiguration: FirefoxAccountConfiguration {
-        let syncService: Bool = self.prefs.boolForKey("useChinaSyncService") ?? false
-        if syncService {
+        let locale = NSLocale.currentLocale()
+        if self.prefs.boolForKey("useChinaSyncService") ?? (locale.localeIdentifier == "zh_CN") {
             return ChinaEditionFirefoxAccountConfiguration()
         }
         return ProductionFirefoxAccountConfiguration()


### PR DESCRIPTION
Bug 1237499 - China edition does not display the sign-in page of China-hosted Firefox Accounts / Sync service for the first run