### PR TITLE
Bug 1238036 - Make the webview first responder on touch

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -450,4 +450,11 @@ private class BrowserWebView: WKWebView, MenuHelperInterface {
             self.delegate?.browserWebView(self, didSelectFindInPageForSelection: selection)
         }
     }
+
+    private override func hitTest(point: CGPoint, withEvent event: UIEvent?) -> UIView? {
+        // The find-in-page selection menu only appears if the webview is the first responder.
+        becomeFirstResponder()
+
+        return super.hitTest(point, withEvent: event)
+    }
 }


### PR DESCRIPTION
`touchesBegan` doesn't get fired for `WKWebView`, presumably because they don't fire the super `UIView.hitTest` implementation triggers the touch events. As a workaround, we can hook into `hitTest` directly.