### PR TITLE
Bug 1246921 - Regression: Editing logins no longer update from detail screen

### DIFF
--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -6,6 +6,10 @@ import Foundation
 
 class TestAppDelegate: AppDelegate {
     override func getProfile(application: UIApplication) -> Profile {
+        if let profile = self.profile {
+            return profile
+        }
+
         // Use a clean profile for each test session.
         let profile = BrowserProfile(localName: "testProfile", app: application)
         _ = try? profile.files.removeFilesInDirectory()

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -379,9 +379,15 @@ extension LoginDetailViewController {
             return
         }
 
-        let updated = Login(guid: login.guid, hostname: login.hostname, username: username, password: password)
-        if updated.isValid.isSuccess {
+        // Keep a copy of the old data in case we fail and need to revert back
+        let oldPassword = login.password
+        let oldUsername = login.username
+        login.update(password: password, username: username)
+
+        if login.isValid.isSuccess {
             profile.logins.updateLoginByGUID(login.guid, new: login, significant: true)
+        } else if let oldUsername = oldUsername {
+            login.update(password: oldPassword, username: oldUsername)
         }
     }
 

--- a/Storage/Logins.swift
+++ b/Storage/Logins.swift
@@ -124,7 +124,7 @@ public protocol LoginUsageData {
 public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatable {
     public var guid: String
 
-    public let credentials: NSURLCredential
+    public private(set) var credentials: NSURLCredential
     public let protectionSpace: NSURLProtectionSpace
 
     public var hostname: String {
@@ -205,6 +205,11 @@ public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatabl
 
         // All good.
         return Maybe(success: ())
+    }
+
+    public func update(password _: String, username: String) {
+        self.credentials =
+            NSURLCredential(user: username, password: password, persistence: credentials.persistence)
     }
 
     // Essentially: should we sync a change?

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -303,14 +303,14 @@ class LoginManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Edit")
         tester().waitForAnimationsToFinish()
 
-        let pathsToSelect = (0..<5).map { NSIndexPath(forRow: $0, inSection: 0) }
+        let pathsToSelect = (0..<3).map { NSIndexPath(forRow: $0, inSection: 0) }
         pathsToSelect.forEach { path in
             tester().tapRowAtIndexPath(path, inTableViewWithAccessibilityIdentifier: "Login List")
         }
         tester().waitForViewWithAccessibilityLabel("Delete")
 
         pathsToSelect.forEach { path in
-            XCTAssertTrue(list.cellForRowAtIndexPath(firstIndexPath)!.selected)
+            XCTAssertTrue(list.cellForRowAtIndexPath(path)!.selected)
         }
 
         // Deselect only first row
@@ -561,6 +561,13 @@ class LoginManagerTests: KIFTestCase {
     }
 
     func testPreventBlankPasswordInDetail() {
+        openLoginManager()
+
+        tester().waitForViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+        tester().tapViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+
+        tester().waitForViewWithAccessibilityLabel("password")
+
         let list = tester().waitForViewWithAccessibilityIdentifier("Login Detail List") as! UITableView
 
         tester().tapViewWithAccessibilityLabel("Edit")


### PR DESCRIPTION
I've also included a few No Bug patches to get the tests running again. After the 'Whats new' patch landed, retrieving the profile from the app delegate in LoginManagerTests was throwing an explicit unwrapped exception because of how getProfile now gets called multiple times in the AppDelegate class. Along with that, I found another bug when running the tests on smaller devices and fixed that as well.