### PR TITLE
Bug 1249632 - Tapping switch cells in settings should not highlight

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -164,6 +164,7 @@ class BoolSetting: Setting {
         control.addTarget(self, action: "switchValueChanged:", forControlEvents: UIControlEvents.ValueChanged)
         control.on = prefs.boolForKey(prefKey) ?? defaultValue
         cell.accessoryView = control
+        cell.selectionStyle = .None
         if let titleLabel = cell.textLabel {
             cell.detailTextLabel?.snp_makeConstraints { make in
                 make.left.equalTo(titleLabel)


### PR DESCRIPTION
I wanted to start with something very small :smile: 