### PR TITLE
Bug 1218827 - Blur <select> elements when backgrounding

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -294,6 +294,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self.profile?.shutdown()
             application.endBackgroundTask(taskId)
         }
+
+        // Workaround for crashing in the background when <select> popovers are visible (rdar://24571325).
+        let jsBlurSelect = "if (document.activeElement && document.activeElement.tagName === 'SELECT') { document.activeElement.blur(); }"
+        tabManager.selectedTab?.webView?.evaluateJavaScript(jsBlurSelect, completionHandler: nil)
     }
 
     private func setUpWebServer(profile: Profile) {


### PR DESCRIPTION
The popover for HTML elements seems to be owned by `WKWebView`, so I don't think we can fix this directly. As a workaround, we can try removing focus from any active `<select>` elements when backgrounding, which should dismiss the popover.

Note that this isn't a complete fix: `evaluateJavaScript` only executes JS on the main frame, so we'll still crash for any popovers displayed for iframe `<select>`s. I tried using adding a user script (which allows injecting into iframes) that listened for [`visibilitychange`](https://developer.mozilla.org/en-US/docs/Web/Events/visibilitychange), but `visibilitychange` is fired too late after backgrounding for the fix to work.