### PR TITLE
Bug 1250182/1250187 - Added passcode error states along with passcode lock out when entering multiple failed passcodes

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		E4F21AA61A13C4A300B0FAAA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4F21AA51A13C4A300B0FAAA /* Images.xcassets */; };
 		E60A60821B6BFC0B00F850D4 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A60811B6BFC0B00F850D4 /* CrashReporter.swift */; };
 		E60A60A11B6BFDDC00F850D4 /* CrashReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A60A01B6BFDDC00F850D4 /* CrashReporterTests.swift */; };
+		E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */; };
 		E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */; };
 		E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C001B90A44F005ABB0D /* libz.tbd */; };
 		E6231C031B90A466005ABB0D /* libstdc++.6.0.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */; };
@@ -516,6 +517,8 @@
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
 		E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */; };
+		E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */; };
+		E6927ECF1C7B722300D03F75 /* ErrorToastRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6927ECE1C7B722300D03F75 /* ErrorToastRefTests.swift */; };
 		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
 		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
 		E694AAF01C77AFEC00415F4B /* AuthenticationKeychainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */; };
@@ -1439,6 +1442,7 @@
 		E60961891B62B8C800DD640F /* Firefox.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Firefox.xcconfig; path = Configuration/Firefox.xcconfig; sourceTree = "<group>"; };
 		E60A60811B6BFC0B00F850D4 /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		E60A60A01B6BFDDC00F850D4 /* CrashReporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporterTests.swift; sourceTree = "<group>"; };
+		E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePasscodeViewController.swift; sourceTree = "<group>"; };
 		E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RollingFileLoggerTests.swift; sourceTree = "<group>"; };
 		E6231C001B90A44F005ABB0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		E6231C021B90A466005ABB0D /* libstdc++.6.0.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libstdc++.6.0.9.tbd"; path = "usr/lib/libstdc++.6.0.9.tbd"; sourceTree = SDKROOT; };
@@ -1487,7 +1491,9 @@
 		E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
 		E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
-		E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AppSettingsTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsTableViewController.swift; sourceTree = "<group>"; };
+		E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorToast.swift; sourceTree = "<group>"; };
+		E6927ECE1C7B722300D03F75 /* ErrorToastRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorToastRefTests.swift; sourceTree = "<group>"; };
 		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
 		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
 		E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfo.swift; sourceTree = "<group>"; };
@@ -2254,6 +2260,7 @@
 			isa = PBXGroup;
 			children = (
 				D3FEC38C1AC4B42F00494F45 /* AutocompleteTextField.swift */,
+				E6927EBF1C7B6FB800D03F75 /* ErrorToast.swift */,
 				0BB5B2861AC0A2B90052877D /* SnackBar.swift */,
 				0BB5B2871AC0A2B90052877D /* Toolbar.swift */,
 				D38A1BEC1A9FA2CA00F6A386 /* SiteTableViewController.swift */,
@@ -2582,6 +2589,7 @@
 				E633E2321C21E293001FFF6C /* FXSnapshotTestCase.swift */,
 				E66464901C10CA9C00AF05CE /* SearchInputViewRefTests.swift */,
 				E63ED7B31BFCD9800097D08E /* LoginTableViewCellRefTests.swift */,
+				E6927ECE1C7B722300D03F75 /* ErrorToastRefTests.swift */,
 				E65C5BE11BEA525800D28BEF /* Other */,
 			);
 			path = NativeRefTests;
@@ -2613,6 +2621,7 @@
 				E69E06C81C76198000D0F926 /* AuthenticationManagerConstants.swift */,
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
 				E640E8691C73A47C00C5F072 /* PasscodeViews.swift */,
+				E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */,
 				E640E85D1C73A45A00C5F072 /* PasscodeEntryViewController.swift */,
 				E640E8671C73A46600C5F072 /* PasscodeConfirmViewController.swift */,
 				E69E06B91C76173D00D0F926 /* RequirePasscodeIntervalViewController.swift */,
