### PR TITLE
Bug 1239722 - Open a new tab when new version is detected

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -258,6 +258,8 @@
 		74203E251B276B3D007D481D /* SessionRestoreHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74203E241B276B3D007D481D /* SessionRestoreHandler.swift */; };
 		744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744B0FFD1B4F172E00100422 /* ToolbarTests.swift */; };
 		746B6A791B277C1800EA83E3 /* SessionRestore.html in Resources */ = {isa = PBXBuildFile; fileRef = 746B6A781B277C1800EA83E3 /* SessionRestore.html */; };
+		7479B4EE1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
+		7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7479B4ED1C5306A200DF000B /* Reachability.swift */; };
 		74C027451B2A348C001B1E88 /* SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C027441B2A348C001B1E88 /* SessionData.swift */; };
 		74E36D781B71323500D69DA1 /* SettingsContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */; };
 		7B0B1B791C1B69C900DF4AB5 /* ClientPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BCAAD81B05380B00855D82 /* ClientPickerViewController.swift */; };
@@ -1496,6 +1498,7 @@
 		74203E241B276B3D007D481D /* SessionRestoreHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreHandler.swift; sourceTree = "<group>"; };
 		744B0FFD1B4F172E00100422 /* ToolbarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTests.swift; sourceTree = "<group>"; };
 		746B6A781B277C1800EA83E3 /* SessionRestore.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SessionRestore.html; sourceTree = "<group>"; };
+		7479B4ED1C5306A200DF000B /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = ThirdParty/Reachability.swift; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
 		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
 		7B24DC9B1B67B3590005766B /* ClearPrivateDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTests.swift; sourceTree = "<group>"; };
@@ -2286,6 +2289,7 @@
 				2F1BDF8C1A8523B000213B54 /* SwiftKeychainWrapper */,
 				D38B2D0E1A8D96D00040E6B5 /* GCDWebServer */,
 				28CE842F1A1E571900576538 /* json.swift */,
+				7479B4ED1C5306A200DF000B /* Reachability.swift */,
 			);
 			name = "Third-Party Source";
 			sourceTree = "<group>";
@@ -4642,6 +4646,7 @@
 				288A2DB51AB8B38D0023ABC3 /* Error.swift in Sources */,
 				28E8BEC91B79449B002CC733 /* AlamofireExtensions.swift in Sources */,
 				0B36E4CA1B34CC74000E79BD /* Deferred.swift in Sources */,
+				7479B4EF1C5306A200DF000B /* Reachability.swift in Sources */,
 				285D3B331B4332C00035FD22 /* NotificationConstants.swift in Sources */,
 				288A2DB61AB8B38D0023ABC3 /* Result.swift in Sources */,
 				E6F9653F1B2F242E0034B023 /* NSMutableAttributedStringExtensions.swift in Sources */,
@@ -4914,6 +4919,7 @@
 				E4B3345C1BBF2393004E2BFF /* ADJPackageHandler.m in Sources */,
 				D301AAEE1A3A55B70078DD1D /* TabTrayController.swift in Sources */,
 				D38B2D431A8D96D00040E6B5 /* GCDWebServerMultiPartFormRequest.m in Sources */,
