### PR TITLE
Bug 1247305 - ensure that we don't try and re-present activity sheet …

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -113,13 +113,16 @@ class BrowserViewController: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
+
+        guard let displayedPopoverController = self.displayedPopoverController where displayedPopoverController.isBeingPresented() else {
+            return
+        }
+
+        displayedPopoverController.dismissViewControllerAnimated(true, completion: nil)
 
         coordinator.animateAlongsideTransition(nil) { context in
-            if let displayedPopoverController = self.displayedPopoverController {
-                self.updateDisplayedPopoverProperties?()
-                self.presentViewController(displayedPopoverController, animated: true, completion: nil)
-            }
+            self.updateDisplayedPopoverProperties?()
+            self.presentViewController(displayedPopoverController, animated: true, completion: nil)
         }
     }
 
@@ -215,6 +218,10 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    func SELappDidEnterBackgroundNotification() {
+        displayedPopoverController?.dismissViewControllerAnimated(false, completion: nil)
+    }
+
     func SELtappedTopArea() {
         scrollController.showToolbars(animated: true)
     }
@@ -247,6 +254,7 @@ class BrowserViewController: UIViewController {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: BookmarkStatusChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationWillEnterForegroundNotification, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidEnterBackgroundNotification, object: nil)
     }
 
     override func viewDidLoad() {
@@ -256,6 +264,7 @@ class BrowserViewController: UIViewController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELBookmarkStatusDidChange:", name: BookmarkStatusChangedNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappWillResignActiveNotification", name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappDidBecomeActiveNotification", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappDidEnterBackgroundNotification", name: UIApplicationDidEnterBackgroundNotification, object: nil)
         KeyboardHelper.defaultHelper.addDelegate(self)
 
         log.debug("BVC adding footer and header…")


### PR DESCRIPTION
…when entering background
https://bugzilla.mozilla.org/show_bug.cgi?id=1247305

The crash is caused by some code in `viewWillTransitionToSize` which, when called, dismisses any presented view controller and represents in the new size.
However, because when the animation occurs the view is no longer being displayed at all (viewWillTransitiionToSize gets called on backgrounding) it crashes as it has nothing to present the view from.

This fix adds a background notification observer and dismisses any presented vcs when entering the background. Then we `viewWillTransitionToSize` is called we check to see whether the presented vc is currently being displayed and don't try and redisplay if it isn't.

I did contemplate nullifying that presented view controller as well as dismissing it, but decided to keep it around so that it can be represented when coming to the foreground.