### PR TITLE
Bug 1245976 - Allow livemarks to have no title.

### DIFF
--- a/Storage/Bookmarks.swift
+++ b/Storage/Bookmarks.swift
@@ -75,7 +75,7 @@ public struct BookmarkMirrorItem {
             children: children)
     }
 
-    public static func livemark(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String, title: String, description: String?, feedURI: String, siteURI: String) -> BookmarkMirrorItem {
+    public static func livemark(guid: GUID, modified: Timestamp, hasDupe: Bool, parentID: GUID, parentName: String?, title: String?, description: String?, feedURI: String, siteURI: String) -> BookmarkMirrorItem {
         let id = BookmarkRoots.translateIncomingRootGUID(guid)
         let parent = BookmarkRoots.translateIncomingRootGUID(parentID)
 

--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -492,8 +492,8 @@ extension LivemarkPayload: MirrorItemable {
             hasDupe: self.hasDupe,
             // TODO: these might need to be weakened if real-world data is dirty.
             parentID: self["parentid"].asString!,
-            parentName: self["parentName"].asString!,
-            title: self["title"].asString!,
+            parentName: self["parentName"].asString,
+            title: self["title"].asString,
             description: self["description"].asString,
             feedURI: self.feedURI!,
             siteURI: self.siteURI!

--- a/SyncTests/RecordTests.swift
+++ b/SyncTests/RecordTests.swift
@@ -246,6 +246,31 @@ class RecordTests: XCTestCase {
         XCTAssertTrue(bookmark?.isValid() ?? false)
     }
 
+    func testLivemarkMissingFields() {
+        let json = JSON([
+            "id": "M5bwUKK8hPyF",
+            "type": "livemark",
+            "siteUri": "http://www.bbc.co.uk/go/rss/int/news/-/news/",
+            "feedUri": "http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml",
+            "parentName": "Bookmarks Toolbar",
+            "parentid": "toolbar",
+            "children": ["3Qr13GucOtEh"]])
+
+        let bookmark = BookmarkType.payloadFromJSON(json)
+        XCTAssertTrue(bookmark is LivemarkPayload)
+
+        let livemark = bookmark as! LivemarkPayload
+        XCTAssertTrue(livemark.isValid() ?? false)
+        let siteURI = "http://www.bbc.co.uk/go/rss/int/news/-/news/"
+        let feedURI = "http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml"
+        XCTAssertEqual(feedURI, livemark.feedURI)
+        XCTAssertEqual(siteURI, livemark.siteURI)
+
+        let m = (livemark as MirrorItemable).toMirrorItem(NSDate.now())
+        XCTAssertEqual("http://fxfeeds.mozilla.com/en-US/firefox/headlines.xml", m.feedURI)
+        XCTAssertEqual("http://www.bbc.co.uk/go/rss/int/news/-/news/", m.siteURI)
+    }
+
     func testLivemark() {
         let json = JSON([
             "id": "M5bwUKK8hPyF",


### PR DESCRIPTION
nsLivemarkService doesn't seem to restrict created livemarks from having no title.

This allows that to pass through.

Adds a test.