### PR TITLE
Bug 1238006 - (Startup) Crash in Session Restore that takes Springboard

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -421,10 +421,19 @@ extension TabManager {
                     return nil
                 }
 
-                let backList = browser.webView?.backForwardList.backList ?? []
-                let forwardList = browser.webView?.backForwardList.forwardList ?? []
-                let urls = (backList + [currentItem] + forwardList).map { $0.URL }
-                let currentPage = -forwardList.count
+                let urls: [NSURL]
+                let currentPage: Int
+
+                if AppConstants.MOZ_PERSIST_SESSION_HISTORY {
+                    let backList = browser.webView?.backForwardList.backList ?? []
+                    let forwardList = browser.webView?.backForwardList.forwardList ?? []
+                    urls = (backList + [currentItem] + forwardList).map { $0.URL }
+                    currentPage = -forwardList.count
+                } else {
+                    urls = [currentItem.URL]
+                    currentPage = 0
+                }
+
                 self.sessionData = SessionData(currentPage: currentPage, urls: urls, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
             } else {
                 self.sessionData = browser.sessionData

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -47,4 +47,9 @@ public struct AppConstants {
     return true
 #endif
     }()
+
+    /// Enables/disables the saving and restoring tab history in saved sessions
+    public static let MOZ_PERSIST_SESSION_HISTORY: Bool = {
+        return false
+    }()
 }


### PR DESCRIPTION
I started this patch by removing all code to support persisting tab history and restoring it through the `/session/restore` handler. But that turned out to be a very complicated task because the code is all over the place and touches lots of logic.

So I decided to keep all that in place and instead introduce a feature flag `MOZ_PERSIST_SESSION_HISTORY` which can trigger a much simpler session save and restore if set to `false`.

* Instead of saving the whole BackForwardList we just save the current item. So the `SessionData.urls` will contain one entry.
* Instead of restoring through the `SessionRestore.html` mechanism, we simply take the one `NSURL` from `SessionData.urls` and load it immediately via `webView.loadRequest()`

The flag defaults to `false`. There is no way to configure it per build but I think that is fine for now.

This code is compatible with previously stored tab state from older versions. The format has not changed.