### PR TITLE
Bug 1241908 - only dismiss view controller when settings available an…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -969,15 +969,14 @@ class BrowserViewController: UIViewController {
     }
 
     private func popToBrowser() {
-        guard let currentViewController = navigationController?.topViewController else {
-            return
+        guard let currentViewController = navigationController?.topViewController,
+            let presentedViewController = currentViewController.presentedViewController else {
+                return
         }
-        if let presentedViewController = currentViewController.presentedViewController {
-            presentedViewController.dismissViewControllerAnimated(true, completion: nil)
-        }
+        
+        presentedViewController.dismissViewControllerAnimated(false, completion: nil)
         if currentViewController != self {
-            navigationController?.popToViewController(self, animated: false)
-            resetBrowserChrome()
+            self.navigationController?.popViewControllerAnimated(true)
         }
     }
 


### PR DESCRIPTION
…d just pop the top VC with animations rather than pop to BVC.
https://bugzilla.mozilla.org/show_bug.cgi?id=1241908

This was an interesting one. It appears that `navigationController?.popToViewController(self, animated: false) somehow does not allow for BVC to reset itself properly. We got around this by forcing the browser chrome to reset, but it still left the toolbar not showing. 

`navigationController?.popViewControllerAnimated(true)` pops only the top VC and leaves BVC as it should be with the toolbar displayed. It also calls the tab tray dismissal animations which reset the browser chrome, meaning that we don't have to do that manually. I also discovered that you only need to dismiss the tab tray when coming from the settings, not when you're in Tab Tray, selectTab does that for you and handles all the resetting of the chrome.

I've tested both spotlight and 3dt on my 6s (9.2.1) and just spotlight my 5s (9.0.1)