### PR TITLE
Bug 1237149 - Incorrect search engines are shown for zh-CN

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -167,11 +167,29 @@ class SearchEngines {
         }
     }
 
+    // Return the language identifier to be used for the search engine selection. This returns the first
+    // identifier from preferredLanguages and takes into account that on iOS 8, zh-Hans-CN is returned as
+    // zh-Hans. In that case it returns the longer form zh-Hans-CN. Same for traditional Chinese.
+    //
+    // These exceptions can go away when we drop iOS 8 or when we start using a better mechanism for search
+    // engine selection that is not based on language identifier.
+    class func languageIdentifierForSearchEngines() -> String {
+        let languageIdentifier = NSLocale.preferredLanguages().first!
+        switch languageIdentifier {
+            case "zh-Hans":
+                return "zh-Hans-CN"
+            case "zh-Hant":
+                return "zh-Hant-TW"
+            default:
+                return languageIdentifier
+        }
+    }
+
     // Get all known search engines, with the default search engine first, but the others in no
     // particular order.
     class func getUnorderedEngines() -> [OpenSearchEngine] {
         let pluginBasePath: NSString = (NSBundle.mainBundle().resourcePath! as NSString).stringByAppendingPathComponent("SearchPlugins")
-        let languageIdentifier = NSLocale.preferredLanguages().first!
+        let languageIdentifier = languageIdentifierForSearchEngines()
         let fallbackDirectory: NSString = pluginBasePath.stringByAppendingPathComponent("en")
 
         var directory: String?


### PR DESCRIPTION
This is an alternative for the existing pull request that renames the directories.

I think I would prefer to just normalize the language identifier to get some commonality between iOS 8 and iOS 9. Specially because the search engine directories are generated by a script and are based on the Android ones. So I would prefer to keep the same locale identifiers in their names.