### PR TITLE
Bug 1228089 - Detect if the user has a URL in their clipboard when re-entering the app

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -246,6 +246,13 @@ class BrowserViewController: UIViewController {
         })
     }
 
+    func SELdetectClipboardURL() {
+        if let clipboardURL = UIPasteboard.generalPasteboard().string?.asURL where profile.prefs.boolForKey("goToCopiedURL") == true {
+                log.debug("There is a URL on the clipboard")
+                print(clipboardURL)
+        }
+    }
+
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: BookmarkStatusChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
@@ -259,6 +266,8 @@ class BrowserViewController: UIViewController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELBookmarkStatusDidChange:", name: BookmarkStatusChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappWillResignActiveNotification", name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappDidBecomeActiveNotification", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELdetectClipboardURL", name: UIApplicationDidBecomeActiveNotification, object: nil)
+
         KeyboardHelper.defaultHelper.addDelegate(self)
 
         log.debug("BVC adding footer and header…")
@@ -341,6 +350,12 @@ class BrowserViewController: UIViewController {
 
         log.debug("BVC updating toolbar state…")
         self.updateToolbarStateForTraitCollection(self.traitCollection)
+
+        // Need to detect URL on clipboard every time BVC is initialized (except during the first on-boarding)
+        // since attaching it to the DidBecomeActiveNotification at first won't get triggered.
+        if profile.prefs.intForKey(IntroViewControllerSeenProfileKey) == 1 {
+            SELdetectClipboardURL()
+        }
 
         log.debug("BVC setting up constraints…")
         setupConstraints()


### PR DESCRIPTION
1. Added an observer in BVC to check if there's a URL on the clipboard every time the app enters the foreground (however, this check doesn't occur whenever there's a cold start since the observer gets added when BVC is initialized; I just followed the spec and didn't account for that case)
2. printed the URL to console (it also wasn't specific if the URL had to be valid or not, just the fact that it was on the clipboard)

**Thus, two questions:**
_-should we be checking the clipboard every time the app becomes active (first starts up) as well?_
_-should we do some parsing to make sure the URL is a valid one as opposed to "asdfasdfas"_