### PR TITLE
Bug 1240057 - Only reload the pre-redirect URL if we've changed UAs

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -297,11 +297,14 @@ class Browser: NSObject, BrowserWebViewDelegate {
 
     func reload() {
         if #available(iOS 9.0, *) {
-            webView?.customUserAgent = desktopSite ? UserAgent.desktopUserAgent() : nil
+            let userAgent: String? = desktopSite ? UserAgent.desktopUserAgent() : nil
+            if (userAgent ?? "") != webView?.customUserAgent,
+               let currentItem = webView?.backForwardList.currentItem
+            {
+                webView?.customUserAgent = userAgent
 
-            if let currentItem = webView?.backForwardList.currentItem where currentItem.URL != currentItem.initialURL {
                 // Reload the initial URL to avoid UA specific redirection
-                loadRequest(NSURLRequest(URL: currentItem.initialURL, cachePolicy: .ReloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 60))
+                loadRequest(NSURLRequest(URL: currentItem.initialURL, cachePolicy: .ReloadIgnoringLocalCacheData, timeoutInterval: 60))
                 return
             }
         }


### PR DESCRIPTION
Right now, we're using `loadRequest` instead of `reload` every time we refresh the page after a redirect. This logic is here so that enabling/disabling Request Desktop Site tries the original URL instead of the redirected URL, but that's the only time we need to do it. This adds a check to follow this path only if the UA has changed.

I also changed `ReloadIgnoringLocalAndRemoteCacheData` to `ReloadIgnoringLocalCacheData` because the docs for `ReloadIgnoringLocalAndRemoteCacheData` say, "This constant is unimplemented and shouldn’t be used" (thanks, Apple).