### PR TITLE
Bug 1250242 - Adds Touch ID authentication alongside passcode for Logins

### DIFF
--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -75,4 +75,7 @@ struct AuthenticationStrings {
 
     static let oneHour =
         NSLocalizedString("After 1 hour", tableName: "AuthenticationManager", comment: "'After 1 hour' interval item for selecting when to require passcode")
+
+    static let loginsTouchReason =
+        NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
 }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -87,7 +87,6 @@ private struct TempStrings {
 
     // Bug 1198418 - Touch ID Passcode Strings
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
-    let accessLogins            = NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")
 }
 


### PR DESCRIPTION
* Touch ID can now be turned on/off from the authentication settings.
* Touch ID option only displays for devices which support it.
* With Touch ID on, accessing logins will use Touch ID and fallback to passcode.