### PR TITLE
Bug 1232188 - Adjust Retention Tracking

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -521,6 +521,8 @@
 		E4D567A51ADECEB800F1EFE7 /* ReadingListStorageTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D5679B1ADECEB800F1EFE7 /* ReadingListStorageTestCase.swift */; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
 		E4D8F3B01ACDD5150005A2E4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E4D8F3B21ACDD5150005A2E4 /* InfoPlist.strings */; };
+		E4E7EB6B1C4A86430094275D /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E7EB451C4A85D80094275D /* SupportUtils.swift */; };
+		E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */; };
 		E4ECCD8D1AB091470005E717 /* Reader.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4ECCD8C1AB091470005E717 /* Reader.xcassets */; };
 		E4ECCDAE1AB131770005E717 /* FiraSans-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4ECCDAD1AB131770005E717 /* FiraSans-Medium.ttf */; };
 		E4ECD0881B70FD4F00B90D22 /* WindowCloseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */; };
@@ -1743,6 +1745,8 @@
 		E4D8F3B11ACDD5150005A2E4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E4E0BB151AFBC9E4008D6260 /* Shared-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Shared-Bridging-Header.h"; sourceTree = "<group>"; };
 		E4E0BB171AFBC9E4008D6260 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E4E7EB451C4A85D80094275D /* SupportUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtils.swift; sourceTree = "<group>"; };
+		E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtilsTests.swift; sourceTree = "<group>"; };
 		E4ECCD8C1AB091470005E717 /* Reader.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Reader.xcassets; sourceTree = "<group>"; };
 		E4ECCDAD1AB131770005E717 /* FiraSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FiraSans-Medium.ttf"; sourceTree = "<group>"; };
 		E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowCloseHelper.swift; sourceTree = "<group>"; };
@@ -2760,6 +2764,7 @@
 				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
+				E4E7EB451C4A85D80094275D /* SupportUtils.swift */,
 				E66464ED1C10D98000AF05CE /* AssertionUtils.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
 				0B5A92E31B1E6075004F47A2 /* Cancellable.swift */,
@@ -3096,6 +3101,7 @@
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
 				E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
+				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				E6F9650E1B2F1CF20034B023 /* Supporting Files */,
 			);
 			path = SharedTests;
@@ -4552,6 +4558,7 @@
 				E695D8661C037E9F00D3FCCE /* FSUtils.m in Sources */,
 				2FDE87521ABA3EA0005317B1 /* TimeConstants.swift in Sources */,
 				2891CEC41ADC7F2900427D3C /* NSURLExtensions.swift in Sources */,
+				E4E7EB6B1C4A86430094275D /* SupportUtils.swift in Sources */,
 				2FDE87321ABA3E87005317B1 /* json.swift in Sources */,
 				E69966991B72674B0036F797 /* RollingFileLogger.swift in Sources */,
 				288A2DAB1AB8B3700023ABC3 /* BoxType.swift in Sources */,
@@ -4795,6 +4802,7 @@
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */,
+				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,
 				E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */,
 				E695D8681C03804F00D3FCCE /* FSUtilsTests.swift in Sources */,
 				28532BE91C471FFB000072D9 /* ResultTests.swift in Sources */,

