### PR TITLE
Bug 1239073 - Created custom passcode input, pane, and view controller for entering/setting up/confirming a passcode

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -488,6 +488,10 @@
 		E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED7D71BFCD9990097D08E /* LoginTableViewCell.swift */; };
 		E63ED8091BFCF9770097D08E /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65C5B9A1BEA4E7100D28BEF /* SwiftSupport.swift */; };
 		E63ED8E11BFD25580097D08E /* LoginListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63ED8E01BFD25580097D08E /* LoginListViewController.swift */; };
+		E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */; };
+		E640E8681C73A46600C5F072 /* PasscodeConfirmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E8671C73A46600C5F072 /* PasscodeConfirmViewController.swift */; };
+		E640E86A1C73A47C00C5F072 /* PasscodeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E8691C73A47C00C5F072 /* PasscodeViews.swift */; };
+		E640E8701C73BCF500C5F072 /* AuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */; };
 		E64ED8FA1BC55AE300DAF864 /* UIAlertControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64ED8F91BC55AE300DAF864 /* UIAlertControllerExtensions.swift */; };
 		E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
 		E65072A41B273824001A0AC6 /* GeometryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A99D761B20D95800006EDD /* GeometryExtensions.swift */; };
@@ -1415,6 +1419,10 @@
 		E63ED7B31BFCD9800097D08E /* LoginTableViewCellRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginTableViewCellRefTests.swift; sourceTree = "<group>"; };
 		E63ED7D71BFCD9990097D08E /* LoginTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginTableViewCell.swift; sourceTree = "<group>"; };
 		E63ED8E01BFD25580097D08E /* LoginListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListViewController.swift; sourceTree = "<group>"; };
+		E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeEntryViewController.swift; sourceTree = "<group>"; };
+		E640E8671C73A46600C5F072 /* PasscodeConfirmViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeConfirmViewController.swift; sourceTree = "<group>"; };
+		E640E8691C73A47C00C5F072 /* PasscodeViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeViews.swift; sourceTree = "<group>"; };
+		E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationManagerTests.swift; sourceTree = "<group>"; };
 		E64ED8F91BC55AE300DAF864 /* UIAlertControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertControllerExtensions.swift; path = Extensions/UIAlertControllerExtensions.swift; sourceTree = "<group>"; };
 		E653422C1C5944F90039DD9E /* BrowserPrompts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserPrompts.swift; sourceTree = "<group>"; };
 		E65607601C08B4E200534B02 /* SearchInputView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchInputView.swift; sourceTree = "<group>"; };
@@ -2240,6 +2248,7 @@
 				4F9757391AFA6F37006ECC24 /* readerContent.html */,
 				E6EAC5951B29CB3A00E1DE1E /* scrollablePage.html */,
 				D3E171C11A841EAD00AB44CD /* KIFHelper.js */,
+				E640E86F1C73BCF500C5F072 /* AuthenticationManagerTests.swift */,
 				D38F036F1C06387900175932 /* AuthenticationTests.swift */,
 				0BB5B35F1AC0D6360052877D /* BookmarkingTests.swift */,
 				E6B4C4021C68F58B001F97E8 /* BrowserTests.swift */,
@@ -2552,6 +2561,9 @@
 			isa = PBXGroup;
 			children = (
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
+				E640E8691C73A47C00C5F072 /* PasscodeViews.swift */,
+				E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */,
+				E640E8671C73A46600C5F072 /* PasscodeConfirmViewController.swift */,
 			);
 			path = AuthenticationManager;
 			sourceTree = "<group>";
@@ -4090,6 +4102,7 @@
 				E6A118F31C32DE98008989E8 /* SettingsTests.swift in Sources */,
 				744B0FFE1B4F172E00100422 /* ToolbarTests.swift in Sources */,
 				2F642CED1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift in Sources */,
+				E640E8701C73BCF500C5F072 /* AuthenticationManagerTests.swift in Sources */,
 				7B59FC491C68E9B600F58EF5 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
 				E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */,
 			);
@@ -4183,6 +4196,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
+				E640E86A1C73A47C00C5F072 /* PasscodeViews.swift in Sources */,
 				E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,
 				7B3631EA1C244FEE00D12AF9 /* Theme.swift in Sources */,
