### PR TITLE
Bug 1239072 - Authentication Settings + Settings Refactor

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -566,6 +566,9 @@
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E68B437C1C08A875002D2D76 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E68B43751C08A724002D2D76 /* SnapKit.framework */; };
 		E68B437D1C08A888002D2D76 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E68B43751C08A724002D2D76 /* SnapKit.framework */; };
+		E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */; };
+		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
+		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
 		E695D8651C037E9F00D3FCCE /* FSUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E695D8631C037E9F00D3FCCE /* FSUtils.h */; };
 		E695D8661C037E9F00D3FCCE /* FSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E695D8641C037E9F00D3FCCE /* FSUtils.m */; };
 		E695D8681C03804F00D3FCCE /* FSUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */; };
@@ -1791,6 +1794,9 @@
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
 		E68B436D1C08A724002D2D76 /* SnapKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SnapKit.xcodeproj; path = Carthage/Checkouts/SnapKit/SnapKit.xcodeproj; sourceTree = "<group>"; };
+		E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsTableViewController.swift; sourceTree = "<group>"; };
+		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
+		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
 		E695D8631C037E9F00D3FCCE /* FSUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSUtils.h; sourceTree = "<group>"; };
 		E695D8641C037E9F00D3FCCE /* FSUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSUtils.m; sourceTree = "<group>"; };
 		E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSUtilsTests.swift; sourceTree = "<group>"; };
@@ -2287,8 +2293,10 @@
 		2F44FC551A9E83E200FD20CC /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */,
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
 				2F44FCC41A9E85E900FD20CC /* SettingsTableViewController.swift */,
+				E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */,
 				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
 				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
