### PR TITLE
Bug 1236956 Prevent crash on DB connection failure

### DIFF
--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -231,22 +231,25 @@ public class BrowserDB {
 
     typealias IntCallback = (connection: SQLiteDBConnection, inout err: NSError?) -> Int
 
-    func withConnection<T>(flags flags: SwiftData.Flags, inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> T) -> T {
+    func withConnection<T>(flags flags: SwiftData.Flags, inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> T) throws -> T {
         var res: T!
         err = db.withConnection(flags) { connection in
             var err: NSError? = nil
             res = callback(connection: connection, err: &err)
             return err
         }
+        if let err = err {
+            throw err
+        }
         return res
     }
 
-    func withWritableConnection<T>(inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> T) -> T {
-        return withConnection(flags: SwiftData.Flags.ReadWrite, err: &err, callback: callback)
+    func withWritableConnection<T>(inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> T) throws -> T {
+        return try withConnection(flags: SwiftData.Flags.ReadWrite, err: &err, callback: callback)
     }
 
-    func withReadableConnection<T>(inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> Cursor<T>) -> Cursor<T> {
-        return withConnection(flags: SwiftData.Flags.ReadOnly, err: &err, callback: callback)
+    func withReadableConnection<T>(inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> Cursor<T>) throws -> Cursor<T> {
+        return try withConnection(flags: SwiftData.Flags.ReadOnly, err: &err, callback: callback)
     }
 
     func transaction(inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> Bool) -> NSError? {
@@ -428,3 +431,6 @@ extension SQLiteDBConnection {
         return res.count > 0
     }
 }
+
+
+

--- a/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
+++ b/Storage/SQL/SQLiteRemoteClientsAndTabs.swift
@@ -141,19 +141,23 @@ public class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     public func getClients() -> Deferred<Maybe<[RemoteClient]>> {
         var err: NSError?
 
-        let clientCursor = db.withReadableConnection(&err) { connection, _ in
-            return self.clients.query(connection, options: nil)
-        }
+        do {
+            let clientCursor = try db.withReadableConnection(&err) { connection, _ in
+                return self.clients.query(connection, options: nil)
+            }
 
-        if let err = err {
+            if let err = err {
+                clientCursor.close()
+                throw err
+            }
+            let clients = clientCursor.asArray()
             clientCursor.close()
-            return deferMaybe(DatabaseError(err: err))
+            return deferMaybe(clients)
+        } catch let error as NSError {
+            log.error(error.localizedDescription)
+            err = error
         }
-
-        let clients = clientCursor.asArray()
-        clientCursor.close()
-
-        return deferMaybe(clients)
+        return deferMaybe(DatabaseError(err: err))
     }
 
     public func getClientGUIDs() -> Deferred<Maybe<Set<GUID>>> {
@@ -186,66 +190,72 @@ public class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     public func getClientsAndTabs() -> Deferred<Maybe<[ClientAndTabs]>> {
         var err: NSError?
 
-        // Now find the clients.
-        let clientCursor = db.withReadableConnection(&err) { connection, _ in
-            return self.clients.query(connection, options: nil)
-        }
+        do {
+            // Now find the clients.
+            let clientCursor = try db.withReadableConnection(&err) { connection, _ in
+                return self.clients.query(connection, options: nil)
+            }
 
-        if let err = err {
+            if let err = err {
+                clientCursor.close()
+                throw err
+            }
+
+            let clients = clientCursor.asArray()
             clientCursor.close()
-            return deferMaybe(DatabaseError(err: err))
-        }
 
-        let clients = clientCursor.asArray()
-        clientCursor.close()
+            log.debug("Found \(clients.count) clients in the DB.")
 
-        log.debug("Found \(clients.count) clients in the DB.")
+            let tabCursor = try db.withReadableConnection(&err) { connection, _ in
+                return self.tabs.query(connection, options: nil)
+            }
 
-        let tabCursor = db.withReadableConnection(&err) { connection, _ in
-            return self.tabs.query(connection, options: nil)
-        }
+            log.debug("Found \(tabCursor.count) raw tabs in the DB.")
 
-        log.debug("Found \(tabCursor.count) raw tabs in the DB.")
+            if let err = err {
+                tabCursor.close()
+                throw err
+            }
 
-        if let err = err {
-            tabCursor.close()
-            return deferMaybe(DatabaseError(err: err))
-        }
+            let deferred = Deferred<Maybe<[ClientAndTabs]>>(defaultQueue: dispatch_get_main_queue())
 
-        let deferred = Deferred<Maybe<[ClientAndTabs]>>(defaultQueue: dispatch_get_main_queue())
-
-        // Aggregate clientGUID -> RemoteTab.
-        var acc = [String: [RemoteTab]]()
-        for tab in tabCursor {
-            if let tab = tab, guid = tab.clientGUID {
-                if acc[guid] == nil {
-                    acc[guid] = [tab]
+            // Aggregate clientGUID -> RemoteTab.
+            var acc = [String: [RemoteTab]]()
+            for tab in tabCursor {
+                if let tab = tab, guid = tab.clientGUID {
+                    if acc[guid] == nil {
+                        acc[guid] = [tab]
+                    } else {
+                        acc[guid]!.append(tab)
+                    }
                 } else {
-                    acc[guid]!.append(tab)
+                    log.error("Couldn't cast tab \(tab) to RemoteTab.")
                 }
-            } else {
-                log.error("Couldn't cast tab \(tab) to RemoteTab.")
             }
-        }
 
-        tabCursor.close()
+            tabCursor.close()
 
-        // Most recent first.
-        let fillTabs: (RemoteClient) -> ClientAndTabs = { client in
-            var tabs: [RemoteTab]? = nil
-            if let guid: String = client.guid {
-                tabs = acc[guid]
+            // Most recent first.
+            let fillTabs: (RemoteClient) -> ClientAndTabs = { client in
+                var tabs: [RemoteTab]? = nil
+                if let guid: String = client.guid {
+                    tabs = acc[guid]
+                }
+                return ClientAndTabs(client: client, tabs: tabs ?? [])
             }
-            return ClientAndTabs(client: client, tabs: tabs ?? [])
-        }
 
-        let removeLocalClient: (RemoteClient) -> Bool = { client in
-            return client.guid != nil
-        }
+            let removeLocalClient: (RemoteClient) -> Bool = { client in
+                return client.guid != nil
+            }
 
-        // Why is this whole function synchronous?
-        deferred.fill(Maybe(success: clients.filter(removeLocalClient).map(fillTabs)))
-        return deferred
+            // Why is this whole function synchronous?
+            deferred.fill(Maybe(success: clients.filter(removeLocalClient).map(fillTabs)))
+            return deferred
+        } catch let error as NSError {
+            log.error(error.localizedDescription)
+            err = error
+        }
+        return deferMaybe(DatabaseError(err: err))
     }
 
     public func deleteCommands() -> Success {
@@ -305,23 +315,29 @@ public class SQLiteRemoteClientsAndTabs: RemoteClientsAndTabs {
     public func getCommands() -> Deferred<Maybe<[GUID: [SyncCommand]]>> {
         var err: NSError?
 
-        // Now find the clients.
-        let commandCursor = db.withReadableConnection(&err) { connection, _ in
-            return self.commands.query(connection, options: nil)
-        }
+        do {
+            // Now find the clients.
+            let commandCursor = try db.withReadableConnection(&err) { connection, _ in
+                return self.commands.query(connection, options: nil)
+            }
 
-        if let err = err {
+            if let err = err {
+                commandCursor.close()
+                throw err
+            }
+
+            let allCommands = commandCursor.asArray()
             commandCursor.close()
-            return failOrSucceed(err, op: "getCommands", val: [GUID: [SyncCommand]]())
+
+            let clientSyncCommands = clientsFromCommands(allCommands)
+
+            log.debug("Found \(clientSyncCommands.count) client sync commands in the DB.")
+            return failOrSucceed(err, op: "get commands", val: clientSyncCommands)
+        }  catch let error as NSError {
+            log.error(error.localizedDescription)
+            err = error
         }
-
-        let allCommands = commandCursor.asArray()
-        commandCursor.close()
-
-        let clientSyncCommands = clientsFromCommands(allCommands)
-
-        log.debug("Found \(clientSyncCommands.count) client sync commands in the DB.")
-        return failOrSucceed(err, op: "get commands", val: clientSyncCommands)
+        return failOrSucceed(err, op: "getCommands", val: [GUID: [SyncCommand]]())
     }
 
     func clientsFromCommands(commands: [SyncCommand]) -> [GUID: [SyncCommand]] {

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -408,13 +408,15 @@ public class SQLiteDBConnection {
         if key == nil && prevKey == nil {
             do {
                 try self.prepareCleartext()
-            } catch {
+            } catch let err as NSError {
+                log.warning("Preparing to clear text failed: \(err)")
                 return nil
             }
         } else {
             do {
                 try self.prepareEncrypted(flags, key: key, prevKey: prevKey)
-            } catch {
+            } catch let err as NSError {
+                log.warning("Preparing to encrypt failed: \(err)")
                 return nil
             }
         }


### PR DESCRIPTION
Also, add extra logging to help discover the cause of the crash.

There are a number of potential causes of the failure to fetch a connection. This patch adds a throws to the withConnection function in BrowserDB that simply throws the NSError returned by SwiftData and then calling functions either rethrow or handle that error appropriately. This should prevent the crash and provide extra understanding of the cause of crash by logging the error generated.

I have also added extra logging in SwiftData optional init in order to try and get a clearer understanding of why the connection failed.