### PR TITLE
Bug 1224245 – Use the non-mobile UA to get HTML for favicons.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -293,11 +293,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // readable from extensions, so they can just use the cached identifier.
         let defaults = NSUserDefaults(suiteName: AppInfo.sharedContainerIdentifier())!
         defaults.registerDefaults(["UserAgent": firefoxUA])
-        FaviconFetcher.userAgent = firefoxUA
+
         SDWebImageDownloader.sharedDownloader().setValue(firefoxUA, forHTTPHeaderField: "User-Agent")
 
         // Record the user agent for use by search suggestion clients.
         SearchViewController.userAgent = firefoxUA
+
+        // Some sites will only serve HTML that points to .ico files.
+        // The FaviconFetcher is explicitly for getting high-res icons, so use the desktop user agent.
+        FaviconFetcher.userAgent = UserAgent.desktopUserAgent()
     }
 
     func application(application: UIApplication, handleActionWithIdentifier identifier: String?, forLocalNotification notification: UILocalNotification, completionHandler: () -> Void) {

--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -112,7 +112,7 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
                 }
 
                 var bestType = IconType.NoneFound
-                element.iterate("head.link") { link in
+                element.iterateWithRootXPath("//head//link[contains(@rel, 'icon')]") { link in
                     var iconType: IconType? = nil
                     if let rel = link.attribute("rel") {
                         switch (rel) {
@@ -128,8 +128,16 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
                                 iconType = nil
                         }
                     }
+
+                    guard let href = link.attribute("href") where iconType != nil else {
+                        return
+                    }
+
+                    if (href.endsWith(".ico")) {
+                        iconType = .Guess
+                    }
+
                     if let type = iconType where !bestType.isPreferredTo(type),
-                        let href = link.attribute("href"),
                         let iconUrl = NSURL(string: href, relativeToURL: url) {
                             let icon = Favicon(url: iconUrl.absoluteString, date: NSDate(), type: type)
                             // If we already have a list of Favicons going already, then add it…
@@ -145,7 +153,7 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
 
                 // If we haven't got any options icons, then use the default at the root of the domain.
                 if let url = NSURL(string: "/favicon.ico", relativeToURL: url) where icons.isEmpty {
-                    let icon = Favicon(url: url.absoluteString, date: NSDate(), type: .Icon)
+                    let icon = Favicon(url: url.absoluteString, date: NSDate(), type: .Guess)
                     icons = [icon]
                 }
             }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1224245

Prefer png to ico files.

Use the firefox desktop user agent to get the high res favicons.