### PR TITLE
Bug 1244829 - SupportUtils.URLForTopic should use languageIdentifier instead of localeIdentifier

### DIFF
--- a/SharedTests/SupportUtilsTests.swift
+++ b/SharedTests/SupportUtilsTests.swift
@@ -9,9 +9,9 @@ import XCTest
 class SupportUtilsTests: XCTestCase {
     func testURLForTopic() {
         let appVersion = AppInfo.appVersion
-        let localeIdentifier = NSLocale.currentLocale().localeIdentifier
-        XCTAssertEqual(SupportUtils.URLForTopic("Bacon")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/Bacon")
-        XCTAssertEqual(SupportUtils.URLForTopic("Cheese & Crackers")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/Cheese%20&%20Crackers")
-        XCTAssertEqual(SupportUtils.URLForTopic("Möbelträgerfüße")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(localeIdentifier)/M%C3%B6beltr%C3%A4gerf%C3%BC%C3%9Fe")
+        let languageIdentifier = NSLocale.preferredLanguages().first!
+        XCTAssertEqual(SupportUtils.URLForTopic("Bacon")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(languageIdentifier)/Bacon")
+        XCTAssertEqual(SupportUtils.URLForTopic("Cheese & Crackers")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(languageIdentifier)/Cheese%20&%20Crackers")
+        XCTAssertEqual(SupportUtils.URLForTopic("Möbelträgerfüße")?.absoluteString, "https://support.mozilla.org/1/mobile/\(appVersion)/iOS/\(languageIdentifier)/M%C3%B6beltr%C3%A4gerf%C3%BC%C3%9Fe")
     }
 }

--- a/Utils/SupportUtils.swift
+++ b/Utils/SupportUtils.swift
@@ -12,9 +12,10 @@ public struct SupportUtils {
     /// The resulting NSURL will include the app version, operating system and locale code. For example, a topic
     /// "cheese" will be turned into a link that looks like https://support.mozilla.org/1/mobile/2.0/iOS/en-US/cheese
     public static func URLForTopic(topic: String) -> NSURL? {
-        guard let escapedTopic = topic.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLPathAllowedCharacterSet()) else {
+        guard let escapedTopic = topic.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLPathAllowedCharacterSet()),
+                languageIdentifier = NSLocale.preferredLanguages().first else {
             return nil
         }
-        return NSURL(string: "https://support.mozilla.org/1/mobile/\(AppInfo.appVersion)/iOS/\(NSLocale.currentLocale().localeIdentifier)/\(escapedTopic)")
+        return NSURL(string: "https://support.mozilla.org/1/mobile/\(AppInfo.appVersion)/iOS/\(languageIdentifier)/\(escapedTopic)")
     }
 }


### PR DESCRIPTION
This patch makes SupportUtils.URLForTopic use the *language identifier* instead of the *locale identifier*.