### PR TITLE
Bug 1237539 - kCFErrorDomainCFNetwork is shown when pages try to unsuccesfully open native apps

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1767,7 +1767,10 @@ extension BrowserViewController: WKNavigationDelegate {
             if UIApplication.sharedApplication().canOpenURL(url) {
                 openExternal(url)
             } else {
-                ErrorPageHelper().showPage(NSError(domain: kCFErrorDomainCFNetwork as String, code: Int(CFNetworkErrors.CFErrorHTTPBadURL.rawValue), userInfo: [:]), forUrl: url, inWebView: webView)
+                // Only show the error page if this was not a JavaScript initiated request. This prevents the error to overwrite apps that try to open native apps from an already loadeded page.
+                if navigationAction.navigationType != WKNavigationType.Other {
+                    ErrorPageHelper().showPage(NSError(domain: kCFErrorDomainCFNetwork as String, code: Int(CFNetworkErrors.CFErrorHTTPBadURL.rawValue), userInfo: [:]), forUrl: url, inWebView: webView)
+                }
             }
             decisionHandler(WKNavigationActionPolicy.Cancel)
         }


### PR DESCRIPTION
The problem is that we should not show this error page if an app tries to probe if a native application is installed from JavaScript. The error page would overwrite the actual page. This patch fixes that. It will report errors for every navigation action except 'Other', which means JavaScript-initiated.