@@ -4234,6 +4248,7 @@
 				0BF42D371A7C0B8E00889E28 /* FaviconManager.swift in Sources */,
 				39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */,
 				6BB2FD981B017DAB001A189B /* AuralProgressBar.swift in Sources */,
+				E640E8681C73A46600C5F072 /* PasscodeConfirmViewController.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
@@ -4283,6 +4298,7 @@
 				D3A9949C1A3686BD008AD1AC /* BrowserViewController.swift in Sources */,
 				59A681BDFC95A19F05E07223 /* SearchViewController.swift in Sources */,
 				D30B0F301AA7D66300C01CA3 /* ThumbnailCell.swift in Sources */,
+				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
 				D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/PasscodeConfirmViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeConfirmViewController.swift
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SwiftKeychainWrapper
+
+let NotificationPasscodeDidCreate   = "NotificationPasscodeDidCreate"
+let NotificationPasscodeDidChange   = "NotificationPasscodeDidChange"
+let NotificationPasscodeDidRemove   = "NotificationPasscodeDidRemove"
+
+enum PasscodeConfirmAction {
+    case Created
+    case Removed
+    case Changed
+}
+
+private let PaneSwipeDuration: NSTimeInterval = 0.3
+
+/// Presented to the user when creating/removing/changing a passcode.
+class PasscodeConfirmViewController: UIViewController {
+    private lazy var pager: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.pagingEnabled = true
+        scrollView.userInteractionEnabled = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+
+    private var panes = [PasscodePane]()
+    private var confirmCode: String?
+    private var currentPaneIndex: Int = 0
+
+    private let confirmAction: PasscodeConfirmAction
+
+    class func newPasscodeVC() -> PasscodeConfirmViewController {
+        let passcodeVC = PasscodeConfirmViewController(confirmAction: .Created)
+        passcodeVC.panes = [
+            PasscodePane(title: AuthenticationStrings.enterPasscode),
+            PasscodePane(title: AuthenticationStrings.reenterPasscode),
+        ]
+        return passcodeVC
+    }
+
+    class func changePasscodeVC() -> PasscodeConfirmViewController {
+        let passcodeVC = PasscodeConfirmViewController(confirmAction: .Changed)
+        passcodeVC.panes = [
+            PasscodePane(title: AuthenticationStrings.enterPasscode),
+            PasscodePane(title: AuthenticationStrings.enterNewPasscode),
+        ]
+        return passcodeVC
+    }
+
+    class func removePasscodeVC() -> PasscodeConfirmViewController {
+        let passcodeVC = PasscodeConfirmViewController(confirmAction: .Removed)
+        passcodeVC.panes = [
+            PasscodePane(title: AuthenticationStrings.enterPasscode),
+            PasscodePane(title: AuthenticationStrings.reenterPasscode),
+        ]
+        return passcodeVC
+    }
+
+    init(confirmAction: PasscodeConfirmAction) {
+        self.confirmAction = confirmAction
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: Selector("dismiss"))
+        view.addSubview(pager)
+        automaticallyAdjustsScrollViewInsets = false
+        panes.forEach { pager.addSubview($0) }
+        pager.snp_makeConstraints { make in
+            make.bottom.left.right.equalTo(self.view)
+            make.top.equalTo(self.snp_topLayoutGuideBottom)
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        panes.enumerate().forEach { index, pane in
+            pane.frame = CGRect(origin: CGPoint(x: CGFloat(index) * pager.frame.width, y: 0), size: pager.frame.size)
+        }
+        pager.contentSize = CGSize(width: CGFloat(panes.count) * pager.frame.width, height: pager.frame.height)
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        panes.first?.codeInputView.delegate = self
+        panes.first?.codeInputView.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.view.endEditing(true)
+    }
+}
+
+extension PasscodeConfirmViewController {
+    private func scrollToNextPane() {
+        guard (currentPaneIndex + 1) < panes.count else {
+            return
+        }
+        currentPaneIndex += 1
+        scrollToPaneAtIndex(currentPaneIndex)
+    }
+
+    private func scrollToPreviousPane() {
+        guard (currentPaneIndex - 1) >= 0 else {
+            return
+        }
+        currentPaneIndex -= 1
+        scrollToPaneAtIndex(currentPaneIndex)
+    }
+
+    private func scrollToPaneAtIndex(index: Int) {
+        UIView.animateWithDuration(PaneSwipeDuration, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: {
+            self.pager.contentOffset = CGPoint(x: CGFloat(self.currentPaneIndex) * self.pager.frame.width, y: 0)
+        }, completion: nil)
+    }
+
+    @objc private func dismiss() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+    }
+}
+
+extension PasscodeConfirmViewController: PasscodeInputViewDelegate {
+    func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String) {
+        if currentPaneIndex == 0 {
+            // Constraint: When removing or changing a passcode, we need to make sure that the first passcode they've
+            // entered matches the one stored in the keychain
+            if (confirmAction == .Removed || confirmAction == .Changed) && code != KeychainWrapper.stringForKey(KeychainKeyPasscode) {
+                // TODO: Show error for incorrect passcode
+                inputView.resetCode()
+                inputView.becomeFirstResponder()
+                return
+            }
+
+            confirmCode = code
+            scrollToNextPane()
+            let nextPane = panes[currentPaneIndex]
+            nextPane.codeInputView.becomeFirstResponder()
+            nextPane.codeInputView.delegate = self
+        } else if currentPaneIndex == 1 {
+            // Constraint: When changing passcodes, the new passcode cannot match their old passcode.
+            if confirmAction == .Changed && confirmCode == code {
+                // TODO: Show error telling the user that they need to enter a different passcode
+                resetConfirmation()
+                return
+            }
+
+            // Constraint: When removing/creating passcodes, the first and confirmation codes must match.
+            if (confirmAction == .Created || confirmAction == .Removed) && confirmCode != code {
+                // TODO: Show error telling the user that the passcodes must match
+                resetConfirmation()
+                return
+            }
+
+            performActionAndNotify(confirmAction, forCode: code)
+            dismiss()
+        }
+    }
+
+    private func resetConfirmation() {
+        scrollToPreviousPane()
+        confirmCode = nil
+        let previousPane = panes[currentPaneIndex]
+        panes.forEach { $0.codeInputView.resetCode() }
+        previousPane.codeInputView.becomeFirstResponder()
+    }
+
+    private func performActionAndNotify(confirmAction: PasscodeConfirmAction, forCode code: String) {
+        let notificationCenter = NSNotificationCenter.defaultCenter()
+        let notificationName: String
+        switch confirmAction {
+        case .Changed:
+            KeychainWrapper.setString(code, forKey: KeychainKeyPasscode)
+            notificationName = NotificationPasscodeDidChange
+        case .Created:
+            KeychainWrapper.setString(code, forKey: KeychainKeyPasscode)
+            notificationName = NotificationPasscodeDidCreate
+        case .Removed:
+            KeychainWrapper.removeObjectForKey(KeychainKeyPasscode)
+            notificationName = NotificationPasscodeDidRemove
+        }
+
+        notificationCenter.postNotificationName(notificationName, object: nil)
+    }
+}

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SnapKit
+import Shared
+import SwiftKeychainWrapper
+
+/// Delegate available for PasscodeEntryViewController consumers to be notified of the validation of a passcode.
+@objc protocol PasscodeEntryDelegate: class {
+    func passcodeValidationDidSucceed()
+}
+
+/// Presented to the to user when asking for their passcode to validate entry into a part of the app.
+class PasscodeEntryViewController: UIViewController {
+    weak var delegate: PasscodeEntryDelegate?
+    private let passcodePane = PasscodePane(title: AuthenticationStrings.enterPasscode)
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: Selector("dismiss"))
+        automaticallyAdjustsScrollViewInsets = false
+        view.addSubview(passcodePane)
+        passcodePane.snp_makeConstraints { make in
+            make.bottom.left.right.equalTo(self.view)
+            make.top.equalTo(self.snp_topLayoutGuideBottom)
+        }
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        passcodePane.codeInputView.delegate = self
+        passcodePane.codeInputView.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.view.endEditing(true)
+    }
+}
+
+extension PasscodeEntryViewController {
+    @objc private func dismiss() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+    }
+}
+
+extension PasscodeEntryViewController: PasscodeInputViewDelegate {
+    func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String) {
+        if let passcode = KeychainWrapper.stringForKey(KeychainKeyPasscode) where passcode == code {
+            delegate?.passcodeValidationDidSucceed()
+        } else {
+            // TODO: Show error for incorrect passcode
+        }
+    }
+}

