### PR TITLE
Bug 1227215 - Update the tab count after showing the restore alert

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -492,9 +492,11 @@ class BrowserViewController: UIViewController {
         let alert = UIAlertController.restoreTabsAlert(
             okayCallback: { _ in
                 self.tabManager.restoreTabs()
+                self.updateTabCountUsingTabManager(self.tabManager, animated: false)
             },
             noCallback: { _ in
                 self.tabManager.addTabAndSelect()
+                self.updateTabCountUsingTabManager(self.tabManager, animated: false)
             }
         )
 


### PR DESCRIPTION
We're calling `updateTabCountUsingTabManager` at the end of `viewWillAppear` to update the tab count, but since the restore prompt callbacks are async, that will be called before the user has made a selection.