@@ -3048,6 +3056,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		E692E3271C46E62D009D1240 /* AuthenticationManager */ = {
+			isa = PBXGroup;
+			children = (
+				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
+			);
+			path = AuthenticationManager;
+			sourceTree = "<group>";
+		};
 		E699220D1B94E3EF007C480D /* About */ = {
 			isa = PBXGroup;
 			children = (
@@ -3249,6 +3265,7 @@
 			isa = PBXGroup;
 			children = (
 				2816EFFF1B33E05400522243 /* UIConstants.swift */,
+				E692E3271C46E62D009D1240 /* AuthenticationManager */,
 				D3A994941A368691008AD1AC /* Browser */,
 				7B0B1B9C1C1B69F500DF4AB5 /* Extensions */,
 				F84B22211A09122500AAB793 /* Home */,
@@ -4781,9 +4798,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
 				39C5750E1BE28BAE00E1C4B1 /* OnePasswordExtension.h in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
 				39C5750F1BE28BAE00E1C4B1 /* OnePasswordExtension.m in Sources */,
+				E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */,
 				7B3631EA1C244FEE00D12AF9 /* Theme.swift in Sources */,
 				E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */,
 				E4CD9F6D1A77DD2800318571 /* ReaderModeStyleViewController.swift in Sources */,
@@ -4917,6 +4936,7 @@
 				7B844E3D1BBDDB9D00E733A2 /* ChevronView.swift in Sources */,
 				D38B2D491A8D96D00040E6B5 /* GCDWebServerDataResponse.m in Sources */,
 				E4C358551AF144BA00299F7E /* FSReadingList.m in Sources */,
+				E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */,
 				E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */,
 				E4B334571BBF2393004E2BFF /* ADJConfig.m in Sources */,
 				D38B2D521A8D96D00040E6B5 /* GCDWebServerStreamedResponse.m in Sources */,

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+
+private let ImmediatelyInSeconds: Int32 = 0
+private let OneMinuteInSeconds: Int32 = 1 * 60
+private let FiveMinutesInSeconds: Int32 = 5 * 60
+private let TenMinutesInSeconds: Int32 = 10 * 60
+private let FifteenMinutesInSeconds: Int32 = 15 * 60
+private let OneHourInSeconds: Int32 = 1 * 60 * 60
+
+private let PrefKeyTouchIDEnabled = "authentication.touchIDEnabled"
+private let PrefKeyRequirePasscodeInterval = "authentication.requirePasscodeInterval"
+
+private extension NSAttributedString {
+    static func rowTitle(string: String) -> NSAttributedString {
+        return NSAttributedString(string: string, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    static func disabledRowTitle(string: String) -> NSAttributedString {
+        return NSAttributedString(string: string, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewDisabledRowTextColor])
+    }
+}
+
+class TurnPasscodeOnSetting: Setting {
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
+        let title = NSLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Title for setting to turn on passcode")
+        super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+                   delegate: delegate)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        // Navigate to passcode configuration screen
+    }
+}
+
+class TurnPasscodeOffSetting: Setting {
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
+        let title = NSLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Title for setting to turn off passcode")
+        super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+                   delegate: delegate)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        // Navigate to passcode configuration screen
+    }
+}
+
+class ChangePasscodeSetting: Setting {
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, enabled: Bool) {
+        let title = NSLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Title for setting to change passcode")
+        let attributedTitle = (enabled ?? true) ? NSAttributedString.rowTitle(title) : NSAttributedString.disabledRowTitle(title)
+        super.init(title: attributedTitle,
+                   delegate: delegate,
+                   enabled: enabled)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        // Navigate to passcode configuration screen
+    }
+}
+
+class RequirePasscodeSetting: Setting {
+    private let intervalLookup = [
+        ImmediatelyInSeconds:       NSLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode"),
+        OneMinuteInSeconds:         NSLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode"),
+        FiveMinutesInSeconds:       NSLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode"),
+        TenMinutesInSeconds:        NSLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode"),
+        FifteenMinutesInSeconds:    NSLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode"),
+        OneHourInSeconds:           NSLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode"),
+    ]
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var style: UITableViewCellStyle { return .Value1 }
+
+    override var status: NSAttributedString {
+        if let interval = requireInterval, intervalTitle = intervalLookup[interval] {
+            return NSAttributedString(string: intervalTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        }
+        return NSAttributedString(string: "")
+    }
+
+    private var requireInterval: Int32?
+
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, requireInterval: Int32? = nil, enabled: Bool? = nil) {
+        let title = NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Title for setting to require a passcode")
+        let attributedTitle = (enabled ?? true) ? NSAttributedString.rowTitle(title) : NSAttributedString.disabledRowTitle(title)
+        super.init(title: attributedTitle,
+                   delegate: delegate,
+                   enabled: enabled)
+        self.requireInterval = requireInterval
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        // Navigate to passcode configuration screen
+    }
+}
+
+class AuthenticationSettingsViewController: SettingsTableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.title = NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+
+        if true {
+            return passcodeEnabledSettings()
+        } else {
+            return passcodeDisabledSettings()
+        }
+    }
+
+    private func passcodeEnabledSettings() -> [SettingSection] {
+        var settings = [SettingSection]()
+
+        let passcodeSectionTitle = NSAttributedString(string: NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings"))
+        let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
+            TurnPasscodeOffSetting(settings: self),
+            ChangePasscodeSetting(settings: self, delegate: nil, enabled: true)
+        ])
+
+        let prefs = profile.prefs
+        let requirePasscodeSection = SettingSection(title: nil, children: [
+            RequirePasscodeSetting(settings: self),
+            BoolSetting(prefs: prefs,
+                prefKey: "touchid.logins",
+                defaultValue: false,
+                titleText: NSLocalizedString("Use Touch ID", tableName:  "AuthenticationManager", comment: "List section title for when to use Touch ID")
+            ),
+        ])
+
+        settings += [
+            passcodeSection,
+            requirePasscodeSection,
+        ]
+
+        return settings
+    }
+
+    private func passcodeDisabledSettings() -> [SettingSection] {
+        var settings = [SettingSection]()
+
+        let passcodeSectionTitle = NSAttributedString(string: NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings"))
+        let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
+            TurnPasscodeOnSetting(settings: self),
+            ChangePasscodeSetting(settings: self, delegate: nil, enabled: false)
+        ])
+
+        let prefs = profile.prefs
+        let requirePasscodeSection = SettingSection(title: nil, children: [
+            RequirePasscodeSetting(settings: self, delegate: nil, requireInterval: profile.prefs.intForKey(PrefKeyRequirePasscodeInterval), enabled: false),
+        ])
+
+        settings += [
+            passcodeSection,
+            requirePasscodeSection,
+        ]
+
+        return settings
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2349,7 +2349,7 @@ extension BrowserViewController: IntroViewControllerDelegate {
         // Show the settings page if we have already signed in. If we haven't then show the signin page
         let vcToPresent: UIViewController
         if profile.hasAccount() {
-            let settingsTableViewController = SettingsTableViewController()
+            let settingsTableViewController = AppSettingsTableViewController()
             settingsTableViewController.profile = profile
             settingsTableViewController.tabManager = tabManager
             vcToPresent = settingsTableViewController

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -439,7 +439,7 @@ class TabTrayController: UIViewController {
     }
 
     func SELdidClickSettingsItem() {
-        let settingsTableViewController = SettingsTableViewController()
+        let settingsTableViewController = AppSettingsTableViewController()
         settingsTableViewController.profile = profile
         settingsTableViewController.tabManager = tabManager
         settingsTableViewController.settingsDelegate = self

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1,0 +1,542 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import Account
+
+// This file contains all of the settings available in the main settings screen of the app.
+
+private var ShowDebugSettings: Bool = false
+private var DebugSettingsClickCount: Int = 0
+
+// For great debugging!
+class HiddenSetting: Setting {
+    let settings: SettingsTableViewController
+
+    init(settings: SettingsTableViewController) {
+        self.settings = settings
+        super.init(title: nil)
+    }
+
+    override var hidden: Bool {
+        return !ShowDebugSettings
+    }
+}
+
+// Sync setting for connecting a Firefox Account.  Shown when we don't have an account.
+class ConnectSetting: WithoutAccountSetting {
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Sign In", comment: "Text message / button in the settings table view"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = FxAContentViewController()
+        viewController.delegate = self
+        viewController.url = settings.profile.accountConfiguration.signInURL
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+// Sync setting for disconnecting a Firefox Account.  Shown when we have an account.
+class DisconnectSetting: WithAccountSetting {
+    override var accessoryType: UITableViewCellAccessoryType { return .None }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account"), attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let alertController = UIAlertController(
+            title: NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert"),
+            message: NSLocalizedString("Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Text of the 'log out firefox account' alert"),
+            preferredStyle: UIAlertControllerStyle.Alert)
+        alertController.addAction(
+            UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button in the 'log out firefox account' alert"), style: .Cancel) { (action) in
+                // Do nothing.
+            })
+        alertController.addAction(
+            UIAlertAction(title: NSLocalizedString("Log Out", comment: "Disconnect button in the 'log out firefox account' alert"), style: .Destructive) { (action) in
+                self.settings.profile.removeAccount()
+            })
+        navigationController?.presentViewController(alertController, animated: true, completion: nil)
+    }
+}
+
+class SyncNowSetting: WithAccountSetting {
+    private lazy var timestampFormatter: NSDateFormatter = {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    private let syncNowTitle = NSAttributedString(string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.blackColor(), NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+
+    private let syncingTitle = NSAttributedString(string: NSLocalizedString("Syncing…", comment: "Syncing Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+
+    override var accessoryType: UITableViewCellAccessoryType { return .None }
+
+    override var style: UITableViewCellStyle { return .Value1 }
+
+    override var title: NSAttributedString? {
+        return profile.syncManager.isSyncing ? syncingTitle : syncNowTitle
+    }
+
+    override var status: NSAttributedString? {
+        guard let timestamp = profile.syncManager.lastSyncFinishTime else {
+            return nil
+        }
+
+        let formattedLabel = timestampFormatter.stringFromDate(NSDate.fromTimestamp(timestamp))
+        let attributedString = NSMutableAttributedString(string: formattedLabel)
+        let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
+        let range = NSMakeRange(0, attributedString.length)
+        attributedString.setAttributes(attributes, range: range)
+        return attributedString
+    }
+
+    override func onConfigureCell(cell: UITableViewCell) {
+        cell.textLabel?.attributedText = title
+        cell.detailTextLabel?.attributedText = status
+        cell.accessoryType = accessoryType
+        cell.accessoryView = nil
+        cell.userInteractionEnabled = !profile.syncManager.isSyncing
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        profile.syncManager.syncEverything()
+    }
+}
+
+// Sync setting that shows the current Firefox Account status.
+class AccountStatusSetting: WithAccountSetting {
+    override var accessoryType: UITableViewCellAccessoryType {
+        if let account = profile.getAccount() {
+            switch account.actionNeeded {
+            case .NeedsVerification:
+                // We link to the resend verification email page.
+                return .DisclosureIndicator
+            case .NeedsPassword:
+                 // We link to the re-enter password page.
+                return .DisclosureIndicator
+            case .None, .NeedsUpgrade:
+                // In future, we'll want to link to /settings and an upgrade page, respectively.
+                return .None
+            }
+        }
+        return .DisclosureIndicator
+    }
+
+    override var title: NSAttributedString? {
+        if let account = profile.getAccount() {
+            return NSAttributedString(string: account.email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+        }
+        return nil
+    }
+
+    override var status: NSAttributedString? {
+        if let account = profile.getAccount() {
+            switch account.actionNeeded {
+            case .None:
+                return nil
+            case .NeedsVerification:
+                return NSAttributedString(string: NSLocalizedString("Verify your email address.", comment: "Text message in the settings table view"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+            case .NeedsPassword:
+                let string = NSLocalizedString("Enter your password to connect.", comment: "Text message in the settings table view")
+                let range = NSRange(location: 0, length: string.characters.count)
+                let orange = UIColor(red: 255.0 / 255, green: 149.0 / 255, blue: 0.0 / 255, alpha: 1)
+                let attrs = [NSForegroundColorAttributeName : orange]
+                let res = NSMutableAttributedString(string: string)
+                res.setAttributes(attrs, range: range)
+                return res
+            case .NeedsUpgrade:
+                let string = NSLocalizedString("Upgrade Firefox to connect.", comment: "Text message in the settings table view")
+                let range = NSRange(location: 0, length: string.characters.count)
+                let orange = UIColor(red: 255.0 / 255, green: 149.0 / 255, blue: 0.0 / 255, alpha: 1)
+                let attrs = [NSForegroundColorAttributeName : orange]
+                let res = NSMutableAttributedString(string: string)
+                res.setAttributes(attrs, range: range)
+                return res
+            }
+        }
+        return nil
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = FxAContentViewController()
+        viewController.delegate = self
+
+        if let account = profile.getAccount() {
+            switch account.actionNeeded {
+            case .NeedsVerification:
+                let cs = NSURLComponents(URL: account.configuration.settingsURL, resolvingAgainstBaseURL: false)
+                cs?.queryItems?.append(NSURLQueryItem(name: "email", value: account.email))
+                viewController.url = cs?.URL
+            case .NeedsPassword:
+                let cs = NSURLComponents(URL: account.configuration.forceAuthURL, resolvingAgainstBaseURL: false)
+                cs?.queryItems?.append(NSURLQueryItem(name: "email", value: account.email))
+                viewController.url = cs?.URL
+            case .None, .NeedsUpgrade:
+                // In future, we'll want to link to /settings and an upgrade page, respectively.
+                return
+            }
+        }
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+// For great debugging!
+class RequirePasswordDebugSetting: WithAccountSetting {
+    override var hidden: Bool {
+        if !ShowDebugSettings {
+            return true
+        }
+        if let account = profile.getAccount() where account.actionNeeded != FxAActionNeeded.NeedsPassword {
+            return false
+        }
+        return true
+    }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: require password", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        profile.getAccount()?.makeSeparated()
+        settings.tableView.reloadData()
+    }
+}
+
+
+// For great debugging!
+class RequireUpgradeDebugSetting: WithAccountSetting {
+    override var hidden: Bool {
+        if !ShowDebugSettings {
+            return true
+        }
+        if let account = profile.getAccount() where account.actionNeeded != FxAActionNeeded.NeedsUpgrade {
+            return false
+        }
+        return true
+    }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: require upgrade", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        profile.getAccount()?.makeDoghouse()
+        settings.tableView.reloadData()
+    }
+}
+
+// For great debugging!
+class ForgetSyncAuthStateDebugSetting: WithAccountSetting {
+    override var hidden: Bool {
+        if !ShowDebugSettings {
+            return true
+        }
+        if let _ = profile.getAccount() {
+            return false
+        }
+        return true
+    }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Debug: forget Sync auth state", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        profile.getAccount()?.syncAuthState.invalidate()
+        settings.tableView.reloadData()
+    }
+}
+
+
+class DeleteExportedDataSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        // Not localized for now.
+        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
+        let fileManager = NSFileManager.defaultManager()
+        do {
+            let files = try fileManager.contentsOfDirectoryAtPath(documentsPath)
+            for file in files {
+                if file.startsWith("browser.") || file.startsWith("logins.") {
+                    try fileManager.removeItemInDirectory(documentsPath, named: file)
+                }
+            }
+        } catch {
+            print("Couldn't delete exported data: \(error).")
+        }
+    }
+}
+
+class ExportBrowserDataSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        // Not localized for now.
+        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
+        do {
+            let log = Logger.syncLogger
+            try self.settings.profile.files.copyMatching(fromRelativeDirectory: "", toAbsoluteDirectory: documentsPath) { file in
+                log.debug("Matcher: \(file)")
+                return file.startsWith("browser.") || file.startsWith("logins.")
+            }
+        } catch {
+            print("Couldn't export browser data: \(error).")
+        }
+    }
+}
+
+// Show the current version of Firefox
+class VersionSetting : Setting {
+    let settings: SettingsTableViewController
+
+    init(settings: SettingsTableViewController) {
+        self.settings = settings
+        super.init(title: nil)
+    }
+
+    override var title: NSAttributedString? {
+        let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+        let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as! String
+        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), appVersion, buildNumber), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.selectionStyle = .None
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        if AppConstants.BuildChannel != .Aurora {
+            DebugSettingsClickCount += 1
+            if DebugSettingsClickCount >= 5 {
+                DebugSettingsClickCount = 0
+                ShowDebugSettings = !ShowDebugSettings
+                settings.tableView.reloadData()
+            }
+        }
+    }
+}
+
+// Opens the the license page in a new tab
+class LicenseAndAcknowledgementsSetting: Setting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var url: NSURL? {
+        return NSURL(string: WebServer.sharedInstance.URLForResource("license", module: "about"))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
+// Opens about:rights page in the content view controller
+class YourRightsSetting: Setting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Your Rights", comment: "Your Rights settings section title"), attributes:
+            [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var url: NSURL? {
+        return NSURL(string: "https://www.mozilla.org/about/legal/terms/firefox/")
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
+// Opens the on-boarding screen again
+class ShowIntroductionSetting: Setting {
+    let profile: Profile
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(title: NSAttributedString(string: NSLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        navigationController?.dismissViewControllerAnimated(true, completion: {
+            if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
+                appDelegate.browserViewController.presentIntroViewController(true)
+            }
+        })
+    }
+}
+
+class SendFeedbackSetting: Setting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Send Feedback", comment: "Show an input.mozilla.org page where people can submit feedback"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var url: NSURL? {
+        let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+        return NSURL(string: "https://input.mozilla.org/feedback/fxios/\(appVersion)")
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
+// Opens the the SUMO page in a new tab
+class OpenSupportPageSetting: Setting {
+    init(delegate: SettingsDelegate?) {
+        super.init(title: NSAttributedString(string: NSLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+            delegate: delegate)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        navigationController?.dismissViewControllerAnimated(true) {
+            if let url = NSURL(string: "https://support.mozilla.org/products/ios") {
+                self.delegate?.settingsOpenURLInNewTab(url)
+            }
+        }
+    }
+}
+
+// Opens the search settings pane
+class SearchSetting: Setting {
+    let profile: Profile
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var style: UITableViewCellStyle { return .Value1 }
+
+    override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine.shortName) }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        super.init(title: NSAttributedString(string: NSLocalizedString("Search", comment: "Open search section of settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = SearchSettingsTableViewController()
+        viewController.model = profile.searchEngines
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+class LoginsSetting: Setting {
+    let profile: Profile
+    var tabManager: TabManager!
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate?) {
+        self.profile = settings.profile
+        self.tabManager = settings.tabManager
+
+        let loginsTitle = NSLocalizedString("Logins", comment: "Label used as an item in Settings. When touched, the user will be navigated to the Logins/Password manager.")
+        super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+                   delegate: delegate)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = LoginListViewController(profile: profile)
+        viewController.settingsDelegate = delegate
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+class TouchIDPasscodeSetting: Setting {
+    let profile: Profile
+    var tabManager: TabManager!
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
+        self.profile = settings.profile
+        self.tabManager = settings.tabManager
+
+        let title = NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
+        super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
+                   delegate: delegate)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = AuthenticationSettingsViewController()
+        viewController.profile = profile
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+class ClearPrivateDataSetting: Setting {
+    let profile: Profile
+    var tabManager: TabManager!
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        self.tabManager = settings.tabManager
+
+        let clearTitle = NSLocalizedString("Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
+        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = ClearPrivateDataTableViewController()
+        viewController.profile = profile
+        viewController.tabManager = tabManager
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+class PrivacyPolicySetting: Setting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: NSLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var url: NSURL? {
+        return NSURL(string: "https://www.mozilla.org/privacy/firefox/")
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController)
+    }
+}
+
+class ChinaSyncServiceSetting: WithoutAccountSetting {
+    override var accessoryType: UITableViewCellAccessoryType { return .None }
+    var prefs: Prefs { return settings.profile.prefs }
+    let prefKey = "useChinaSyncService"
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "本地同步服务", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
+    }
+
+    override var status: NSAttributedString? {
+        return NSAttributedString(string: "本地服务使用火狐通行证同步数据", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
+    }
+
+    override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        let control = UISwitch()
+        control.onTintColor = UIConstants.ControlTintColor
+        control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
+        control.on = prefs.boolForKey(prefKey) ?? true
+        cell.accessoryView = control
+        cell.selectionStyle = .None
+    }
+
+    @objc func switchValueChanged(toggle: UISwitch) {
+        prefs.setObject(toggle.on, forKey: prefKey)
+    }
+}
+

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+import Shared
+import Account
+
+/// App Settings Screen (triggered by tapping the 'Gear' in the Tab Tray Controller)
+class AppSettingsTableViewController: SettingsTableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = NSLocalizedString("Settings", comment: "Settings")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: NSLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar"),
+            style: UIBarButtonItemStyle.Done,
+            target: navigationController, action: "SELdone")
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        var settings = [SettingSection]()
+
+        let privacyTitle = NSLocalizedString("Privacy", comment: "Privacy section title")
+        let accountDebugSettings: [Setting]
+        if AppConstants.BuildChannel != .Aurora {
+            accountDebugSettings = [
+                // Debug settings:
+                RequirePasswordDebugSetting(settings: self),
+                RequireUpgradeDebugSetting(settings: self),
+                ForgetSyncAuthStateDebugSetting(settings: self),
+            ]
+        } else {
+            accountDebugSettings = []
+        }
+
+        let prefs = profile.prefs
+        var generalSettings = [
+            SearchSetting(settings: self),
+            BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
+                titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),
+            BoolSetting(prefs: prefs, prefKey: "saveLogins", defaultValue: true,
+                titleText: NSLocalizedString("Save Logins", comment: "Setting to enable the built-in password manager")),
+        ]
+
+        let accountChinaSyncSetting: [Setting]
+        let locale = NSLocale.currentLocale()
+        if locale.localeIdentifier != "zh_CN" {
+            accountChinaSyncSetting = []
+        } else {
+            accountChinaSyncSetting = [
+                // Show China sync service setting:
+                ChinaSyncServiceSetting(settings: self)
+            ]
+        }
+        // There is nothing to show in the Customize section if we don't include the compact tab layout
+        // setting on iPad. When more options are added that work on both device types, this logic can
+        // be changed.
+        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
+            generalSettings +=  [
+                BoolSetting(prefs: prefs, prefKey: "CompactTabLayout", defaultValue: true,
+                    titleText: NSLocalizedString("Use Compact Tabs", comment: "Setting to enable compact tabs in the tab overview"))
+            ]
+        }
+
+        settings += [
+            SettingSection(title: nil, children: [
+                // Without a Firefox Account:
+                ConnectSetting(settings: self),
+                // With a Firefox Account:
+                AccountStatusSetting(settings: self),
+                SyncNowSetting(settings: self)
+            ] + accountChinaSyncSetting + accountDebugSettings),
+            SettingSection(title: NSAttributedString(string: NSLocalizedString("General", comment: "General settings section title")), children: generalSettings)
+        ]
+
+        var privacySettings = [Setting]()
+        if AppConstants.MOZ_LOGIN_MANAGER {
+            privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
+        }
+
+        if AppConstants.MOZ_AUTHENTICATION_MANAGER {
+            privacySettings.append(TouchIDPasscodeSetting(settings: self))
+        }
+
+        privacySettings.append(ClearPrivateDataSetting(settings: self))
+
+        if #available(iOS 9, *) {
+            privacySettings += [
+                BoolSetting(prefs: prefs,
+                    prefKey: "settings.closePrivateTabs",
+                    defaultValue: false,
+                    titleText: NSLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs"),
+                    statusText: NSLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'"))
+            ]
+        }
+
+        privacySettings += [
+            BoolSetting(prefs: prefs, prefKey: "crashreports.send.always", defaultValue: false,
+                titleText: NSLocalizedString("Send Crash Reports", comment: "Setting to enable the sending of crash reports"),
+                settingDidChange: { configureActiveCrashReporter($0) }),
+            PrivacyPolicySetting()
+        ]
+
+
+        settings += [
+            SettingSection(title: NSAttributedString(string: privacyTitle), children: privacySettings),
+            SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
+                ShowIntroductionSetting(settings: self),
+                SendFeedbackSetting(),
+                OpenSupportPageSetting(delegate: settingsDelegate),
+            ]),
+            SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [
+                VersionSetting(settings: self),
+                LicenseAndAcknowledgementsSetting(),
+                YourRightsSetting(),
+                DisconnectSetting(settings: self),
+                ExportBrowserDataSetting(settings: self),
+                DeleteExportedDataSetting(settings: self),
+            ])
+        ]
+
+        return settings
+    }
+
+    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        // Make account/sign-in and close private tabs rows taller, as per design specs.
+        let section = settings[indexPath.section]
+        if let setting = section[indexPath.row] as? BoolSetting where setting.prefKey == "settings.closePrivateTabs" {
+            return 64
+        } else if section[indexPath.row] is ConnectSetting {
+            return 64
+        }
+
+        return super.tableView(tableView, heightForRowAtIndexPath: indexPath)
+    }
+}

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -8,8 +8,6 @@ import Shared
 import UIKit
 import XCGLogger
 
