### PR TITLE
Bug 1239028 – Ensure spotlight displays favicon on first time visit to page

### DIFF
--- a/Client/Frontend/Browser/FaviconManager.swift
+++ b/Client/Frontend/Browser/FaviconManager.swift
@@ -34,6 +34,7 @@ class FaviconManager : BrowserHelper {
         let manager = SDWebImageManager.sharedManager()
         self.browser?.favicons.removeAll(keepCapacity: false)
         if let tab = self.browser,
+            let currentURL = tab.url,
             let url = tab.url?.absoluteString {
                 let site = Site(url: url, title: "")
                 var favicons = [Favicon]()
@@ -60,13 +61,17 @@ class FaviconManager : BrowserHelper {
                                 fav.width = Int(img.size.width)
                                 fav.height = Int(img.size.height)
                             } else {
+                                if favicons.count == 1 && favicons[0].type == .Guess {
+                                    // No favicon is indicated in the HTML
+                                    self.noFaviconAvailable(tab, atURL: currentURL)
+                                }
                                 return
                             }
 
                             if !tab.isPrivate {
                                 self.profile.favicons.addFavicon(fav, forSite: site)
                                 if tab.favicons.isEmpty {
-                                    self.makeFaviconAvailable(tab, atURL: tab.url!, favicon: fav, withImage: img)
+                                    self.makeFaviconAvailable(tab, atURL: currentURL, favicon: fav, withImage: img)
                                 }
                             }
                             tab.favicons.append(fav)
@@ -79,5 +84,11 @@ class FaviconManager : BrowserHelper {
     func makeFaviconAvailable(tab: Browser, atURL url: NSURL, favicon: Favicon, withImage image: UIImage) {
         let helper = tab.getHelper(name: "SpotlightHelper") as? SpotlightHelper
         helper?.updateImage(image, forURL: url)
+    }
+
+    func noFaviconAvailable(tab: Browser, atURL url: NSURL) {
+        let helper = tab.getHelper(name: "SpotlightHelper") as? SpotlightHelper
+        helper?.updateImage(forURL: url)
+
     }
 }

--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -69,17 +69,17 @@ class SpotlightHelper: NSObject {
                 activity.contentAttributeSet = attrs
                 activity.eligibleForSearch = true
 
-                // We can't be certain that the favicon isn't already available.
-                // If it is, for this URL, then update the activity with the favicon now.
-                if let image = thumbnailImage where urlForThumbnail == url {
-                    updateImage(image, forURL: url)
-                }
             }
         }
-        activity.becomeCurrent()
+
+        // We can't be certain that the favicon isn't already available.
+        // If it is, for this URL, then update the activity with the favicon now.
+        if urlForThumbnail == url {
+            updateImage(thumbnailImage, forURL: url)
+        }
     }
 
-    func updateImage(image: UIImage, forURL url: NSURL) {
+    func updateImage(image: UIImage? = nil, forURL url: NSURL) {
         guard let currentActivity = self.activity where currentActivity.webpageURL == url else {
             // We've got a favicon, but not for this URL.
             // Let's store it until we can get the title and description.
@@ -89,10 +89,14 @@ class SpotlightHelper: NSObject {
         }
 
         if #available(iOS 9.0, *) {
-            activity?.contentAttributeSet?.thumbnailData = UIImagePNGRepresentation(image)
+            if let image = image {
+                activity?.contentAttributeSet?.thumbnailData = UIImagePNGRepresentation(image)
+            }
         }
         urlForThumbnail = nil
         thumbnailImage = nil
+
+        becomeCurrent()
     }
 
     func becomeCurrent() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1239028

The primary cause of this bug is that once becomeCurrent() has been called, setting the thumbnail data doesn't make any effect.

The fix is to ensure that the we call becomeCurrent() only once, but we need to be able to detect when no favicons are available.

There is a corner case here, which is that if favicons are specified in the HTML, but they all fail to load, then the page won't be be available for Spotlight or handoff.