### PR TITLE
Bug 1244138 - Temporarily hide placeholder images for favicons on the Login list/detail pages

### DIFF
--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -418,7 +418,7 @@ private class LoginCursorDataSource: NSObject, UITableViewDataSource {
         let cell = tableView.dequeueReusableCellWithIdentifier(LoginCellIdentifier, forIndexPath: indexPath) as! LoginTableViewCell
 
         let login = loginAtIndexPath(indexPath)
-        cell.style = .IconAndBothLabels
+        cell.style = .NoIconAndBothLabels
         cell.updateCellWithLogin(login)
 
         return cell

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -141,7 +141,7 @@ extension LoginDetailViewController: UITableViewDataSource {
         switch InfoItem(rawValue: indexPath.row)! {
         case .TitleItem:
             let loginCell = dequeueLoginCellForIndexPath(indexPath)
-            loginCell.style = .IconAndDescriptionLabel
+            loginCell.style = .NoIconAndBothLabels
             loginCell.descriptionLabel.text = login.hostname
             return loginCell
 


### PR DESCRIPTION
A temporary patch for hiding the placeholder favicons for the 2.0 release.