### PR TITLE
Bug 1237351 - Reset restoring state if sessionrestore.html can't load

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2056,8 +2056,16 @@ extension BrowserViewController: WKUIDelegate {
             return
         }
 
-        if let url = error.userInfo["NSErrorFailingURLKey"] as? NSURL {
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? NSURL {
             ErrorPageHelper().showPage(error, forUrl: url, inWebView: webView)
+
+            // If the local web server isn't working for some reason (Firefox cellular data is
+            // disabled in settings, for example), we'll fail to load the session restore URL.
+            // We rely on loading that page to get the restore callback to reset the restoring
+            // flag, so if we fail to load that page, reset it here.
+            if AboutUtils.getAboutComponent(url) == "sessionrestore" {
+                tabManager.tabs.filter { $0.webView == webView }.first?.restoring = false
+            }
         }
     }
 


### PR DESCRIPTION
There must be an iOS bug that prevents our local server from being accessed when cellular data is disabled. The browser isn't terribly useful in this state anyway (unless someone's trying to use reader mode -- but there's not much we can do about it), so the main concern is making it work properly when we enable cellular data again.

We do already update the toolbar state on every page load, but only if we've finished restoring. Since we fail to load the session restore page, this flag is stuck. The workaround here listens for load errors: if we catch an about:sessionrestore page failure, we can reset the `restoring` flag.