### PR TITLE
Bug 1241089 dismiss all modals on new tab from 3DT & Spotlight

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -961,14 +961,16 @@ class BrowserViewController: UIViewController {
     }
 
     private func popToBrowser() {
-        guard let currentViewController = navigationController?.topViewController where currentViewController != self else {
+        guard let currentViewController = navigationController?.topViewController else {
             return
         }
         if let presentedViewController = currentViewController.presentedViewController {
             presentedViewController.dismissViewControllerAnimated(true, completion: nil)
         }
-        navigationController?.popToViewController(self, animated: false)
-        resetBrowserChrome()
+        if currentViewController != self {
+            navigationController?.popToViewController(self, animated: false)
+            resetBrowserChrome()
+        }
     }
 
     // Mark: User Agent Spoofing


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1241089

Ensure that all modally presented view controllers are dismissed before displaying a tab through 3DT or Spotlight.

Before it dismissed only modal controllers from TabTrayViewController (i.e. settings) but ignored modals on BVC (i.e. alert views or actions sheets).