### PR TITLE
Bug 1236919 - The reader view controls menu is misplaced when switching to landscape

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2217,12 +2217,22 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 readerModeStyleViewController.readerModeStyle = readerModeStyle
                 readerModeStyleViewController.modalPresentationStyle = UIModalPresentationStyle.Popover
 
-                let popoverPresentationController = readerModeStyleViewController.popoverPresentationController
-                popoverPresentationController?.backgroundColor = UIColor.whiteColor()
-                popoverPresentationController?.delegate = self
-                popoverPresentationController?.sourceView = readerModeBar
-                popoverPresentationController?.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.ToolbarHeight, width: 1, height: 1)
-                popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection.Up
+                let setupPopover = { [unowned self] in
+                    if let popoverPresentationController = readerModeStyleViewController.popoverPresentationController {
+                        popoverPresentationController.backgroundColor = UIColor.whiteColor()
+                        popoverPresentationController.delegate = self
+                        popoverPresentationController.sourceView = readerModeBar
+                        popoverPresentationController.sourceRect = CGRect(x: readerModeBar.frame.width/2, y: UIConstants.ToolbarHeight, width: 1, height: 1)
+                        popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.Up
+                    }
+                }
+
+                setupPopover()
+
+                if readerModeStyleViewController.popoverPresentationController != nil {
+                    displayedPopoverController = readerModeStyleViewController
+                    updateDisplayedPopoverProperties = setupPopover
+                }
 
                 self.presentViewController(readerModeStyleViewController, animated: true, completion: nil)
             }


### PR DESCRIPTION
ReaderModeStyleViewController's popoverPresentationController's properties weren't updated on rotation like other popoverPresentationControllers. Luckily, we already implemented rotation handling with other popover controllers (eg. the long press on link ones) with variables: displayedPopoverController and updateDisplayedPopoverProperties. So I just edited the reader mode's popover controller to use those variables so that its properties would get updated on rotation!