@@ -4255,6 +4264,7 @@
 				E65C5BE01BEA522600D28BEF /* UIImage+Snapshot.m in Sources */,
 				E65C5BD51BEA4F8A00D28BEF /* FBSnapshotTestController.m in Sources */,
 				E65C5BD41BEA4F8A00D28BEF /* FBSnapshotTestCasePlatform.m in Sources */,
+				E6927ECF1C7B722300D03F75 /* ErrorToastRefTests.swift in Sources */,
 				E63ED8091BFCF9770097D08E /* SwiftSupport.swift in Sources */,
 				E63ED7B41BFCD9800097D08E /* LoginTableViewCellRefTests.swift in Sources */,
 				E65C5BD31BEA4F8A00D28BEF /* FBSnapshotTestCase.m in Sources */,
@@ -4308,6 +4318,7 @@
 				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */,
 				0BB5B2891AC0A2B90052877D /* Toolbar.swift in Sources */,
+				E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */,
 				E60A60821B6BFC0B00F850D4 /* CrashReporter.swift in Sources */,
 				E4CD9F2D1A6DC91200318571 /* BrowserLocationView.swift in Sources */,
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
@@ -4338,6 +4349,7 @@
 				E640E8681C73A46600C5F072 /* PasscodeConfirmViewController.swift in Sources */,
 				E698FFDA1B4AADF40001F623 /* BrowserScrollController.swift in Sources */,
 				D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */,
+				E6927EC01C7B6FB800D03F75 /* ErrorToast.swift in Sources */,
 				D30B101E1AA7F9C600C01CA3 /* HomePanels.swift in Sources */,
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/AuthenticationKeychainInfo.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationKeychainInfo.swift
@@ -7,6 +7,7 @@ import Shared
 import SwiftKeychainWrapper
 
 public let KeychainKeyAuthenticationInfo = "authenticationInfo"