+				7479B4EE1C5306A200DF000B /* Reachability.swift in Sources */,
 				0B3E7D951B27A7CE00E2E84D /* AboutHomeHandler.swift in Sources */,
 				D3BE7B461B054F8600641031 /* TestAppDelegate.swift in Sources */,
 				0B62EFD21AD63CD100ACB9CD /* Clearables.swift in Sources */,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -521,6 +521,14 @@ class BrowserViewController: UIViewController {
         log.debug("BVC calling super.viewDidAppear.")
         super.viewDidAppear(animated)
         log.debug("BVC done.")
+
+        let appVersion = AppInfo.appVersion
+        if profile.prefs.stringForKey("latestAppVersion") != appVersion && DeviceInfo.hasConnectivity() {
+            if let whatsNewURL = AppConstants.whatsNewURLForVersion(appVersion) {
+                self.openURLInNewTab(whatsNewURL)
+                profile.prefs.setString(appVersion, forKey: "latestAppVersion")
+            }
+        }
     }
 
     override func viewWillDisappear(animated: Bool) {

--- a/ThirdParty/Reachability.swift
+++ b/ThirdParty/Reachability.swift
@@ -1,0 +1,113 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Isuru Nanayakkara
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+import Foundation
+import SystemConfiguration
+
+
+let ReachabilityStatusChangedNotification = "ReachabilityStatusChangedNotification"
+
+enum ReachabilityType: CustomStringConvertible {
+    case WWAN
+    case WiFi
+
+    var description: String {
+        switch self {
+        case .WWAN: return "WWAN"
+        case .WiFi: return "WiFi"
+        }
+    }
+}
+
+enum ReachabilityStatus: CustomStringConvertible  {
+    case Offline
+    case Online(ReachabilityType)
+    case Unknown
+
+    var description: String {
+        switch self {
+        case .Offline: return "Offline"
+        case .Online(let type): return "Online (\(type))"
+        case .Unknown: return "Unknown"
+        }
+    }
+}
+
+public class Reach {
+
+    func connectionStatus() -> ReachabilityStatus {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(sizeofValue(zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        guard let defaultRouteReachability = withUnsafePointer(&zeroAddress, {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        }) else {
+            return .Unknown
+        }
+
+        var flags : SCNetworkReachabilityFlags = []
+        if !SCNetworkReachabilityGetFlags(defaultRouteReachability, &flags) {
+            return .Unknown
+        }
+
+        return ReachabilityStatus(reachabilityFlags: flags)
+    }
+
+
+    func monitorReachabilityChanges() {
+        let host = "google.com"
+        var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+        let reachability = SCNetworkReachabilityCreateWithName(nil, host)!
+
+        SCNetworkReachabilitySetCallback(reachability, { (_, flags, _) in
+            let status = ReachabilityStatus(reachabilityFlags: flags)
+
+            NSNotificationCenter.defaultCenter().postNotificationName(ReachabilityStatusChangedNotification,
+                object: nil,
+                userInfo: ["Status": status.description])
+
+            }, &context)
+
+        SCNetworkReachabilityScheduleWithRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes)
+    }
+
+}
+
+extension ReachabilityStatus {
+    private init(reachabilityFlags flags: SCNetworkReachabilityFlags) {
+        let connectionRequired = flags.contains(.ConnectionRequired)
+        let isReachable = flags.contains(.Reachable)
+        let isWWAN = flags.contains(.IsWWAN)
+
+        if !connectionRequired && isReachable {
+            if isWWAN {
+                self = .Online(.WWAN)
+            } else {
+                self = .Online(.WiFi)
+            }
+        } else {
+            self =  .Offline
+        }
+    }
+}

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -58,4 +58,9 @@ public struct AppConstants {
     return true
 #endif
     }()
+
+    /// Function returning the What's New page for iOS
+    public static func whatsNewURLForVersion(version: String) -> NSURL? {
+        return NSURL(string: "https://support.mozilla.org/1/mobile/\(version)/%OS%/%LOCALE%/new-ios")
+    }
 }

--- a/Utils/DeviceInfo.swift
+++ b/Utils/DeviceInfo.swift
@@ -65,4 +65,16 @@ public class DeviceInfo {
         // Thus, testing has to take place on actual devices.
         return !lowGraphicsQualityModels.contains(specificModelName)
     }
+
+    public class func hasConnectivity() -> Bool {
+        let status = Reach().connectionStatus()
+        switch status {
+        case .Online(.WWAN):
+            return true
+        case .Online(.WiFi):
+            return true
+        default:
+            return false
+        }
+    }
 }


### PR DESCRIPTION
1. created function in AppConstants to return the newest version of the "What's New" page for iOS
2. imported Readability file into 3rd party folder (https://github.com/Isuru-Nanayakkara/Reach)
3. updated BVC viewDidAppear logic and added a network connectivity check before opening the new tab upon app update