### PR TITLE
Bug 1250149 – Whitelist only webpages for NSUserActivity

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -910,7 +910,7 @@ class BrowserViewController: UIViewController {
     private func updateURLBarDisplayURL(tab: Browser) {
         urlBar.currentURL = tab.displayURL
 
-        let isPage = (tab.displayURL != nil) ? isWebPage(tab.displayURL!) : false
+        let isPage = tab.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isWebPage: isPage)
 
         guard let url = tab.displayURL?.absoluteString else {
@@ -1735,16 +1735,6 @@ extension BrowserViewController: TabManagerDelegate {
 
     func tabManagerDidRestoreTabs(tabManager: TabManager) {
         updateTabCountUsingTabManager(tabManager)
-    }
-
-    private func isWebPage(url: NSURL) -> Bool {
-        let httpSchemes = ["http", "https"]
-
-        if let _ = httpSchemes.indexOf(url.scheme) {
-            return true
-        }
-
-        return false
     }
 
     private func updateTabCountUsingTabManager(tabManager: TabManager, animated: Bool = true) {

--- a/Client/Helpers/SpotlightHelper.swift
+++ b/Client/Helpers/SpotlightHelper.swift
@@ -48,7 +48,7 @@ class SpotlightHelper: NSObject {
     }
 
     func update(pageContent: [String: String], forURL url: NSURL) {
-        if AboutUtils.isAboutURL(url) || url.scheme == "about" {
+        if !url.isWebPage() {
             return
         }
 

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -213,6 +213,16 @@ extension NSURL {
             return nil
         }
     }
+
+    public func isWebPage() -> Bool {
+        let httpSchemes = ["http", "https"]
+
+        if let _ = httpSchemes.indexOf(scheme) {
+            return true
+        }
+
+        return false
+    }
 }
 
 //MARK: Private Helpers


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1250149

This whitelists http and https schemes.

In doing so, move the isWebPage() method from BVC to NSURLExtensions.