### PR TITLE
Bug 1247911 - Regression: The reader view controls menu is dismissed when switching orientation on iPhones

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -115,11 +115,11 @@ class BrowserViewController: UIViewController {
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
+        displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
+
         guard let displayedPopoverController = self.displayedPopoverController else {
             return
         }
-
-        displayedPopoverController.dismissViewControllerAnimated(true, completion: nil)
 
         coordinator.animateAlongsideTransition(nil) { context in
             self.updateDisplayedPopoverProperties?()


### PR DESCRIPTION
Follow up fix to previous PR