-private var ShowDebugSettings: Bool = false
-private var DebugSettingsClickCount: Int = 0
 
 // The following are only here because we use master for L10N and otherwise these strings would disappear from the v1.0 release
 private let Bug1204635_S1 = NSLocalizedString("Clear Everything", tableName: "ClearPrivateData", comment: "Title of the Clear private data dialog.")
@@ -54,12 +52,15 @@ class Setting {
 
     var accessoryType: UITableViewCellAccessoryType { return .None }
 
+    private(set) var enabled: Bool = true
+
     // Called when the cell is setup. Call if you need the default behaviour.
     func onConfigureCell(cell: UITableViewCell) {
         cell.detailTextLabel?.attributedText = status
         cell.textLabel?.attributedText = title
         cell.accessoryType = accessoryType
         cell.accessoryView = nil
+        cell.selectionStyle = enabled ? .Default : .None
     }
 
     // Called when the pref is tapped.
@@ -75,9 +76,10 @@ class Setting {
         }
     }
 
-    init(title: NSAttributedString? = nil, delegate: SettingsDelegate? = nil) {
+    init(title: NSAttributedString? = nil, delegate: SettingsDelegate? = nil, enabled: Bool? = nil) {
         self._title = title
         self.delegate = delegate
+        self.enabled = enabled ?? true
     }
 }
 
