### PR TITLE
Bug 1231955 - Article appears as read in reader view and unread in about:home

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2303,6 +2303,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 if let url = ReaderModeUtils.decodeURL(url) {
                     profile.readingList?.createRecordWithURL(url.absoluteString, title: tab.title ?? "", addedBy: UIDevice.currentDevice().name) // TODO Check result, can this fail?
                     readerModeBar.added = true
+                    readerModeBar.unread = true
                 }
             }
 
@@ -2311,6 +2312,7 @@ extension BrowserViewController: ReaderModeBarViewDelegate {
                 if let successValue = result.successValue, record = successValue {
                     profile.readingList?.deleteRecord(record) // TODO Check result, can this fail?
                     readerModeBar.added = false
+                    readerModeBar.unread = false
                 }
             }
         }

--- a/Client/Frontend/Browser/ReaderModeBarView.swift
+++ b/Client/Frontend/Browser/ReaderModeBarView.swift
@@ -137,32 +137,19 @@ class ReaderModeBarView: UIView {
         delegate?.readerModeBar(self, didSelectButton: added ? .RemoveFromReadingList : .AddToReadingList)
     }
 
-    private func updateUnread(unread: Bool) {
-        var buttonType: ReaderModeBarButtonType = unread ? .MarkAsRead : .MarkAsUnread
-        if !added {
-            buttonType = .MarkAsUnread
-        }
-        readStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
-
-        readStatusButton.enabled = added
-        readStatusButton.alpha = added ? 1.0 : 0.6
-    }
-
     var unread: Bool = true {
         didSet {
-            updateUnread(unread)
+            let buttonType: ReaderModeBarButtonType = unread && added ? .MarkAsRead : .MarkAsUnread
+            readStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
+            readStatusButton.enabled = added
+            readStatusButton.alpha = added ? 1.0 : 0.6
         }
     }
-
-    private func updateAdded(added: Bool) {
-        let buttonType: ReaderModeBarButtonType = added ? .RemoveFromReadingList : .AddToReadingList
-        listStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
-    }
-
+    
     var added: Bool = false {
         didSet {
-            updateAdded(added)
-            updateUnread(unread)
+            let buttonType: ReaderModeBarButtonType = added ? .RemoveFromReadingList : .AddToReadingList
+            listStatusButton.setImage(buttonType.image, forState: UIControlState.Normal)
         }
     }
 }


### PR DESCRIPTION
we need to update the reader mode bar's unread property in ReaderModeBarViewDelegate's didSelectButton or else unread won't be changed to true (if we reproduce the STR in this bug), causing the icon to remain in its "read" state.