--- a/Client/Frontend/AuthenticationManager/PasscodeViews.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeViews.swift
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+private struct PasscodeUX {
+    static let TitleVerticalSpacing: CGFloat = 32
+    static let DigitSize: CGFloat = 30
+    static let TopMargin: CGFloat = 80
+    static let PasscodeFieldSize: CGSize = CGSize(width: 160, height: 32)
+}
+
+@objc protocol PasscodeInputViewDelegate: class {
+    func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String)
+}
+
+/// A custom, keyboard-able view that displays the blank/filled digits when entrering a passcode.
+class PasscodeInputView: UIView, UIKeyInput {
+    weak var delegate: PasscodeInputViewDelegate?
+
+    var digitFont: UIFont = UIConstants.PasscodeEntryFont
+
+    let blankCharacter: Character = "-"
+
+    let filledCharacter: Character = "•"
+
+    private let passcodeSize: Int
+
+    private var inputtedCode: String = ""
+
+    private var blankDigitString: NSAttributedString {
+        return NSAttributedString(string: "\(blankCharacter)", attributes: [NSFontAttributeName: digitFont])
+    }
+
+    private var filledDigitString: NSAttributedString {
+        return NSAttributedString(string: "\(filledCharacter)", attributes: [NSFontAttributeName: digitFont])
+    }
+
+    @objc var keyboardType: UIKeyboardType = .NumberPad
+
+    init(frame: CGRect, passcodeSize: Int) {
+        self.passcodeSize = passcodeSize
+        super.init(frame: frame)
+        opaque = false
+    }
+
+    convenience init(passcodeSize: Int) {
+        self.init(frame: CGRectZero, passcodeSize: passcodeSize)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func canBecomeFirstResponder() -> Bool {
+        return true
+    }
+
+    func resetCode() {
+        inputtedCode = ""
+        setNeedsDisplay()
+    }
+
+    @objc func hasText() -> Bool {
+        return inputtedCode.characters.count > 0
+    }
+
+    @objc func insertText(text: String) {
+        guard inputtedCode.characters.count < passcodeSize else {
+            return
+        }
+
+        inputtedCode += text
+        setNeedsDisplay()
+        if inputtedCode.characters.count == passcodeSize {
+            delegate?.passcodeInputView(self, didFinishEnteringCode: inputtedCode)
+        }
+    }
+
+    // Required for implementing UIKeyInput
+    @objc func deleteBackward() {
+        guard inputtedCode.characters.count > 0 else {
+            return
+        }
+
+        inputtedCode.removeAtIndex(inputtedCode.endIndex.predecessor())
+        setNeedsDisplay()
+    }
+
+    override func drawRect(rect: CGRect) {
+        let offset = floor(rect.width / CGFloat(passcodeSize))
+        let size = CGSize(width: offset, height: rect.height)
+        let containerRect = CGRect(origin: CGPointZero, size: size)
+        // Chop up our rect into n containers and draw each digit centered inside.
+        (0..<passcodeSize).forEach { index in
+            let characterToDraw = index < inputtedCode.characters.count ? filledDigitString : blankDigitString
+            var boundingRect = characterToDraw.boundingRectWithSize(size, options: [], context: nil)
+            boundingRect.center = containerRect.center
+            boundingRect = CGRectApplyAffineTransform(boundingRect, CGAffineTransformMakeTranslation(floor(CGFloat(index) * offset), 0))
+            characterToDraw.drawInRect(boundingRect)
+        }
+    }
+}
+
+/// A pane that gets displayed inside the PasscodeViewController that displays a title and a passcode input field.
+class PasscodePane: UIView {
+    let codeInputView = PasscodeInputView(passcodeSize: 4)
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIConstants.DefaultChromeFont
+        label.isAccessibilityElement = true
+        return label
+    }()
+
+    private let centerContainer = UIView()
+
+    override func accessibilityElementCount() -> Int {
+        return 1
+    }
+
+    override func accessibilityElementAtIndex(index: Int) -> AnyObject? {
+        switch index {
+        case 0:     return titleLabel
+        default:    return nil
+        }
+    }
+
+    init(title: String) {
+        super.init(frame: CGRectZero)
+        backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+
+        titleLabel.text = title
+        centerContainer.addSubview(titleLabel)
+        centerContainer.addSubview(codeInputView)
+        addSubview(centerContainer)
+
+        centerContainer.snp_makeConstraints { make in
+            make.centerX.equalTo(self)
+            make.top.equalTo(self).offset(PasscodeUX.TopMargin)
+        }
+
+        titleLabel.snp_makeConstraints { make in
+            make.centerX.equalTo(centerContainer)
+            make.top.equalTo(centerContainer)
+            make.bottom.equalTo(codeInputView.snp_top).offset(-PasscodeUX.TitleVerticalSpacing)
+        }
+
+        codeInputView.snp_makeConstraints { make in
+            make.centerX.equalTo(centerContainer)
+            make.bottom.equalTo(centerContainer)
+            make.size.equalTo(PasscodeUX.PasscodeFieldSize)
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -24,9 +24,11 @@ public struct UIConstants {
     // Static fonts
     static let DefaultChromeSize: CGFloat = 14
     static let DefaultChromeSmallSize: CGFloat = 11
+    static let PasscodeEntryFontSize: CGFloat = 36
     static let DefaultChromeFont: UIFont = UIFont.systemFontOfSize(DefaultChromeSize, weight: UIFontWeightRegular)
     static let DefaultChromeBoldFont = UIFont.boldSystemFontOfSize(DefaultChromeSize)
     static let DefaultChromeSmallFontBold = UIFont.boldSystemFontOfSize(DefaultChromeSmallSize)
+    static let PasscodeEntryFont = UIFont.systemFontOfSize(PasscodeEntryFontSize, weight: UIFontWeightBold)
 
     // These highlight colors are currently only used on Snackbar buttons when they're pressed
     static let HighlightColor = UIColor(red: 205/255, green: 223/255, blue: 243/255, alpha: 0.9)
@@ -83,9 +85,6 @@ private struct TempStrings {
     let backToThemesAccessibilityString = NSLocalizedString("Back to Themes", tableName: "LightweightThemes", comment: "Pending feature; currently unused string! Accessibility label for back button to theme chooser")
 
     // Bug 1198418 - Touch ID Passcode Strings
-    let setPasscode             = NSLocalizedString("Set Passcode", tableName: "AuthenticationManager", comment: "Screen title for Set Passcode")
-    let enterPasscode           = NSLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Title for entering a passcode")
-    let reenterPasscode         = NSLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Title for re-entering a passcode")
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
     let accessLogins            = NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Storage
+@testable import Client
+import SwiftKeychainWrapper
+
+class AuthenticationManagerTests: KIFTestCase {
+
+    private func openAuthenticationManager() {
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Touch ID & Passcode")
+    }
+
+    private func closeAuthenticationManager() {
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    private func resetPasscode() {
+        KeychainWrapper.removeObjectForKey(KeychainKeyPasscode)
+    }
+
+    private func setPasscode(code: String) {
+        KeychainWrapper.setString(code, forKey: KeychainKeyPasscode)
+    }
+
+    func testTurnOnPasscodeSetsPasscode() {
+        resetPasscode()
+
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Turn Passcode On")
+        tester().waitForViewWithAccessibilityLabel("Enter a passcode")
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
+
+        // Enter same passcode when confirming
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
+
+        XCTAssertEqual(KeychainWrapper.stringForKey(KeychainKeyPasscode)!, "1337")
+
+        closeAuthenticationManager()
+        resetPasscode()
+    }
+
+    func testTurnOffPasscode() {
+        setPasscode("1337")
+
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
+        tester().waitForViewWithAccessibilityLabel("Enter a passcode")
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
+
+        // Enter same passcode when confirming
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
+        XCTAssertNil(KeychainWrapper.stringForKey(KeychainKeyPasscode))
+
+        closeAuthenticationManager()
+    }
+
+    func testChangePasscode() {
+        setPasscode("1337")
+
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Change Passcode")
+        tester().waitForViewWithAccessibilityLabel("Enter a passcode")
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
+
+        // Enter same passcode when confirming
+        tester().tapViewWithAccessibilityLabel("2")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
+        XCTAssertEqual(KeychainWrapper.stringForKey(KeychainKeyPasscode), "2337")
+
+        closeAuthenticationManager()
+    }
+}


### PR DESCRIPTION
This PR includes the construction of the Passcode creation/confirmation/entry view controller. There isn't any true validation/storage of passcodes yet as that will come in a follow up patch. This is mostly just the UI and handling of input for passcodes.