### PR TITLE
Bug 1249635 - Added passcode entry screen when accessing Login Manager

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -518,6 +518,7 @@
 		E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */; };
 		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
 		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
+		E694AAF01C77AFEC00415F4B /* AuthenticationKeychainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */; };
 		E695D8651C037E9F00D3FCCE /* FSUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E695D8631C037E9F00D3FCCE /* FSUtils.h */; };
 		E695D8661C037E9F00D3FCCE /* FSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E695D8641C037E9F00D3FCCE /* FSUtils.m */; };
 		E695D8681C03804F00D3FCCE /* FSUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */; };
@@ -1489,6 +1490,7 @@
 		E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AppSettingsTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
 		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
+		E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfo.swift; sourceTree = "<group>"; };
 		E695D8631C037E9F00D3FCCE /* FSUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSUtils.h; sourceTree = "<group>"; };
 		E695D8641C037E9F00D3FCCE /* FSUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSUtils.m; sourceTree = "<group>"; };
 		E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSUtilsTests.swift; sourceTree = "<group>"; };
@@ -2607,6 +2609,7 @@
 		E692E3271C46E62D009D1240 /* AuthenticationManager */ = {
 			isa = PBXGroup;
 			children = (
+				E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */,
 				E69E06C81C76198000D0F926 /* AuthenticationManagerConstants.swift */,
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
 				E640E8691C73A47C00C5F072 /* PasscodeViews.swift */,
@@ -4371,6 +4374,7 @@
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
+				E694AAF01C77AFEC00415F4B /* AuthenticationKeychainInfo.swift in Sources */,
 				7B59FC471C68E9B600F58EF5 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
 				D39949F51C22461A00E2A03C /* RequestDesktopSiteActivity.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/AuthenticationKeychainInfo.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationKeychainInfo.swift
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftKeychainWrapper
+
+public let KeychainKeyAuthenticationInfo = "authenticationInfo"
+
+// MARK: - Helper methods for accessing Authentication information from the Keychain
+extension KeychainWrapper {
+    class func authenticationInfo() -> AuthenticationKeychainInfo? {
+        return KeychainWrapper.objectForKey(KeychainKeyAuthenticationInfo) as? AuthenticationKeychainInfo
+    }
+
+    class func setAuthenticationInfo(info: AuthenticationKeychainInfo?) {
+        if let info = info {
+            KeychainWrapper.setObject(info, forKey: KeychainKeyAuthenticationInfo)
+        } else {
+            KeychainWrapper.removeObjectForKey(KeychainKeyAuthenticationInfo)
+        }
+    }
+}
+
+class AuthenticationKeychainInfo: NSObject, NSCoding {
+    private(set) var lastPasscodeValidationTimestamp: Timestamp?
+    private(set) var passcode: String?
+    private(set) var requiredPasscodeInterval: PasscodeInterval?
+
+    init(passcode: String) {
+        self.passcode = passcode
+        self.requiredPasscodeInterval = .Immediately
+    }
+
+    func encodeWithCoder(aCoder: NSCoder) {
+        if let lastPasscodeValidationTimestamp = lastPasscodeValidationTimestamp {
+            let timestampNumber = NSNumber(unsignedLongLong: lastPasscodeValidationTimestamp)
+            aCoder.encodeObject(timestampNumber, forKey: "lastPasscodeValidationTimestamp")
+        }
+
+        aCoder.encodeObject(passcode, forKey: "passcode")
+        aCoder.encodeObject(requiredPasscodeInterval?.rawValue, forKey: "requiredPasscodeInterval")
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        self.lastPasscodeValidationTimestamp = (aDecoder.decodeObjectForKey("lastPasscodeValidationTimestamp") as? NSNumber)?.unsignedLongLongValue
+        self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
+        if let interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
+            self.requiredPasscodeInterval = PasscodeInterval(rawValue: interval.integerValue)
+        }
+    }
+}
+
+// MARK: - API
+extension AuthenticationKeychainInfo {
+    func updatePasscode(passcode: String) {
+        self.passcode = passcode
+        self.lastPasscodeValidationTimestamp = nil
+    }
+
+    func updateRequiredPasscodeInterval(interval: PasscodeInterval) {
+        self.requiredPasscodeInterval = interval
+        self.lastPasscodeValidationTimestamp = nil
+    }
+
+    func recordValidationTime() {
+        self.lastPasscodeValidationTimestamp = NSDate.now()
+    }
+}

--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -3,13 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
-
-let PrefKeyTouchIDEnabled = "authentication.touchIDEnabled"
-let PrefKeyRequirePasscodeInterval = "authentication.requirePasscodeInterval"
-let KeychainKeyPasscode = "AppPasscode"
+import Shared
 
 // Passcode intervals with rawValue in seconds.
-enum PasscodeInterval: Int32 {
+enum PasscodeInterval: Int {
     var settingTitle: String {
         switch self {
         case .Immediately:      return AuthenticationStrings.immediately
@@ -34,8 +31,14 @@ struct AuthenticationStrings {
     static let requirePasscode =
         NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Title for setting to require a passcode")
 
+    static let enterAPasscode =
+        NSLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Title above input for entering a passcode")
+
+    static let enterPasscodeTitle =
+        NSLocalizedString("Enter Passcode", tableName: "AuthenticationManager", comment: "Screen title for entering a passcode")
+
     static let enterPasscode =
-        NSLocalizedString("Enter a passcode", tableName: "AuthenticationManager", comment: "Title for entering a passcode")
+        NSLocalizedString("Enter passcode", tableName: "AuthenticationManager", comment: "Title above input for entering passcode while removing/changing")
 
     static let reenterPasscode =
         NSLocalizedString("Re-enter passcode", tableName: "AuthenticationManager", comment: "Title for re-entering a passcode")

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -7,47 +7,35 @@ import UIKit
 import Shared
 import SwiftKeychainWrapper
 
-
 class TurnPasscodeOnSetting: Setting {
-    let prefs: Prefs
-
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
-        self.prefs = settings.profile.prefs
         super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOnPasscode),
                    delegate: delegate)
     }
 
     override func onClick(navigationController: UINavigationController?) {
         // Navigate to passcode configuration screen
-        let passcodeVC = PasscodeConfirmViewController.newPasscodeVC(prefs: self.prefs)
+        let passcodeVC = PasscodeConfirmViewController.newPasscodeVC()
         passcodeVC.title = AuthenticationStrings.setPasscode
-        let passcodeNav = UINavigationController(rootViewController: passcodeVC)
-        navigationController?.presentViewController(passcodeNav, animated: true, completion: nil)
+        navigationController?.presentViewController(UINavigationController(rootViewController: passcodeVC), animated: true, completion: nil)
     }
 }
 
 class TurnPasscodeOffSetting: Setting {
-    let prefs: Prefs
-
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
-        self.prefs = settings.profile.prefs
         super.init(title: NSAttributedString.tableRowTitle(AuthenticationStrings.turnOffPasscode),
                    delegate: delegate)
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        let passcodeVC = PasscodeConfirmViewController.removePasscodeVC(prefs: self.prefs)
+        let passcodeVC = PasscodeConfirmViewController.removePasscodeVC()
         passcodeVC.title = AuthenticationStrings.turnOffPasscode
-        let passcodeNav = UINavigationController(rootViewController: passcodeVC)
-        navigationController?.presentViewController(passcodeNav, animated: true, completion: nil)
+        navigationController?.presentViewController(UINavigationController(rootViewController: passcodeVC), animated: true, completion: nil)
     }
 }
 
 class ChangePasscodeSetting: Setting {
-    let prefs: Prefs
-
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, enabled: Bool) {
-        self.prefs = settings.profile.prefs
         let attributedTitle: NSAttributedString = (enabled ?? false) ?
             NSAttributedString.tableRowTitle(AuthenticationStrings.changePasscode) :
             NSAttributedString.disabledTableRowTitle(AuthenticationStrings.changePasscode)
@@ -58,33 +46,27 @@ class ChangePasscodeSetting: Setting {
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        let passcodeVC = PasscodeConfirmViewController.changePasscodeVC(prefs: self.prefs)
+        let passcodeVC = PasscodeConfirmViewController.changePasscodeVC()
         passcodeVC.title = AuthenticationStrings.changePasscode
-        let passcodeNav = UINavigationController(rootViewController: passcodeVC)
-        navigationController?.presentViewController(passcodeNav, animated: true, completion: nil)
+        navigationController?.presentViewController(UINavigationController(rootViewController: passcodeVC), animated: true, completion: nil)
     }
 }
 
 class RequirePasscodeSetting: Setting {
-    let prefs: Prefs
-
     override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
 
     override var style: UITableViewCellStyle { return .Value1 }
 
     override var status: NSAttributedString {
         // Only show the interval if we are enabled and have an interval set.
-        if let interval = prefs.intForKey(PrefKeyRequirePasscodeInterval),
-           let valueType = PasscodeInterval(rawValue: interval)
-           where enabled
-        {
-            return NSAttributedString.disabledTableRowTitle(valueType.settingTitle)
+        let authenticationInterval = KeychainWrapper.authenticationInfo()
+        if let interval = authenticationInterval?.requiredPasscodeInterval where enabled {
+            return NSAttributedString.disabledTableRowTitle(interval.settingTitle)
         }
         return NSAttributedString(string: "")
     }
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil, enabled: Bool? = nil) {
-        self.prefs = settings.profile.prefs
         let title = AuthenticationStrings.requirePasscode
         let attributedTitle = (enabled ?? true) ? NSAttributedString.tableRowTitle(title) : NSAttributedString.disabledTableRowTitle(title)
         super.init(title: attributedTitle,
@@ -93,7 +75,7 @@ class RequirePasscodeSetting: Setting {
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        navigationController?.pushViewController(RequirePasscodeIntervalViewController(prefs: self.prefs), animated: true)
+        navigationController?.pushViewController(RequirePasscodeIntervalViewController(), animated: true)
     }
 }
 
@@ -116,7 +98,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
     }
 
     override func generateSettings() -> [SettingSection] {
-        if let _ = KeychainWrapper.stringForKey(KeychainKeyPasscode) {
+        if let _ = KeychainWrapper.authenticationInfo() {
             return passcodeEnabledSettings()
         } else {
             return passcodeDisabledSettings()

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -15,9 +15,11 @@ import SwiftKeychainWrapper
 /// Presented to the to user when asking for their passcode to validate entry into a part of the app.
 class PasscodeEntryViewController: UIViewController {
     weak var delegate: PasscodeEntryDelegate?
-    private let passcodePane = PasscodePane(title: AuthenticationStrings.enterPasscode)
+    private let passcodePane = PasscodePane()
+    private var authenticationInfo: AuthenticationKeychainInfo?
 
     init() {
+        self.authenticationInfo = KeychainWrapper.authenticationInfo()
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -27,6 +29,7 @@ class PasscodeEntryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = AuthenticationStrings.enterPasscodeTitle
         view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: Selector("dismiss"))
         automaticallyAdjustsScrollViewInsets = false
@@ -57,7 +60,9 @@ extension PasscodeEntryViewController {
 
 extension PasscodeEntryViewController: PasscodeInputViewDelegate {
     func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String) {
-        if let passcode = KeychainWrapper.stringForKey(KeychainKeyPasscode) where passcode == code {
+        if let passcode = authenticationInfo?.passcode where passcode == code {
+            authenticationInfo?.recordValidationTime()
+            KeychainWrapper.setAuthenticationInfo(authenticationInfo)
             delegate?.passcodeValidationDidSucceed()
         } else {
             // TODO: Show error for incorrect passcode

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -66,6 +66,7 @@ extension PasscodeEntryViewController: PasscodeInputViewDelegate {
             delegate?.passcodeValidationDidSucceed()
         } else {
             // TODO: Show error for incorrect passcode
+            passcodePane.codeInputView.resetCode()
         }
     }
 }

--- a/Client/Frontend/AuthenticationManager/PasscodeViews.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeViews.swift
@@ -126,7 +126,7 @@ class PasscodePane: UIView {
         }
     }
 
-    init(title: String) {
+    init(title: String? = nil) {
         super.init(frame: CGRectZero)
         backgroundColor = UIConstants.TableViewHeaderBackgroundColor
 

--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Shared
+import SwiftKeychainWrapper
 
 /// Screen presented to the user when selecting the time interval before requiring a passcode
 class RequirePasscodeIntervalViewController: UITableViewController {
@@ -16,12 +17,10 @@ class RequirePasscodeIntervalViewController: UITableViewController {
         .OneHour
     ]
 
-    private let prefs: Prefs
     private let BasicCheckmarkCell = "BasicCheckmarkCell"
-    private var selectedInterval: PasscodeInterval?
+    private var authenticationInfo: AuthenticationKeychainInfo?
 
-    init(prefs: Prefs) {
-        self.prefs = prefs
+    init() {
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -53,9 +52,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        if let intervalTime = prefs.intForKey(PrefKeyRequirePasscodeInterval) {
-            self.selectedInterval = PasscodeInterval(rawValue: intervalTime)
-        }
+        self.authenticationInfo = KeychainWrapper.authenticationInfo()
         tableView.reloadData()
     }
 
@@ -64,7 +61,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
         let option = intervalOptions[indexPath.row]
         let intervalTitle = NSAttributedString.tableRowTitle(option.settingTitle)
         cell.textLabel?.attributedText = intervalTitle
-        cell.accessoryType = selectedInterval == option ? .Checkmark : .None
+        cell.accessoryType = authenticationInfo?.requiredPasscodeInterval == option ? .Checkmark : .None
         return cell
     }
 
@@ -73,9 +70,8 @@ class RequirePasscodeIntervalViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let selectedOption = intervalOptions[indexPath.row]
-        selectedInterval = selectedOption
-        prefs.setInt(selectedOption.rawValue, forKey: PrefKeyRequirePasscodeInterval)
+        authenticationInfo?.updateRequiredPasscodeInterval(intervalOptions[indexPath.row])
+        KeychainWrapper.setAuthenticationInfo(authenticationInfo)
         tableView.reloadData()
     }
 }

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -10,6 +10,11 @@ import Shared
 
 class AuthenticationManagerTests: KIFTestCase {
 
+    override func tearDown() {
+        super.tearDown()
+        resetPasscode()
+    }
+
     private func openAuthenticationManager() {
         tester().tapViewWithAccessibilityLabel("Show Tabs")
         tester().tapViewWithAccessibilityLabel("Settings")
@@ -60,7 +65,6 @@ class AuthenticationManagerTests: KIFTestCase {
         XCTAssertEqual(info.requiredPasscodeInterval, .Immediately)
 
         closeAuthenticationManager()
-        resetPasscode()
     }
 
     func testTurnOffPasscode() {
@@ -149,5 +153,103 @@ class AuthenticationManagerTests: KIFTestCase {
         XCTAssertEqual(requirePasscodeCell.detailTextLabel!.text, PasscodeInterval.OneHour.settingTitle)
 
         closeAuthenticationManager()
+    }
+
+    func testEnteringLoginsUsingPasscode() {
+        setPasscode("1337", interval: .Immediately)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+
+        // Enter wrong passcode
+        tester().tapViewWithAccessibilityLabel("2")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        // Check for error
+        tester().waitForTimeInterval(2)
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityIdentifier("Login List")
+
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testEnteringLoginsUsingPasscodeWithImmediateInterval() {
+        setPasscode("1337", interval: .Immediately)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityIdentifier("Login List")
+
+        tester().tapViewWithAccessibilityLabel("Back")
+
+        // Trying again should display passcode screen since we've set the interval to be immediately.
+        tester().tapViewWithAccessibilityLabel("Logins")
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testEnteringLoginsUsingPasscodeWithFiveMinutesInterval() {
+        setPasscode("1337", interval: .FiveMinutes)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+
+        // Enter a passcode
+        tester().tapViewWithAccessibilityLabel("1")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("3")
+        tester().tapViewWithAccessibilityLabel("7")
+
+        tester().waitForViewWithAccessibilityIdentifier("Login List")
+
+        tester().tapViewWithAccessibilityLabel("Back")
+
+        // Trying again should not display the passcode screen since the interval is 5 minutes
+        tester().tapViewWithAccessibilityLabel("Logins")
+        tester().waitForViewWithAccessibilityIdentifier("Login List")
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testEnteringLoginsWithNoPasscode() {
+        XCTAssertNil(KeychainWrapper.authenticationInfo())
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+        tester().waitForViewWithAccessibilityIdentifier("Login List")
+
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
     }
 }

--- a/Utils/TimeConstants.swift
+++ b/Utils/TimeConstants.swift
@@ -13,7 +13,8 @@ public let OneMonthInMilliseconds = 30 * OneDayInMilliseconds
 public let OneWeekInMilliseconds = 7 * OneDayInMilliseconds
 public let OneDayInMilliseconds = 24 * OneHourInMilliseconds
 public let OneHourInMilliseconds = 60 * OneMinuteInMilliseconds
-public let OneMinuteInMilliseconds: UInt64 = 60 * 1000
+public let OneMinuteInMilliseconds = 60 * OneSecondInMilliseconds
+public let OneSecondInMilliseconds: UInt64 = 1000
 
 extension NSDate {
     public class func now() -> Timestamp {


### PR DESCRIPTION
* Updates the settings option to include a check for showing the passcode entry screen when navigating to Logins.
* Minor refactoring to how we store data in the keychain by creating a new AuthenticationKeychainInfo bundle to make accessing related data easier instead of using keys.