### PR TITLE
Bug 1229952 - Initialize Cancel button with 0 alpha

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -163,6 +163,7 @@ class URLBarView: UIView {
         cancelButton.titleEdgeInsets = UIEdgeInsetsMake(10, 12, 10, 12)
         cancelButton.setContentHuggingPriority(1000, forAxis: UILayoutConstraintAxis.Horizontal)
         cancelButton.setContentCompressionResistancePriority(1000, forAxis: UILayoutConstraintAxis.Horizontal)
+        cancelButton.alpha = 0
         return cancelButton
     }()
 


### PR DESCRIPTION
Like the `progressBar`, we should make the Cancel button initially invisible so it doesn't pop up when we call `prepareOverlayAnimation()`.