--- a/Client/Application/AdjustIntegration.swift
+++ b/Client/Application/AdjustIntegration.swift
@@ -30,7 +30,11 @@ private struct AdjustSettings {
 /// functions in this object from other parts of the application.
 
 class AdjustIntegration: NSObject {
-    static let sharedInstance = AdjustIntegration()
+    let profile: Profile
+    
+    init(profile: Profile) {
+        self.profile = profile
+    }
 
     /// Return an ADJConfig object if Adjust has been enabled. It is determined from the values in
     /// the Info.plist file if Adjust should be enabled, and if so, what its application token and
@@ -96,43 +100,83 @@ class AdjustIntegration: NSObject {
         }
         return path
     }
+
+    /// Return true if Adjust should be enabled. If the user has disabled the Send Anonymous Usage Data then we immediately
+    /// return false. Otherwise we only do one ping, which means we only enable it if we have not seen the attributiond
+    /// data yet.
+    
+    private func shouldEnable() throws -> Bool {
+        if profile.prefs.boolForKey("settings.sendUsageData") ?? true {
+            return true
+        }
+        return try hasAttribution() == false
+    }
+    
+    /// Return true if retention (session) tracking should be enabled. This follows the Send Anonymous Usage Data
+    /// setting.
+    
+    private func shouldTrackRetention() -> Bool {
+        return profile.prefs.boolForKey("settings.sendUsageData") ?? true
+    }
 }
 
 extension AdjustIntegration: AdjustDelegate {
-    /// This is called as part of `UIApplication.didFinishLaunchingWithOptions()`. To make sure we only send one ping
-    /// to Adjust, we check if the attribution has been written to disk. If it has then that means we have done a
-    /// successful attribution ping and we do not run Adjust at all.
+    /// This is called as part of `UIApplication.didFinishLaunchingWithOptions()`. We always initialize the
+    /// Adjust SDK. We always let it send the initial attribution ping. Session tracking is only enabled if
+    /// the Send Anonymous Usage Data setting is turned on.
 
     func triggerApplicationDidFinishLaunchingWithOptions(launchOptions: [NSObject : AnyObject]?) -> Void {
         do {
-            if try hasAttribution() == false {
-                if let config = getConfig() {
-                    Adjust.appDidLaunch(config)
-                } else {
-                    Logger.browserLogger.info("Adjust - Skipping because no or invalid config found")
+            if let config = getConfig() {
+                // Always initialize Adjust - otherwise we cannot enable/disable it later. Their SDK must be
+                // initialized through appDidFinishLaunching otherwise it will be in a bad state.
+                Adjust.appDidLaunch(config)
+
+                // Disable it right now if we have the attribution and if the user has disabled session tracking. If
+                // we do not have attribution yet then we wait until it comes in and at that point make the decision
+                // to disable Adjust again.
+                if try hasAttribution() {
+                    if !shouldTrackRetention() {
+                        Logger.browserLogger.info("Adjust - Disabling because sending of usage data is not allowed")
+                        Adjust.setEnabled(false)
+                    }
                 }
             } else {
-                Logger.browserLogger.info("Adjust - Skipping because we have already seen attribution info for this install")
+                Logger.browserLogger.info("Adjust - Skipping because no or invalid config found")
             }
         } catch let error {
-            Logger.browserLogger.error("Adjust - Failed to register application launch: \(error)")
+            Logger.browserLogger.error("Adjust - Disabling because we failed to configure: \(error)")
+            Adjust.setEnabled(false)
         }
     }
 
     /// This is called when Adjust has figured out the attribution. It will call us with a summary
     /// of all the things it knows. Like the campaign ID. We simply save this to a local file so
-    /// that we know we have done a single attribution ping to Adjust. This is also used to prevent
-    /// sending data to adjust multiple times.
+    /// that we know we have done a single attribution ping to Adjust.
     ///
-    /// We also disable Adjust here, otherwise it keeps sending session pings until the app is cold
-    /// started again.
+    /// Here we also disable Adjust based on the Send Anonymous Usage Data setting.
 
     func adjustAttributionChanged(attribution: ADJAttribution!) {
         do {
-            Adjust.setEnabled(false)
-            try AdjustIntegration.sharedInstance.saveAttribution(attribution)
+            Logger.browserLogger.info("Adjust - Saving attribution info to disk")
+            try saveAttribution(attribution)
         } catch let error {
             Logger.browserLogger.error("Adjust - Failed to save attribution: \(error)")
         }
+        // Keep Adjust enabled only if the user has allowed this
+        if shouldTrackRetention() {
+            Logger.browserLogger.info("Adjust - Enabling because user allows anonymous usage data collection")
+            Adjust.setEnabled(true)
+        } else {
+            Logger.browserLogger.info("Adjust - Disabling because user does not allow anonymous usage data collection")
+            Adjust.setEnabled(false)
+        }
+    }
+
+    /// This is called from the Settings screen. The settings screen will remember the choice in the
+    /// profile and then use this method to disable or enable Adjust.
+    
+    static func setEnabled(enabled: Bool) {
+        Adjust.setEnabled(enabled)
     }
 }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var rootViewController: UINavigationController!
     weak var profile: BrowserProfile?
     var tabManager: TabManager!
+    var adjustIntegration: AdjustIntegration?
 
     weak var application: UIApplication?
     var launchOptions: [NSObject: AnyObject]?
@@ -126,6 +127,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let localNotification = launchOptions?[UIApplicationLaunchOptionsLocalNotificationKey] as? UILocalNotification {
             viewURLInNewTab(localNotification)
         }
+        
+        adjustIntegration = AdjustIntegration(profile: profile)
 
         log.debug("Done with setting up the application.")
         return true
@@ -162,15 +165,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.profile = p
         return p
     }
-
+    
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         var shouldPerformAdditionalDelegateHandling = true
 
         log.debug("Did finish launching.")
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
-            AdjustIntegration.sharedInstance.triggerApplicationDidFinishLaunchingWithOptions(launchOptions)
-        }
+        
+        log.debug("Setting up Adjust")
+        self.adjustIntegration?.triggerApplicationDidFinishLaunchingWithOptions(launchOptions)
+        
         log.debug("Making window key and visible…")
         self.window!.makeKeyAndVisible()
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -394,6 +394,25 @@ class SendFeedbackSetting: Setting {
     }
 }
 