+public let AllowedPasscodeFailedAttempts = 3
 
 // MARK: - Helper methods for accessing Authentication information from the Keychain
 extension KeychainWrapper {
@@ -27,10 +28,16 @@ class AuthenticationKeychainInfo: NSObject, NSCoding {
     private(set) var lastPasscodeValidationTimestamp: Timestamp?
     private(set) var passcode: String?
     private(set) var requiredPasscodeInterval: PasscodeInterval?
+    private(set) var lockOutTimestamp: Timestamp?
+    private(set) var failedAttempts: Int
+
+    // Timeout period before user can retry entering passcodes
+    var lockTimeInterval = 15 * OneMinuteInMilliseconds
 
     init(passcode: String) {
         self.passcode = passcode
         self.requiredPasscodeInterval = .Immediately
+        self.failedAttempts = 0
     }
 
     func encodeWithCoder(aCoder: NSCoder) {
@@ -39,13 +46,21 @@ class AuthenticationKeychainInfo: NSObject, NSCoding {
             aCoder.encodeObject(timestampNumber, forKey: "lastPasscodeValidationTimestamp")
         }
 
+        if let lockOutTimestamp = lockOutTimestamp where isLocked() {
+            let timestampNumber = NSNumber(unsignedLongLong: lockOutTimestamp)
+            aCoder.encodeObject(timestampNumber, forKey: "lockOutTimestamp")
+        }
+
         aCoder.encodeObject(passcode, forKey: "passcode")
         aCoder.encodeObject(requiredPasscodeInterval?.rawValue, forKey: "requiredPasscodeInterval")
+        aCoder.encodeInteger(failedAttempts, forKey: "failedAttempts")
     }
 
     required init?(coder aDecoder: NSCoder) {
         self.lastPasscodeValidationTimestamp = (aDecoder.decodeObjectForKey("lastPasscodeValidationTimestamp") as? NSNumber)?.unsignedLongLongValue
+        self.lockOutTimestamp = (aDecoder.decodeObjectForKey("lockOutTimestamp") as? NSNumber)?.unsignedLongLongValue
         self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
+        self.failedAttempts = aDecoder.decodeIntegerForKey("failedAttempts")
         if let interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
             self.requiredPasscodeInterval = PasscodeInterval(rawValue: interval.integerValue)
         }
@@ -54,6 +69,11 @@ class AuthenticationKeychainInfo: NSObject, NSCoding {
 
 // MARK: - API
 extension AuthenticationKeychainInfo {
+    private func resetLockoutState() {
+        self.failedAttempts = 0
+        self.lockOutTimestamp = nil
+    }
+
     func updatePasscode(passcode: String) {
         self.passcode = passcode
         self.lastPasscodeValidationTimestamp = nil
@@ -64,7 +84,33 @@ extension AuthenticationKeychainInfo {
         self.lastPasscodeValidationTimestamp = nil
     }
 
-    func recordValidationTime() {
+    func recordValidation() {
+        // Save the timestamp to remember the last time we successfully 
+        // validated and clear out the failed attempts counter.
         self.lastPasscodeValidationTimestamp = NSDate.now()
+        resetLockoutState()
+    }
+
+    func lockOutUser() {
+        self.lockOutTimestamp = NSProcessInfo().systemUptimeTimestamp()
+    }
+
+    func recordFailedAttempt() {
+        self.failedAttempts += 1
+    }
+
+    func isLocked() -> Bool {
+        if NSProcessInfo().systemUptimeTimestamp() < self.lockOutTimestamp {
+            // Unlock and require passcode input
+            resetLockoutState()
+            return false
+        }
+        return (NSProcessInfo().systemUptimeTimestamp() - (self.lockOutTimestamp ?? 0)) < lockTimeInterval
+    }
+}
+
+extension NSProcessInfo {
+    public func systemUptimeTimestamp() -> Timestamp {
+        return Timestamp(NSProcessInfo().systemUptime * NSTimeInterval(OneSecondInMilliseconds))
     }
 }

--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -26,7 +26,7 @@ enum PasscodeInterval: Int {
     case OneHour        = 3600
 }
 
-// Strings used throughout the Authentication Manager
+// Strings used in multiple areas within the Authentication Manager
 struct AuthenticationStrings {
     static let requirePasscode =
         NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Title for setting to require a passcode")
@@ -78,4 +78,16 @@ struct AuthenticationStrings {
 
     static let loginsTouchReason =
         NSLocalizedString("Use your fingerprint to access Logins now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing logins")
+
+    static let wrongPasscodeError =
+        NSLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app")
+
+    static let incorrectAttemptsRemaining =
+        NSLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining")
+
+    static let maximumAttemptsReached =
+        NSLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
+
+    static let maximumAttemptsReachedNoTime =
+        NSLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
 }

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftKeychainWrapper
+
+class BasePasscodeViewController: UIViewController {
+    var authenticationInfo: AuthenticationKeychainInfo?
+
+    var errorToast: ErrorToast?
+    let errorPadding: CGFloat = 10
+
+    init() {
+        self.authenticationInfo = KeychainWrapper.authenticationInfo()
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: Selector("dismiss"))
+        automaticallyAdjustsScrollViewInsets = false
+    }
+
+    func displayError(text: String) {
+        errorToast?.removeFromSuperview()
+        errorToast = {
+            let toast = ErrorToast()
+            toast.textLabel.text = text
+            view.addSubview(toast)
+            toast.snp_makeConstraints { make in
+                make.center.equalTo(self.view)
+                make.left.greaterThanOrEqualTo(self.view).offset(errorPadding)
+                make.right.lessThanOrEqualTo(self.view).offset(-errorPadding)
+            }
+            return toast
+        }()
+    }
+
+    func dismiss() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+    }
+}

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -13,26 +13,13 @@ import SwiftKeychainWrapper
 }
 
 /// Presented to the to user when asking for their passcode to validate entry into a part of the app.
-class PasscodeEntryViewController: UIViewController {
+class PasscodeEntryViewController: BasePasscodeViewController {
     weak var delegate: PasscodeEntryDelegate?
     private let passcodePane = PasscodePane()
-    private var authenticationInfo: AuthenticationKeychainInfo?
-
-    init() {
-        self.authenticationInfo = KeychainWrapper.authenticationInfo()
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         title = AuthenticationStrings.enterPasscodeTitle
-        view.backgroundColor = UIConstants.TableViewHeaderBackgroundColor
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel, target: self, action: Selector("dismiss"))
-        automaticallyAdjustsScrollViewInsets = false
         view.addSubview(passcodePane)
         passcodePane.snp_makeConstraints { make in
             make.bottom.left.right.equalTo(self.view)
@@ -43,7 +30,14 @@ class PasscodeEntryViewController: UIViewController {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         passcodePane.codeInputView.delegate = self
-        passcodePane.codeInputView.becomeFirstResponder()
+
+        // Don't show the keyboard or allow typing if we're locked out. Also display the error.
+        if authenticationInfo?.isLocked() ?? false {
+            displayError(AuthenticationStrings.maximumAttemptsReachedNoTime)
+            passcodePane.codeInputView.userInteractionEnabled = false
+        } else {
+            passcodePane.codeInputView.becomeFirstResponder()
+        }
     }
 
     override func viewWillDisappear(animated: Bool) {
@@ -52,21 +46,27 @@ class PasscodeEntryViewController: UIViewController {
     }
 }
 
-extension PasscodeEntryViewController {
-    @objc private func dismiss() {
-        self.dismissViewControllerAnimated(true, completion: nil)
-    }
-}
-
 extension PasscodeEntryViewController: PasscodeInputViewDelegate {
     func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String) {
         if let passcode = authenticationInfo?.passcode where passcode == code {
-            authenticationInfo?.recordValidationTime()
+            authenticationInfo?.recordValidation()
             KeychainWrapper.setAuthenticationInfo(authenticationInfo)
             delegate?.passcodeValidationDidSucceed()
         } else {
-            // TODO: Show error for incorrect passcode
+            authenticationInfo?.recordFailedAttempt()
+            let numberOfAttempts = authenticationInfo?.failedAttempts ?? 0
+            if numberOfAttempts == AllowedPasscodeFailedAttempts {
+                authenticationInfo?.lockOutUser()
+                displayError(AuthenticationStrings.maximumAttemptsReachedNoTime)
+                passcodePane.codeInputView.userInteractionEnabled = false
+                resignFirstResponder()
+            } else {
+                displayError(String(format: AuthenticationStrings.incorrectAttemptsRemaining, (AllowedPasscodeFailedAttempts - numberOfAttempts)))
+            }
             passcodePane.codeInputView.resetCode()
+
+            // Store mutations on authentication info object
+            KeychainWrapper.setAuthenticationInfo(authenticationInfo)
         }
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -509,7 +509,7 @@ class LoginsSetting: Setting {
                     // Update our authentication info's last validation timestamp so we don't ask again based
                     // on the set required interval
                     let authInfo = KeychainWrapper.authenticationInfo()
-                    authInfo?.recordValidationTime()
+                    authInfo?.recordValidation()
                     KeychainWrapper.setAuthenticationInfo(authInfo)
 
                     dispatch_async(dispatch_get_main_queue()) {

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -88,13 +88,6 @@ private struct TempStrings {
     // Bug 1198418 - Touch ID Passcode Strings
     let turnOffYourPasscode     = NSLocalizedString("Turn off your passcode.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when turning off passcode")
     let accessPBMode            = NSLocalizedString("Use your fingerprint to access Private Browsing now.", tableName: "AuthenticationManager", comment: "Touch ID prompt subtitle when accessing private browsing")
-
-    let mismatchPasscodeError   = NSLocalizedString("Passcodes didn't match. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed to user when their confirming passcode doesn't match the first code.")
-    let wrongPasscodeError      = NSLocalizedString("Incorrect passcode. Try again.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app")
-    let useNewPasscodeError     = NSLocalizedString("New passcode must be different than existing code.", tableName: "AuthenticationManager", comment: "Error message displayed when user tries to enter the same passcode as their existing code when changing it.")
-    let incorrectAttemptsRemaining = NSLocalizedString("Incorrect passcode. Try again (Attempts remaining: %d).", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode when trying to enter a protected section of the app with attempts remaining")
-    let maximumAttemptsReached  = NSLocalizedString("Maximum attempts reached. Please try again in an hour.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
-    let maximumAttemptsReachedNoTime  = NSLocalizedString("Maximum attempts reached. Please try again later.", tableName: "AuthenticationManager", comment: "Error message displayed when user enters incorrect passcode and has reached the maximum number of attempts.")
 }
 
 /// Old strings that will be removed when we kill 1.0. We need to keep them around for now for l10n export.

--- a/Client/Frontend/Widgets/ErrorToast.swift
+++ b/Client/Frontend/Widgets/ErrorToast.swift
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SnapKit
+
+private struct ErrorToastDefaultUX {
+    static let cornerRadius: CGFloat = 40
+    static let fillColor = UIColor(red: 186/255, green: 32/255, blue: 36/255, alpha: 1)
+    static let margins = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+    static let textColor = UIColor.whiteColor()
+}
+
+class ErrorToast: UIView {
+    lazy var textLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = ErrorToastDefaultUX.textColor
+        label.textAlignment = .Center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    var cornerRadius: CGFloat = ErrorToastDefaultUX.cornerRadius {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var fillColor: UIColor = ErrorToastDefaultUX.fillColor {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        opaque = false
+        addSubview(textLabel)
+        textLabel.snp_makeConstraints { make in
+            make.edges.equalTo(self).inset(ErrorToastDefaultUX.margins)
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawRect(rect: CGRect) {
+        super.drawRect(rect)
+        fillColor.setFill()
+        let path = UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius)
+        path.fill()
+    }
+}

--- a/NativeRefTests/ErrorToastRefTests.swift
+++ b/NativeRefTests/ErrorToastRefTests.swift
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+@testable import Client
+
+class ErrorToastRefTests: FXSnapshotTestCase {
+    let defaultFrame = CGRect(origin: CGPointZero, size: CGSize(width: 320, height: 64))
+    let compressedFrame = CGRect(origin: CGPointZero, size: CGSize(width: 160, height: 64))
+    let stretchedFrame = CGRect(origin: CGPointZero, size: CGSize(width: 728, height: 64))
+
+    var toast: ErrorToast!
+
+    override func setUp() {
+        super.setUp()
+        toast = ErrorToast(frame: CGRectZero)
+    }
+
+    func testDefaultCellLayout() {
+        toast.textLabel.text = "Incorrect passcode. Try again."
+        toast.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
+        toast.frame = CGRect(origin: CGPointZero, size: toast.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize))
+        toast.layoutIfNeeded()
+        FBSnapshotVerifyView(toast!)
+    }   
+}

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -37,27 +37,22 @@ class AuthenticationManagerTests: KIFTestCase {
         KeychainWrapper.setAuthenticationInfo(info)
     }
 
+    private func enterPasscodeWithDigits(digits: String) {
+        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex]))
+        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(1)]))
+        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(2)]))
+        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(3)]))
+    }
+
     func testTurnOnPasscodeSetsPasscodeAndInterval() {
         resetPasscode()
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Turn Passcode On")
         tester().waitForViewWithAccessibilityLabel("Enter a passcode")
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
-
-        // Enter same passcode when confirming
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
 
         let info = KeychainWrapper.authenticationInfo()!
@@ -73,21 +68,9 @@ class AuthenticationManagerTests: KIFTestCase {
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
-
-        // Enter same passcode when confirming
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
         XCTAssertNil(KeychainWrapper.authenticationInfo())
 
@@ -100,21 +83,9 @@ class AuthenticationManagerTests: KIFTestCase {
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Change Passcode")
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
-
-        // Enter same passcode when confirming
-        tester().tapViewWithAccessibilityLabel("2")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("2337")
         tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
 
         let info = KeychainWrapper.authenticationInfo()!
@@ -127,7 +98,7 @@ class AuthenticationManagerTests: KIFTestCase {
         setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
-        tester().tapViewWithAccessibilityLabel("Require Passcode, Immediately")
+        tester().tapViewWithAccessibilityLabel("Require Passcode")
 
         let tableView = tester().waitForViewWithAccessibilityIdentifier("AuthenticationManager.passcodeIntervalTableView") as! UITableView
         var immediatelyCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0))!
@@ -163,22 +134,7 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-
-        // Enter wrong passcode
-        tester().tapViewWithAccessibilityLabel("2")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
-        // Check for error
-        tester().waitForTimeInterval(2)
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
 
         tester().tapViewWithAccessibilityLabel("Back")
@@ -194,15 +150,8 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
-
         tester().tapViewWithAccessibilityLabel("Back")
 
         // Trying again should display passcode screen since we've set the interval to be immediately.
@@ -221,15 +170,8 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-
-        // Enter a passcode
-        tester().tapViewWithAccessibilityLabel("1")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("3")
-        tester().tapViewWithAccessibilityLabel("7")
-
+        enterPasscodeWithDigits("1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
-
         tester().tapViewWithAccessibilityLabel("Back")
 
         // Trying again should not display the passcode screen since the interval is 5 minutes
@@ -251,5 +193,108 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Back")
         tester().tapViewWithAccessibilityLabel("Done")
         tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testWrongPasscodeDisplaysAttemptsAndMaxError() {
+        setPasscode("1337", interval: .FiveMinutes)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+
+        // Enter wrong passcode
+        enterPasscodeWithDigits("1234")
+        tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
+        enterPasscodeWithDigits("1234")
+        tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 1))
+        enterPasscodeWithDigits("1234")
+        tester().waitForViewWithAccessibilityLabel(AuthenticationStrings.maximumAttemptsReachedNoTime)
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testWrongPasscodeAttemptsPersistAcrossEntryAndConfirmation() {
+        setPasscode("1337", interval: .FiveMinutes)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+
+        // Enter wrong passcode
+        enterPasscodeWithDigits("1234")
+        tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityLabel("Touch ID & Passcode")
+        tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
+
+        // Enter wrong passcode, again
+        enterPasscodeWithDigits("1234")
+        tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 1))
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        closeAuthenticationManager()
+    }
+
+    func testChangedPasswordMustBeNew() {
+        setPasscode("1337", interval: .FiveMinutes)
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Change Passcode")
+
+        tester().waitForViewWithAccessibilityLabel("Enter passcode")
+        enterPasscodeWithDigits("1337")
+
+        tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
+        enterPasscodeWithDigits("1337")
+
+        // Should display error and take us back to first pane
+        tester().waitForViewWithAccessibilityLabel("New passcode must be different than existing code.")
+        tester().waitForViewWithAccessibilityLabel("Enter passcode")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        closeAuthenticationManager()
+    }
+
+    func testPasscodesMustMatchWhenCreating() {
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Turn Passcode On")
+
+        tester().waitForViewWithAccessibilityLabel("Enter a passcode")
+        enterPasscodeWithDigits("1337")
+
+        tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
+        enterPasscodeWithDigits("1234")
+
+        // Should display error and take us back to first pane
+        tester().waitForViewWithAccessibilityLabel("Passcodes didn't match. Try again.")
+        tester().waitForViewWithAccessibilityLabel("Enter a passcode")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        closeAuthenticationManager()
+    }
+
+    func testPasscodesMustMatchWhenRemoving() {
+        setPasscode("1337", interval: .Immediately)
+
+        openAuthenticationManager()
+        tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
+
+        tester().waitForViewWithAccessibilityLabel("Enter passcode")
+        enterPasscodeWithDigits("1337")
+
+        tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
+        enterPasscodeWithDigits("1234")
+
+        // Should display error and take us back to first pane
+        tester().waitForViewWithAccessibilityLabel("Passcodes didn't match. Try again.")
+        tester().waitForViewWithAccessibilityLabel("Enter passcode")
+
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        closeAuthenticationManager()
     }
 }


### PR DESCRIPTION
I've combined these patches mostly because they seemed related. Here are the changes:

* Adds a new ErrorToast view thats used to display an error label.
* Added the various errors to be displayed for all of the passcode failure state.
* Implemented a lock out period of 15 minutes after entering 3 consecutive incorrect passcodes.
* Failure attempt counter is reset when successfully logging in.
* Failure attempts persist across entry/changing/removal so prevent a user from switching screen to try different passcodes.