### PR TITLE
Issue# 1482: slow compile times. Quick (and arbitrary changes) to syntax makes compiling faster

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -654,8 +654,8 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
         // visible cells do sometimes return also not visible cells when attempting to go past the last cell with VoiceOver right-flick gesture; so make sure we have only visible cells (yeah...)
         visibleCells = visibleCells.filter { !CGRectIsEmpty(CGRectIntersection($0.frame, bounds)) }
 
-        let indexPaths = visibleCells.map { self.collectionView.indexPathForCell($0)! }
-            .sort { $0.section < $1.section || ($0.section == $1.section && $0.row < $1.row) }
+        let cells = visibleCells.map { self.collectionView.indexPathForCell($0)! }
+        let indexPaths = cells.sort { $0.section < $1.section || ($0.section == $1.section && $0.row < $1.row) }
 
         if indexPaths.count == 0 {
             return NSLocalizedString("No tabs", comment: "Message spoken by VoiceOver to indicate that there are no tabs in the Tabs Tray")

--- a/Storage/SQL/BrowserTable.swift
+++ b/Storage/SQL/BrowserTable.swift
@@ -527,8 +527,7 @@ public class BrowserTable: Table {
         let views = AllViews.map { "DROP VIEW IF EXISTS \($0)" }
         let indices = AllIndices.map { "DROP INDEX IF EXISTS \($0)" }
         let tables = AllTables.map { "DROP TABLE IF EXISTS \($0)" }
-        let queries = views + indices + tables + additional
-
+        let queries = Array([views, indices, tables, additional].flatten())
         return self.run(db, queries: queries)
     }
 }

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -390,31 +390,9 @@ public class SQLiteLogins: BrowserLogins {
     }
 
     private func cloneMirrorToOverlay(whereClause whereClause: String?, args: Args?) -> Deferred<Maybe<Int>> {
-        let shared =
-        "guid " +
-        ", hostname" +
-        ", httpRealm" +
-        ", formSubmitURL" +
-        ", usernameField" +
-        ", passwordField" +
-        ", timeCreated" +
-        ", timeLastUsed" +
-        ", timePasswordChanged" +
-        ", timesUsed" +
-        ", username" +
-        ", password "
-
-        let local =
-        ", local_modified " +
-        ", is_deleted " +
-        ", sync_status "
-
-        let sql = "INSERT OR IGNORE INTO \(TableLoginsLocal) " +
-        "(\(shared)\(local)) " +
-        "SELECT \(shared), NULL AS local_modified, 0 AS is_deleted, 0 AS sync_status " +
-        "FROM \(TableLoginsMirror) " +
-        (whereClause ?? "")
-
+        let shared = "guid, hostname, httpRealm, formSubmitURL, usernameField, passwordField, timeCreated, timeLastUsed, timePasswordChanged, timesUsed, username, password "
+        let local = ", local_modified, is_deleted, sync_status "
+        let sql = "INSERT OR IGNORE INTO \(TableLoginsLocal) (\(shared)\(local)) SELECT \(shared), NULL AS local_modified, 0 AS is_deleted, 0 AS sync_status FROM \(TableLoginsMirror) \(whereClause ?? "")"
         return self.db.write(sql, withArgs: args)
     }
 


### PR DESCRIPTION
TabTrayController: 60s to 7s
BrowserTable: 4s to <0.5s
SQLiteLogins: 7s to <0.5s

I didn't put too much time into the exact causes here; just changing to equivalent syntax produces an acceptable speedup.

See issue #1482 