+class SendAnonymousUsageDataSetting: BoolSetting {
+    init(prefs: Prefs, delegate: SettingsDelegate?) {
+        super.init(
+            prefs: prefs, prefKey: "settings.sendUsageData", defaultValue: true,
+            attributedTitleText: NSAttributedString(string: NSLocalizedString("Send Anonymous Usage Data", tableName: "SendAnonymousUsageData", comment: "See http://bit.ly/1SmEXU1")),
+            attributedStatusText: NSAttributedString(string: NSLocalizedString("More Info…", tableName: "SendAnonymousUsageData", comment: "See http://bit.ly/1SmEXU1"), attributes: [NSForegroundColorAttributeName: UIColor.blueColor()]),
+            settingDidChange: { AdjustIntegration.setEnabled($0) }
+        )
+    }
+
+    override var url: NSURL? {
+        return SupportUtils.URLForTopic("adjust")
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
 // Opens the the SUMO page in a new tab
 class OpenSupportPageSetting: Setting {
     init(delegate: SettingsDelegate?) {

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -110,6 +110,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
             SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
                 ShowIntroductionSetting(settings: self),
                 SendFeedbackSetting(),
+                SendAnonymousUsageDataSetting(prefs: prefs, delegate: settingsDelegate),
                 OpenSupportPageSetting(delegate: settingsDelegate),
             ]),
             SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -124,23 +124,27 @@ class BoolSetting: Setting {
     private let prefs: Prefs
     private let defaultValue: Bool
     private let settingDidChange: ((Bool) -> Void)?
-    private let statusText: String?
+    private let statusText: NSAttributedString?
 
-    init(prefs: Prefs, prefKey: String, defaultValue: Bool, titleText: String, statusText: String? = nil, settingDidChange: ((Bool) -> Void)? = nil) {
+    init(prefs: Prefs, prefKey: String, defaultValue: Bool, attributedTitleText: NSAttributedString, attributedStatusText: NSAttributedString? = nil, settingDidChange: ((Bool) -> Void)? = nil) {
         self.prefs = prefs
         self.prefKey = prefKey
         self.defaultValue = defaultValue
         self.settingDidChange = settingDidChange
-        self.statusText = statusText
-        super.init(title: NSAttributedString(string: titleText, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+        self.statusText = attributedStatusText
+        super.init(title: attributedTitleText)
+    }
+
+    convenience init(prefs: Prefs, prefKey: String, defaultValue: Bool, titleText: String, statusText: String? = nil, settingDidChange: ((Bool) -> Void)? = nil) {
+        var statusTextAttributedString: NSAttributedString?
+        if let statusTextString = statusText {
+            statusTextAttributedString = NSAttributedString(string: statusTextString, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
+        }
+        self.init(prefs: prefs, prefKey: prefKey, defaultValue: defaultValue, attributedTitleText: NSAttributedString(string: titleText, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]), attributedStatusText: statusTextAttributedString, settingDidChange: settingDidChange)
     }
 
     override var status: NSAttributedString? {
-        if let text = statusText {
-            return NSAttributedString(string: text, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
-        } else {
-            return nil
-        }
+        return statusText
     }
 
     override func onConfigureCell(cell: UITableViewCell) {

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -86,10 +86,6 @@ private struct TempStrings {
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
     let accessLogins            = NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")
-
-    // Bug 1235840 - Land string for opting out of anonymous data usage sending
-    let sendAnonymousUsageData = NSLocalizedString("Send Anonymous Usage Data", tableName: "SendAnonymousUsageData", comment: "See http://bit.ly/1SmEXU1")
-    let moreInfo = NSLocalizedString("More Info…", tableName: "SendAnonymousUsageData", comment: "See http://bit.ly/1SmEXU1")
 }
 
 /// Old strings that will be removed when we kill 1.0. We need to keep them around for now for l10n export.

--- a/SharedTests/SupportUtilsTests.swift
+++ b/SharedTests/SupportUtilsTests.swift
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import XCTest
+
+class SupportUtilsTests: XCTestCase {
+    func testURLForTopic() {
+        let appVersion = AppInfo.appVersion
+        let localeIdentifier = NSLocale.currentLocale().localeIdentifier
+        XCTAssertEqual(SupportUtils.URLForTopic("Bacon")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/Bacon")
+        XCTAssertEqual(SupportUtils.URLForTopic("Cheese & Crackers")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/Cheese%20&%20Crackers")
+        XCTAssertEqual(SupportUtils.URLForTopic("Möbelträgerfüße")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/M%C3%B6beltr%C3%A4gerf%C3%BC%C3%9Fe")
+    }
+}

--- a/Utils/SupportUtils.swift
+++ b/Utils/SupportUtils.swift
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// Utility functions related to SUMO.
+public struct SupportUtils {
+    /// Construct a NSURL pointing to a specific topic on SUMO. The topic should be a non-escaped string. It will
+    /// be properly escaped by this function.
+    ///
+    /// The resulting NSURL will include the app version, operating system and locale code. For example, a topic
+    /// "cheese" will be turned into a link that looks like https://support.mozilla.org/1/mobile/2.0/iOS/en-US/cheese
+    public static func URLForTopic(topic: String) -> NSURL? {
+        guard let escapedTopic = topic.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLPathAllowedCharacterSet()) else {
+            return nil
+        }
+        return NSURL(string: "https://support.mozilla.org/1/mobile/\(AppInfo.appVersion)/iOS/\(NSLocale.currentLocale().localeIdentifier)/\(escapedTopic)")
+    }
+}


### PR DESCRIPTION
This patch enabled retention tracking for Adjust. It also introduces a new *Send Anonymous Usage Data* setting which is used to disable the retention tracking.

There are three parts to this patch:

1. I was manually creating links to `support.mozilla.org`. These links have a standard format. So I introduced a `SupportUtils` class with a `linkForTopic()` function in it.
2. The `AdjustIntegration` class now understands it also needs to enable retention tracking.
3. New setting to disable *Send Anonymous Usage Data*.

Couple of things to note:

* Previously, we would run the Adjust startup code in a `dispatch_async` block. I have removed that because the Adjust code expects to run from the main thread and also because I have measured the time it takes to start it up, which is just a few milliseconds and actually **less** than doing it via `dispatch_async`.
* The `AdjustIntegration` class used to be a singleton. Now it is simply owned by the `AppDelegate`. This is because it needs to be initialized with the `Profile`, so that it can get to the settings.
* There is still some debug logging, which I would like to keep until we know this code is all good.