### PR TITLE
Bug 1241190 – Fix Crash for about:blank in Spotlight Helper.

### DIFF
--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -47,6 +47,10 @@ class SpotlightHelper: NSObject {
     }
 
     func update(pageContent: [String: String], forURL url: NSURL) {
+        if AboutUtils.isAboutURL(url) || url.scheme == "about" {
+            return
+        }
+
         var activity: NSUserActivity
         if let currentActivity = self.activity where currentActivity.webpageURL == url {
             activity = currentActivity


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1241190

This detects about: schemes. It does not explicitly handle all the other non-valid schemes, though these are prevented from loading (i.e. the `about` scheme is the only invalid scheme that the webview is allowed to open).