### PR TITLE
Fixed What's New Tab feature to detect clean install vs. upgrade

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // We need to check if the app is a clean install to use for
         // preventing the What's New URL from appearing.
-        if getProfile(application).prefs.stringForKey(LatestAppVersionProfileKey) == nil {
+        if getProfile(application).prefs.stringForKey(IntroViewControllerSeenProfileKey) == nil {
             getProfile(application).prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
         }
         log.debug("Done with setting up the application.")

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // We need to check if the app is a clean install to use for
         // preventing the What's New URL from appearing.
-        if getProfile(application).prefs.stringForKey(IntroViewControllerSeenProfileKey) == nil {
+        if getProfile(application).prefs.intForKey(IntroViewControllerSeenProfileKey) == nil {
             getProfile(application).prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
         }
         log.debug("Done with setting up the application.")


### PR DESCRIPTION
If the intro has not been seen yet, that means it's a clean install meaning that we do not show the What's New page until the next upgrade. We do this by setting LatestAppVersionProfileKey to the current app version so that the What's new page is not shown until the next upgrade.