### PR TITLE
Bug 1245503 - Added matching login validation as toolkit to prevent saving invalid logins

### DIFF
--- a/Client/Frontend/Browser/LoginsHelper.swift
+++ b/Client/Frontend/Browser/LoginsHelper.swift
@@ -135,6 +135,10 @@ class LoginsHelper: BrowserHelper {
     }
 
     private func promptSave(login: LoginData) {
+        guard login.isValid.isSuccess else {
+            return
+        }
+
         let promptMessage: NSAttributedString
         if let username = login.username {
             let promptStringFormat = NSLocalizedString("Do you want to save the password for %@ on %@?", comment: "Prompt for saving a password. The first parameter is the username being saved. The second parameter is the hostname of the site.")
@@ -168,6 +172,10 @@ class LoginsHelper: BrowserHelper {
     }
 
     private func promptUpdateFromLogin(login old: LoginData, toLogin new: LoginData) {
+        guard new.isValid.isSuccess else {
+            return
+        }
+
         let guid = old.guid
 
         let formatted: String

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -373,13 +373,14 @@ extension LoginDetailViewController {
         editingInfo = false
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Edit, target: self, action: "SELedit")
 
-        let username = usernameField?.text ?? ""
-        let password = passwordField?.text ?? ""
+        // We only care to update if we changed something
+        guard let username = usernameField?.text, password = passwordField?.text
+            where username != login.username || password != login.password else {
+            return
+        }
 
-        // Update login if there were any changes
-        if username != login.username || password != login.password {
-            // Update local, in-memory copy to view changes right away.
-            login = Login(guid: login.guid, hostname: login.hostname, username: username, password: password)
+        let updated = Login(guid: login.guid, hostname: login.hostname, username: username, password: password)
+        if updated.isValid.isSuccess {
             profile.logins.updateLoginByGUID(login.guid, new: login, significant: true)
         }
     }

--- a/ClientTests/AuthenticatorTests.swift
+++ b/ClientTests/AuthenticatorTests.swift
@@ -33,6 +33,7 @@ class MockMalformableLogin: LoginData {
     var usernameField: String?
     var passwordField: String?
     var hasMalformedHostname = true
+    var isValid = Maybe(success: ())
 
     static func createWithHostname(hostname: String, username: String, password: String) -> MockMalformableLogin {
         return self.init(guid: Bytes.generateGUID(), hostname: hostname, username: username, password: password)

--- a/Storage/Logins.swift
+++ b/Storage/Logins.swift
@@ -104,6 +104,7 @@ public protocol LoginData: class {
     var formSubmitURL: String? { get set }
     var usernameField: String? { get set }
     var passwordField: String? { get set }
+    var isValid: Maybe<()> { get }
 
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1238103
     var hasMalformedHostname: Bool { get set }
@@ -179,6 +180,33 @@ public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatabl
         return "Login for \(hostname)"
     }
 
+    public var isValid: Maybe<()> {
+        // Referenced from https://mxr.mozilla.org/mozilla-central/source/toolkit/components/passwordmgr/nsLoginManager.js?rev=f76692f0fcf8&mark=280-281#271
+
+        // Logins with empty hostnames are not valid.
+        if hostname.isEmpty {
+            return Maybe(failure: LoginDataError(description: "Can't add a login with an empty hostname."))
+        }
+
+        // Logins with empty passwords are not valid.
+        if password.isEmpty {
+            return Maybe(failure: LoginDataError(description: "Can't add a login with an empty password."))
+        }
+
+        // Logins with both a formSubmitURL and httpRealm are not valid.
+        if let _ = formSubmitURL, _ = httpRealm {
+            return Maybe(failure: LoginDataError(description: "Can't add a login with both a httpRealm and formSubmitURL."))
+        }
+
+        // Login must have at least a formSubmitURL or httpRealm.
+        if (formSubmitURL == nil) && (httpRealm == nil) {
+            return Maybe(failure: LoginDataError(description: "Can't add a login without a httpRealm or formSubmitURL."))
+        }
+
+        // All good.
+        return Maybe(success: ())
+    }
+
     // Essentially: should we sync a change?
     // Desktop ignores usernameField and hostnameField.
     public func isSignificantlyDifferentFrom(login: LoginData) -> Bool {
@@ -187,6 +215,13 @@ public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatabl
                login.username != self.username ||
                login.formSubmitURL != self.formSubmitURL ||
                login.httpRealm != self.httpRealm
+    }
+    
+    /* Used for testing purposes since formSubmitURL should be given back to use from the Logins.js script */
+    public class func createWithHostname(hostname: String, username: String, password: String, formSubmitURL: String?) -> LoginData {
+        let loginData = Login(hostname: hostname, username: username, password: password) as LoginData
+        loginData.formSubmitURL = formSubmitURL
+        return loginData
     }
 
     public class func createWithHostname(hostname: String, username: String, password: String) -> LoginData {

--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -352,6 +352,10 @@ public class SQLiteLogins: BrowserLogins {
     }
 
     public func addLogin(login: LoginData) -> Success {
+        if let error = login.isValid.failureValue {
+            return deferMaybe(error)
+        }
+
         let nowMicro = NSDate.nowMicroseconds()
         let nowMilli = nowMicro / 1000
         let dateMicro = NSNumber(unsignedLongLong: nowMicro)
@@ -460,6 +464,10 @@ public class SQLiteLogins: BrowserLogins {
      * without triggering an upload or a conflict.
      */
     public func updateLoginByGUID(guid: GUID, new: LoginData, significant: Bool) -> Success {
+        if let error = new.isValid.failureValue {
+            return deferMaybe(error)
+        }
+
         // Right now this method is only ever called if the password changes at
         // point of use, so we always set `timePasswordChanged` and `timeLastUsed`.
         // We can (but don't) also assume that `significant` will always be `true`,

--- a/UITests/LoginInputTests.swift
+++ b/UITests/LoginInputTests.swift
@@ -57,4 +57,40 @@ class LoginInputTests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Do you want to update the password for \(username) on \(webRoot)?")
         tester().tapViewWithAccessibilityLabel("Update")
     }
+
+    func testLoginFormDoesntOfferSaveWhenEmptyPassword() {
+        tester().tapViewWithAccessibilityIdentifier("url")
+        let url = "\(webRoot)/loginForm.html"
+        let username = "test@user.com"
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        tester().enterText(username, intoWebViewInputWithName: "username")
+        tester().enterText("", intoWebViewInputWithName: "password")
+        tester().tapWebViewElementWithAccessibilityLabel("submit_btn")
+
+        // Wait a bit then verify that we haven't shown the prompt
+        tester().waitForTimeInterval(2)
+        XCTAssertFalse(tester().viewExistsWithLabel("Do you want to save the password for \(username) on \(webRoot)?"))
+    }
+
+    func testLoginFormDoesntOfferUpdateWhenEmptyPassword() {
+        tester().tapViewWithAccessibilityIdentifier("url")
+        let url = "\(webRoot)/loginForm.html"
+        let username = "test@user.com"
+        let password1 = "password1"
+        let password2 = ""
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url)\n")
+        tester().enterText(username, intoWebViewInputWithName: "username")
+        tester().enterText(password1, intoWebViewInputWithName: "password")
+        tester().tapWebViewElementWithAccessibilityLabel("submit_btn")
+        tester().waitForViewWithAccessibilityLabel("Do you want to save the password for \(username) on \(webRoot)?")
+        tester().tapViewWithAccessibilityLabel("Yes")
+
+        tester().enterText(username, intoWebViewInputWithName: "username")
+        tester().enterText(password2, intoWebViewInputWithName: "password")
+        tester().tapWebViewElementWithAccessibilityLabel("submit_btn")
+
+        // Wait a bit then verify that we haven't shown the prompt
+        tester().waitForTimeInterval(2)
+        XCTAssertFalse(tester().viewExistsWithLabel("Do you want to update the password for \(username) on \(webRoot)?"))
+    }
 }

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -548,7 +548,6 @@ class LoginManagerTests: KIFTestCase {
     }
 
     func testLoginDetailDisplaysLastModified() {
-
         openLoginManager()
 
         tester().waitForViewWithAccessibilityLabel("a0@email.com, http://a0.com")
@@ -557,6 +556,28 @@ class LoginManagerTests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("password")
 
         XCTAssertTrue(tester().viewExistsWithLabelPrefixedBy("Last modified"))
+        tester().tapViewWithAccessibilityLabel("Back")
+        closeLoginManager()
+    }
+
+    func testPreventBlankPasswordInDetail() {
+        let list = tester().waitForViewWithAccessibilityIdentifier("Login Detail List") as! UITableView
+
+        tester().tapViewWithAccessibilityLabel("Edit")
+
+        // Check that we've selected the username field
+        var passwordCell = list.cellForRowAtIndexPath(NSIndexPath(forRow: 2, inSection: 0)) as! LoginTableViewCell
+        var passwordField = passwordCell.descriptionLabel
+
+        tester().tapViewWithAccessibilityLabel("Next")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("")
+        tester().tapViewWithAccessibilityLabel("Done")
+
+        passwordCell = list.cellForRowAtIndexPath(NSIndexPath(forRow: 2, inSection: 0)) as! LoginTableViewCell
+        passwordField = passwordCell.descriptionLabel
+
+        // Confirm that when entering a blank password we revert back to the original
+        XCTAssertEqual(passwordField.text, "passworda0")
 
         tester().tapViewWithAccessibilityLabel("Back")
         closeLoginManager()

--- a/Utils/Extensions/NSURLProtectionSpaceExtensions.swift
+++ b/Utils/Extensions/NSURLProtectionSpaceExtensions.swift
@@ -7,6 +7,11 @@ import Foundation
 extension NSURLProtectionSpace {
 
     public func urlString() -> String {
+        // If our host is empty, return nothing since it doesn't make sense to add the scheme or port.
+        guard !host.isEmpty else {
+            return ""
+        }
+
         var urlString: String
         if let p = `protocol` {
             urlString = "\(p)://\(host)"


### PR DESCRIPTION
Note: There seems to be unrelated issue with master where the tests will fail because of the open new tab on launch so the tests might not be runnable :(