@@ -117,7 +119,8 @@ class SettingSection : Setting {
 // A helper class for settings with a UISwitch.
 // Takes and optional settingsDidChange callback and status text.
 class BoolSetting: Setting {
-    private let prefKey: String
+    let prefKey: String
+
     private let prefs: Prefs
     private let defaultValue: Bool
     private let settingDidChange: ((Bool) -> Void)?
@@ -157,7 +160,7 @@ class BoolSetting: Setting {
 
 // A helper class for prefs that deal with sync. Handles reloading the tableView data if changes to
 // the fxAccount happen.
-private class AccountSetting: Setting, FxAContentViewControllerDelegate {
+class AccountSetting: Setting, FxAContentViewControllerDelegate {
     unowned var settings: SettingsTableViewController
 
     var profile: Profile {
@@ -171,7 +174,7 @@ private class AccountSetting: Setting, FxAContentViewControllerDelegate {
         super.init(title: nil)
     }
 
-    private override func onConfigureCell(cell: UITableViewCell) {
+    override func onConfigureCell(cell: UITableViewCell) {
         super.onConfigureCell(cell)
         if settings.profile.getAccount() != nil {
             cell.selectionStyle = .None
@@ -205,527 +208,12 @@ private class AccountSetting: Setting, FxAContentViewControllerDelegate {
     }
 }
 
-private class WithAccountSetting: AccountSetting {
+class WithAccountSetting: AccountSetting {
     override var hidden: Bool { return !profile.hasAccount() }
 }
 
-private class WithoutAccountSetting: AccountSetting {
+class WithoutAccountSetting: AccountSetting {
     override var hidden: Bool { return profile.hasAccount() }
-}
-
-// Sync setting for connecting a Firefox Account.  Shown when we don't have an account.
-private class ConnectSetting: WithoutAccountSetting {
-    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Sign In", comment: "Text message / button in the settings table view"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let viewController = FxAContentViewController()
-        viewController.delegate = self
-        viewController.url = settings.profile.accountConfiguration.signInURL
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-// Sync setting for disconnecting a Firefox Account.  Shown when we have an account.
-private class DisconnectSetting: WithAccountSetting {
-    override var accessoryType: UITableViewCellAccessoryType { return .None }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Log Out", comment: "Button in settings screen to disconnect from your account"), attributes: [NSForegroundColorAttributeName: UIConstants.DestructiveRed])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let alertController = UIAlertController(
-            title: NSLocalizedString("Log Out?", comment: "Title of the 'log out firefox account' alert"),
-            message: NSLocalizedString("Firefox will stop syncing with your account, but won’t delete any of your browsing data on this device.", comment: "Text of the 'log out firefox account' alert"),
-            preferredStyle: UIAlertControllerStyle.Alert)
-        alertController.addAction(
-            UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button in the 'log out firefox account' alert"), style: .Cancel) { (action) in
-                // Do nothing.
-            })
-        alertController.addAction(
-            UIAlertAction(title: NSLocalizedString("Log Out", comment: "Disconnect button in the 'log out firefox account' alert"), style: .Destructive) { (action) in
-                self.settings.profile.removeAccount()
-                // Refresh, to show that we no longer have an Account immediately.
-                self.settings.SELrefresh()
-            })
-        navigationController?.presentViewController(alertController, animated: true, completion: nil)
-    }
-}
-
-private class SyncNowSetting: WithAccountSetting {
-    private lazy var timestampFormatter: NSDateFormatter = {
-        let formatter = NSDateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }()
-
-    private let syncNowTitle = NSAttributedString(string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.blackColor(), NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
-
-    private let syncingTitle = NSAttributedString(string: NSLocalizedString("Syncing…", comment: "Syncing Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
-
-    override var accessoryType: UITableViewCellAccessoryType { return .None }
-
-    override var style: UITableViewCellStyle { return .Value1 }
-
-    override var title: NSAttributedString? {
-        return profile.syncManager.isSyncing ? syncingTitle : syncNowTitle
-    }
-
-    override var status: NSAttributedString? {
-        guard let timestamp = profile.syncManager.lastSyncFinishTime else {
-            return nil
-        }
-
-        let formattedLabel = timestampFormatter.stringFromDate(NSDate.fromTimestamp(timestamp))
-        let attributedString = NSMutableAttributedString(string: formattedLabel)
-        let attributes = [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)]
-        let range = NSMakeRange(0, attributedString.length)
-        attributedString.setAttributes(attributes, range: range)
-        return attributedString
-    }
-
-    override func onConfigureCell(cell: UITableViewCell) {
-        cell.textLabel?.attributedText = title
-        cell.detailTextLabel?.attributedText = status
-        cell.accessoryType = accessoryType
-        cell.accessoryView = nil
-        cell.userInteractionEnabled = !profile.syncManager.isSyncing
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        profile.syncManager.syncEverything()
-    }
-}
-
-// Sync setting that shows the current Firefox Account status.
-private class AccountStatusSetting: WithAccountSetting {
-    override var accessoryType: UITableViewCellAccessoryType {
-        if let account = profile.getAccount() {
-            switch account.actionNeeded {
-            case .NeedsVerification:
-                // We link to the resend verification email page.
-                return .DisclosureIndicator
-            case .NeedsPassword:
-                 // We link to the re-enter password page.
-                return .DisclosureIndicator
-            case .None, .NeedsUpgrade:
-                // In future, we'll want to link to /settings and an upgrade page, respectively.
-                return .None
-            }
-        }
-        return .DisclosureIndicator
-    }
-
-    override var title: NSAttributedString? {
-        if let account = profile.getAccount() {
-            return NSAttributedString(string: account.email, attributes: [NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFontBold, NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-        }
-        return nil
-    }
-
-    override var status: NSAttributedString? {
-        if let account = profile.getAccount() {
-            switch account.actionNeeded {
-            case .None:
-                return nil
-            case .NeedsVerification:
-                return NSAttributedString(string: NSLocalizedString("Verify your email address.", comment: "Text message in the settings table view"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-            case .NeedsPassword:
-                let string = NSLocalizedString("Enter your password to connect.", comment: "Text message in the settings table view")
-                let range = NSRange(location: 0, length: string.characters.count)
-                let orange = UIColor(red: 255.0 / 255, green: 149.0 / 255, blue: 0.0 / 255, alpha: 1)
-                let attrs = [NSForegroundColorAttributeName : orange]
-                let res = NSMutableAttributedString(string: string)
-                res.setAttributes(attrs, range: range)
-                return res
-            case .NeedsUpgrade:
-                let string = NSLocalizedString("Upgrade Firefox to connect.", comment: "Text message in the settings table view")
-                let range = NSRange(location: 0, length: string.characters.count)
-                let orange = UIColor(red: 255.0 / 255, green: 149.0 / 255, blue: 0.0 / 255, alpha: 1)
-                let attrs = [NSForegroundColorAttributeName : orange]
-                let res = NSMutableAttributedString(string: string)
-                res.setAttributes(attrs, range: range)
-                return res
-            }
-        }
-        return nil
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let viewController = FxAContentViewController()
-        viewController.delegate = self
-
-        if let account = profile.getAccount() {
-            switch account.actionNeeded {
-            case .NeedsVerification:
-                let cs = NSURLComponents(URL: account.configuration.settingsURL, resolvingAgainstBaseURL: false)
-                cs?.queryItems?.append(NSURLQueryItem(name: "email", value: account.email))
-                viewController.url = cs?.URL
-            case .NeedsPassword:
-                let cs = NSURLComponents(URL: account.configuration.forceAuthURL, resolvingAgainstBaseURL: false)
-                cs?.queryItems?.append(NSURLQueryItem(name: "email", value: account.email))
-                viewController.url = cs?.URL
-            case .None, .NeedsUpgrade:
-                // In future, we'll want to link to /settings and an upgrade page, respectively.
-                return
-            }
-        }
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-// For great debugging!
-private class RequirePasswordDebugSetting: WithAccountSetting {
-    override var hidden: Bool {
-        if !ShowDebugSettings {
-            return true
-        }
-        if let account = profile.getAccount() where account.actionNeeded != FxAActionNeeded.NeedsPassword {
-            return false
-        }
-        return true
-    }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: require password", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        profile.getAccount()?.makeSeparated()
-        settings.tableView.reloadData()
-    }
-}
-
-
-// For great debugging!
-private class RequireUpgradeDebugSetting: WithAccountSetting {
-    override var hidden: Bool {
-        if !ShowDebugSettings {
-            return true
-        }
-        if let account = profile.getAccount() where account.actionNeeded != FxAActionNeeded.NeedsUpgrade {
-            return false
-        }
-        return true
-    }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: require upgrade", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        profile.getAccount()?.makeDoghouse()
-        settings.tableView.reloadData()
-    }
-}
-
-// For great debugging!
-private class ForgetSyncAuthStateDebugSetting: WithAccountSetting {
-    override var hidden: Bool {
-        if !ShowDebugSettings {
-            return true
-        }
-        if let _ = profile.getAccount() {
-            return false
-        }
-        return true
-    }
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Debug: forget Sync auth state", comment: "Debug option"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        profile.getAccount()?.syncAuthState.invalidate()
-        settings.tableView.reloadData()
-    }
-}
-
-// For great debugging!
-private class HiddenSetting: Setting {
-    let settings: SettingsTableViewController
-
-    init(settings: SettingsTableViewController) {
-        self.settings = settings
-        super.init(title: nil)
-    }
-
-    override var hidden: Bool {
-        return !ShowDebugSettings
-    }
-}
-
-extension NSFileManager {
-    public func removeItemInDirectory(directory: String, named: String) throws {
-        if let file = NSURL.fileURLWithPath(directory).URLByAppendingPathComponent(named).path {
-            try self.removeItemAtPath(file)
-        }
-    }
-}
-
-private class DeleteExportedDataSetting: HiddenSetting {
-    override var title: NSAttributedString? {
-        // Not localized for now.
-        return NSAttributedString(string: "Debug: delete exported databases", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
-        let fileManager = NSFileManager.defaultManager()
-        do {
-            let files = try fileManager.contentsOfDirectoryAtPath(documentsPath)
-            for file in files {
-                if file.startsWith("browser.") || file.startsWith("logins.") {
-                    try fileManager.removeItemInDirectory(documentsPath, named: file)
-                }
-            }
-        } catch {
-            print("Couldn't delete exported data: \(error).")
-        }
-    }
-}
-
-private class ExportBrowserDataSetting: HiddenSetting {
-    override var title: NSAttributedString? {
-        // Not localized for now.
-        return NSAttributedString(string: "Debug: copy databases to app container", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
-        do {
-            let log = Logger.syncLogger
-            try self.settings.profile.files.copyMatching(fromRelativeDirectory: "", toAbsoluteDirectory: documentsPath) { file in
-                log.debug("Matcher: \(file)")
-                return file.startsWith("browser.") || file.startsWith("logins.")
-            }
-        } catch {
-            print("Couldn't export browser data: \(error).")
-        }
-    }
-}
-
-// Show the current version of Firefox
-private class VersionSetting : Setting {
-    let settings: SettingsTableViewController
-
-    init(settings: SettingsTableViewController) {
-        self.settings = settings
-        super.init(title: nil)
-    }
-
-    override var title: NSAttributedString? {
-        let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
-        let buildNumber = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as! String
-        return NSAttributedString(string: String(format: NSLocalizedString("Version %@ (%@)", comment: "Version number of Firefox shown in settings"), appVersion, buildNumber), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-    private override func onConfigureCell(cell: UITableViewCell) {
-        super.onConfigureCell(cell)
-        cell.selectionStyle = .None
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        if AppConstants.BuildChannel != .Aurora {
-            DebugSettingsClickCount += 1
-            if DebugSettingsClickCount >= 5 {
-                DebugSettingsClickCount = 0
-                ShowDebugSettings = !ShowDebugSettings
-                settings.tableView.reloadData()
-            }
-        }
-    }
-}
-
-// Opens the the license page in a new tab
-private class LicenseAndAcknowledgementsSetting: Setting {
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Licenses", comment: "Settings item that opens a tab containing the licenses. See http://mzl.la/1NSAWCG"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override var url: NSURL? {
-        return NSURL(string: WebServer.sharedInstance.URLForResource("license", module: "about"))
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
-    }
-}
-
-// Opens about:rights page in the content view controller
-private class YourRightsSetting: Setting {
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Your Rights", comment: "Your Rights settings section title"), attributes:
-            [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override var url: NSURL? {
-        return NSURL(string: "https://www.mozilla.org/about/legal/terms/firefox/")
-    }
-
-    private override func onClick(navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
-    }
-}
-
-// Opens the on-boarding screen again
-private class ShowIntroductionSetting: Setting {
-    let profile: Profile
-
-    init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
-        super.init(title: NSAttributedString(string: NSLocalizedString("Show Tour", comment: "Show the on-boarding screen again from the settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        navigationController?.dismissViewControllerAnimated(true, completion: {
-            if let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate {
-                appDelegate.browserViewController.presentIntroViewController(true)
-            }
-        })
-    }
-}
-
-private class SendFeedbackSetting: Setting {
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Send Feedback", comment: "Show an input.mozilla.org page where people can submit feedback"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override var url: NSURL? {
-        let appVersion = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
-        return NSURL(string: "https://input.mozilla.org/feedback/fxios/\(appVersion)")
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
-    }
-}
-
-// Opens the the SUMO page in a new tab
-private class OpenSupportPageSetting: Setting {
-    init(delegate: SettingsDelegate?) {
-        super.init(title: NSAttributedString(string: NSLocalizedString("Help", comment: "Show the SUMO support page from the Support section in the settings. see http://mzl.la/1dmM8tZ"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
-            delegate: delegate)
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        navigationController?.dismissViewControllerAnimated(true) {
-            if let url = NSURL(string: "https://support.mozilla.org/products/ios") {
-                self.delegate?.settingsOpenURLInNewTab(url)
-            }
-        }
-    }
-}
-
-// Opens the search settings pane
-private class SearchSetting: Setting {
-    let profile: Profile
-
-    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
-
-    override var style: UITableViewCellStyle { return .Value1 }
-
-    override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine.shortName) }
-
-    init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
-        super.init(title: NSAttributedString(string: NSLocalizedString("Search", comment: "Open search section of settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let viewController = SearchSettingsTableViewController()
-        viewController.model = profile.searchEngines
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-private class LoginsSetting: Setting {
-    let profile: Profile
-    var tabManager: TabManager!
-
-    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
-
-    init(settings: SettingsTableViewController, delegate: SettingsDelegate?) {
-        self.profile = settings.profile
-        self.tabManager = settings.tabManager
-
-        let loginsTitle = NSLocalizedString("Logins", comment: "Label used as an item in Settings. When touched, the user will be navigated to the Logins/Password manager.")
-        super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
-                   delegate: delegate)
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let viewController = LoginListViewController(profile: profile)
-        viewController.settingsDelegate = delegate
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-private class ClearPrivateDataSetting: Setting {
-    let profile: Profile
-    var tabManager: TabManager!
-
-    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
-
-    init(settings: SettingsTableViewController) {
-        self.profile = settings.profile
-        self.tabManager = settings.tabManager
-
-        let clearTitle = NSLocalizedString("Clear Private Data", comment: "Label used as an item in Settings. When touched it will open a dialog prompting the user to make sure they want to clear all of their private data.")
-        super.init(title: NSAttributedString(string: clearTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        let viewController = ClearPrivateDataTableViewController()
-        viewController.profile = profile
-        viewController.tabManager = tabManager
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-private class PrivacyPolicySetting: Setting {
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: NSLocalizedString("Privacy Policy", comment: "Show Firefox Browser Privacy Policy page from the Privacy section in the settings. See https://www.mozilla.org/privacy/firefox/"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override var url: NSURL? {
-        return NSURL(string: "https://www.mozilla.org/privacy/firefox/")
-    }
-
-    override func onClick(navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController)
-    }
-}
-
-private class ChinaSyncServiceSetting: WithoutAccountSetting {
-    override var accessoryType: UITableViewCellAccessoryType { return .None }
-    var prefs: Prefs { return settings.profile.prefs }
-    let prefKey = "useChinaSyncService"
-
-    override var title: NSAttributedString? {
-        return NSAttributedString(string: "本地同步服务", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
-    }
-
-    override var status: NSAttributedString? {
-        return NSAttributedString(string: "本地服务使用火狐通行证同步数据", attributes: [NSForegroundColorAttributeName: UIConstants.TableViewHeaderTextColor])
-    }
-
-    override func onConfigureCell(cell: UITableViewCell) {
-        super.onConfigureCell(cell)
-        let control = UISwitch()
-        control.onTintColor = UIConstants.ControlTintColor
-        control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
-        control.on = prefs.boolForKey(prefKey) ?? true
-        cell.accessoryView = control
-        cell.selectionStyle = .None
-    }
-
-    @objc func switchValueChanged(toggle: UISwitch) {
-        prefs.setObject(toggle.on, forKey: prefKey)
-    }
 }
 
 @objc
@@ -735,9 +223,12 @@ protocol SettingsDelegate: class {
 
 // The base settings view controller.
 class SettingsTableViewController: UITableViewController {
+
+    typealias SettingsGenerator = (SettingsTableViewController, SettingsDelegate?) -> [SettingSection]
+
     private let Identifier = "CellIdentifier"
     private let SectionHeaderIdentifier = "SectionHeaderIdentifier"
-    private var settings = [SettingSection]()
+    var settings = [SettingSection]()
 
     weak var settingsDelegate: SettingsDelegate?
 
@@ -747,106 +238,6 @@ class SettingsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let privacyTitle = NSLocalizedString("Privacy", comment: "Privacy section title")
-        let accountDebugSettings: [Setting]
-        if AppConstants.BuildChannel != .Aurora {
-            accountDebugSettings = [
-                // Debug settings:
-                RequirePasswordDebugSetting(settings: self),
-                RequireUpgradeDebugSetting(settings: self),
-                ForgetSyncAuthStateDebugSetting(settings: self),
-            ]
-        } else {
-            accountDebugSettings = []
-        }
-
-        let prefs = profile.prefs
-        var generalSettings = [
-            SearchSetting(settings: self),
-            BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
-                titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),
-            BoolSetting(prefs: prefs, prefKey: "saveLogins", defaultValue: true,
-                titleText: NSLocalizedString("Save Logins", comment: "Setting to enable the built-in password manager")),
-        ]
-
-        let accountChinaSyncSetting: [Setting]
-        let locale = NSLocale.currentLocale()
-        if locale.localeIdentifier != "zh_CN" {
-            accountChinaSyncSetting = []
-        } else {
-            accountChinaSyncSetting = [
-                // Show China sync service setting:
-                ChinaSyncServiceSetting(settings: self)
-            ]
-        }
-        // There is nothing to show in the Customize section if we don't include the compact tab layout
-        // setting on iPad. When more options are added that work on both device types, this logic can
-        // be changed.
-        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
-            generalSettings +=  [
-                BoolSetting(prefs: prefs, prefKey: "CompactTabLayout", defaultValue: true,
-                    titleText: NSLocalizedString("Use Compact Tabs", comment: "Setting to enable compact tabs in the tab overview"))
-            ]
-        }
-
-        settings += [
-            SettingSection(title: nil, children: [
-                // Without a Firefox Account:
-                ConnectSetting(settings: self),
-                // With a Firefox Account:
-                AccountStatusSetting(settings: self),
-                SyncNowSetting(settings: self)
-            ] + accountChinaSyncSetting + accountDebugSettings),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("General", comment: "General settings section title")), children: generalSettings)
-        ]
-
-        var privacySettings: [Setting]
-        if AppConstants.MOZ_LOGIN_MANAGER {
-            privacySettings = [LoginsSetting(settings: self, delegate: settingsDelegate), ClearPrivateDataSetting(settings: self)]
-        } else {
-            privacySettings = [ClearPrivateDataSetting(settings: self)]
-        }
-
-        if #available(iOS 9, *) {
-            privacySettings += [
-                BoolSetting(prefs: prefs,
-                    prefKey: "settings.closePrivateTabs",
-                    defaultValue: false,
-                    titleText: NSLocalizedString("Close Private Tabs", tableName: "PrivateBrowsing", comment: "Setting for closing private tabs"),
-                    statusText: NSLocalizedString("When Leaving Private Browsing", tableName: "PrivateBrowsing", comment: "Will be displayed in Settings under 'Close Private Tabs'"))
-            ]
-        }
-
-        privacySettings += [
-            BoolSetting(prefs: prefs, prefKey: "crashreports.send.always", defaultValue: false,
-                titleText: NSLocalizedString("Send Crash Reports", comment: "Setting to enable the sending of crash reports"),
-                settingDidChange: { configureActiveCrashReporter($0) }),
-            PrivacyPolicySetting()
-        ]
-
-
-        settings += [
-            SettingSection(title: NSAttributedString(string: privacyTitle), children: privacySettings),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
-                ShowIntroductionSetting(settings: self),
-                SendFeedbackSetting(),
-                OpenSupportPageSetting(delegate: settingsDelegate),
-            ]),
-            SettingSection(title: NSAttributedString(string: NSLocalizedString("About", comment: "About settings section title")), children: [
-                VersionSetting(settings: self),
-                LicenseAndAcknowledgementsSetting(),
-                YourRightsSetting(),
-                DisconnectSetting(settings: self),
-                ExportBrowserDataSetting(settings: self),
-                DeleteExportedDataSetting(settings: self),
-            ])
-        ]
-
-        navigationItem.title = NSLocalizedString("Settings", comment: "Settings")
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: NSLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar"),
-            style: UIBarButtonItemStyle.Done,
-            target: navigationController, action: "SELdone")
         tableView.registerClass(SettingsTableViewCell.self, forCellReuseIdentifier: Identifier)
         tableView.registerClass(SettingsTableSectionHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: SectionHeaderIdentifier)
         tableView.tableFooterView = SettingsTableFooterView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 128))
@@ -857,8 +248,14 @@ class SettingsTableViewController: UITableViewController {
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
+
+        settings = generateSettings()
+
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELsyncDidChangeState", name: NotificationProfileDidStartSyncing, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELsyncDidChangeState", name: NotificationProfileDidFinishSyncing, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELfirefoxAccountDidChange", name: NotificationFirefoxAccountChanged, object: nil)
+
+        tableView.reloadData()
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -870,6 +267,12 @@ class SettingsTableViewController: UITableViewController {
         super.viewDidDisappear(animated)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationProfileDidStartSyncing, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationProfileDidFinishSyncing, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationFirefoxAccountChanged, object: nil)
+    }
+
+    // Override to provide settings in subclasses
+    func generateSettings() -> [SettingSection] {
+        return []
     }
 
     @objc private func SELsyncDidChangeState() {
@@ -889,6 +292,10 @@ class SettingsTableViewController: UITableViewController {
         } else {
             self.tableView.reloadData()
         }
+    }
+
+    @objc private func SELfirefoxAccountDidChange() {
+        self.tableView.reloadData()
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
@@ -947,33 +354,11 @@ class SettingsTableViewController: UITableViewController {
         return height
     }
 
-    override func tableView(tableView: UITableView, willSelectRowAtIndexPath indexPath: NSIndexPath) -> NSIndexPath? {
+    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let section = settings[indexPath.section]
-        if let setting = section[indexPath.row] {
+        if let setting = section[indexPath.row] where setting.enabled {
             setting.onClick(navigationController)
         }
-        return nil
-    }
-
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        //make account/sign-in and close private tabs rows taller, as per design specs
-        if indexPath.section == 0 && indexPath.row == 0 {
-            return 64
-        }
-
-        if #available(iOS 9, *) {
-            if AppConstants.MOZ_LOGIN_MANAGER {
-                if indexPath.section == 2 && indexPath.row == 2 {
-                    return 64
-                }
-            } else {
-                if indexPath.section == 2 && indexPath.row == 1 {
-                    return 64
-                }
-            }
-        }
-
-        return 44
     }
 }
 

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -43,6 +43,7 @@ public struct UIConstants {
     static let TableViewHeaderBackgroundColor = UIColor(red: 242/255, green: 245/255, blue: 245/255, alpha: 1.0)
     static let TableViewHeaderTextColor = UIColor(red: 130/255, green: 135/255, blue: 153/255, alpha: 1.0)
     static let TableViewRowTextColor = UIColor(red: 53.55/255, green: 53.55/255, blue: 53.55/255, alpha: 1.0)
+    static let TableViewDisabledRowTextColor = UIColor.lightGrayColor()
     static let TableViewSeparatorColor = UIColor(rgb: 0xD1D1D4)
 
     // Firefox Orange
@@ -79,24 +80,9 @@ private struct TempStrings {
     let backToThemesAccessibilityString = NSLocalizedString("Back to Themes", tableName: "LightweightThemes", comment: "Pending feature; currently unused string! Accessibility label for back button to theme chooser")
 
     // Bug 1198418 - Touch ID Passcode Strings
-    let touchIDSetting          = NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
-    let turnPasscodeOn          = NSLocalizedString("Turn Passcode On", tableName: "AuthenticationManager", comment: "Title for setting to turn on passcode")
-    let turnPasscodeOff         = NSLocalizedString("Turn Passcode Off", tableName: "AuthenticationManager", comment: "Title for setting to turn off passcode")
-    let passcode                = NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings")
-    let changePasscode          = NSLocalizedString("Change Passcode", tableName: "AuthenticationManager", comment: "Title for setting to change passcode")
-    let requirePasscode         = NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Title for setting to require a passcode")
     let setPasscode             = NSLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Screen title for Set Passcode")
     let enterPasscode           = NSLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Title for entering a passcode")
     let reenterPasscode         = NSLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Title for re-entering a passcode")
-    let useTouchID              = NSLocalizedString("Use Touch ID for", tableName:  "AuthenticationManager", comment: "List section title for when to use Touch ID")
-    let privateBrowsing         = NSLocalizedString("Private Browsing", tableName: "AuthenticationManager", comment: "List item for Private Browsing")
-    let logins                  = NSLocalizedString("Logins", tableName: "AuthenticationManager", comment: "List item for Logins")
-    let immediately             = NSLocalizedString("Immediately", tableName: "AuthenticationManager", comment: "'Immediately' interval item for selecting when to require passcode")
-    let afterOneMinute          = NSLocalizedString("After 1 minute", tableName: "AuthenticationManager", comment: "'After 1 minute' interval item for selecting when to require passcode")
-    let afterFiveMinutes        = NSLocalizedString("After 5 minutes", tableName: "AuthenticationManager", comment: "'After 5 minutes' interval item for selecting when to require passcode")
-    let afterTenMinutes         = NSLocalizedString("After 10 minutes", tableName: "AuthenticationManager", comment: "'After 10 minutes' interval item for selecting when to require passcode")
-    let afterFifteenMinutes     = NSLocalizedString("After 15 minutes", tableName: "AuthenticationManager", comment: "'After 15 minutes' interval item for selecting when to require passcode")
-    let afterOneHour            = NSLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode")
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
     let accessLogins            = NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -47,4 +47,15 @@ public struct AppConstants {
     return true
 #endif
     }()
+
+    /// Enables/disables the Touch ID/passcode functionality and settings screen
+    public static let MOZ_AUTHENTICATION_MANAGER: Bool = {
+#if MOZ_CHANNEL_AURORA
+    return false
+#elseif MOZ_CHANNEL_RELEASE
+    return false
+#else
+    return true
+#endif
+    }()
 }

--- a/Utils/Extensions/NSFileManagerExtensions.swift
+++ b/Utils/Extensions/NSFileManagerExtensions.swift
@@ -16,6 +16,7 @@ public enum NSFileManagerExtensionsErrorCodes: Int {
 }
 
 public extension NSFileManager {
+
     private func directoryEnumeratorForURL(url: NSURL) throws -> NSDirectoryEnumerator {
         let prefetchedProperties = [
             NSURLIsRegularFileKey,
@@ -90,6 +91,12 @@ public extension NSFileManager {
         return try NSFileManager.defaultManager().contentsOfDirectoryAtPath(path)
             .filter { $0.hasPrefix("\(prefix).") }
             .sort { $0 < $1 }
+    }
+
+    func removeItemInDirectory(directory: String, named: String) throws {
+        if let file = NSURL.fileURLWithPath(directory).URLByAppendingPathComponent(named).path {
+            try self.removeItemAtPath(file)
+        }
     }
 
     private func errorWithCode(code: NSFileManagerExtensionsErrorCodes, underlyingError error: NSError? = nil) -> NSError {


### PR DESCRIPTION
This PR refactors the SettingsTableViewController into a reusable component that can be used for the TouchID/Passcode settings screen. The work includes:

* Extracting the class definitions for App-wide settings into AppSettingsOptions.swift
* Creating a new AppSettingsTableViewController subclass of the existing SettingsTableViewController class to extract specific logic.
* New AuthenticationSettingsViewController that also leverages the simplified SettingsTableViewController along with specific option class declarations.
* Addition of an 'enabled flag on a Setting which is used to enable/disable settings in the Authentication Setting screen.
* Scaffolding for preference keys for setting up passcode require intervals.
* Feature flag for the authentication settings work.