### PR TITLE
Bug 1247911 - Regression: The reader view controls menu is dismissed when switching orientation on iPhones

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -115,7 +115,7 @@ class BrowserViewController: UIViewController {
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
-        guard let displayedPopoverController = self.displayedPopoverController where displayedPopoverController.isBeingPresented() else {
+        guard let displayedPopoverController = self.displayedPopoverController else {
             return
         }
 


### PR DESCRIPTION
1. Due to this fix: https://bugzilla.mozilla.org/show_bug.cgi?id=1247305 , when we rotate, we already dismiss the presentation controller in `willTransitionToTraitCollection` which gets called first. Thus, when we try to update the reader mode presentation controller in `viewWillTransitionToSize`, we skip the animation to display the controller again due to the guard statement. Also, just checking that displayedPopoverController != nil suffices since `popoverPresentationControllerDidDismissPopover` sets that value to nil when we truly dismiss that popover (as opposed to backgrounding it for a bit or rotating the device, the controller is only temporarily "dismissed").
2. I tried testing this patch to see if https://bugzilla.mozilla.org/show_bug.cgi?id=1247305 would happen again. But it seems to be working with this new fix as well (tested on iPad Air, iPad Retina, iPad Air 2). Flagging @AaronMT to test this again though.
