### PR TITLE
Bug 1234086 - Ensure that the tab tray is dismissed on 3DT & Spotligh…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -938,8 +938,9 @@ class BrowserViewController: UIViewController {
     }
 
     func switchToTabForURLOrOpen(url: NSURL) {
-        popToBrowser()
-        if let tab = tabManager.getTabForURL(url) {
+        let tab = tabManager.getTabForURL(url)
+        popToBrowser(tab)
+        if let tab = tab {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url)
@@ -973,14 +974,16 @@ class BrowserViewController: UIViewController {
         urlBar.browserLocationViewDidTapLocation(urlBar.locationView)
     }
 
-    private func popToBrowser() {
-        guard let currentViewController = navigationController?.topViewController,
-            let presentedViewController = currentViewController.presentedViewController else {
+    private func popToBrowser(forTab: Browser? = nil) {
+        guard let currentViewController = navigationController?.topViewController else {
                 return
         }
-        
-        presentedViewController.dismissViewControllerAnimated(false, completion: nil)
-        if currentViewController != self {
+        if let presentedViewController = currentViewController.presentedViewController {
+            presentedViewController.dismissViewControllerAnimated(false, completion: nil)
+        }
+        // if a tab already exists and the top VC is not the BVC then pop the top VC, otherwise don't.
+        if currentViewController != self,
+            let _ = forTab {
             self.navigationController?.popViewControllerAnimated(true)
         }
     }


### PR DESCRIPTION
…t when the tab already exists

* only occurs when app is in tab tray when placed in background and app is still running
* when creating a new tab, tab tray dismissed automatically
* when selected an existing tab then the tab tray fails to dismiss
* ensure that if the tab to select already exists then dismiss the tab tray.

https://bugzilla.mozilla.org/show_bug.cgi?id=1245086