### PR TITLE
Do not show What's New for 2.1 Upgrades

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -519,7 +519,9 @@ class BrowserViewController: UIViewController {
         super.viewDidAppear(animated)
         log.debug("BVC done.")
 
-        if profile.prefs.stringForKey(LatestAppVersionProfileKey) != AppInfo.appVersion && DeviceInfo.hasConnectivity() {
+        // TODO This is a temporary fix to make sure the What's New page will only show for new 2.1 installs
+        // and not for people who upgrade from 2.0.
+        if profile.prefs.stringForKey(LatestAppVersionProfileKey) != "2.1" && DeviceInfo.hasConnectivity() {
             if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
                 self.openURLInNewTab(whatsNewURL)
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -521,7 +521,7 @@ class BrowserViewController: UIViewController {
 
         // TODO This is a temporary fix to make sure the What's New page will only show for new 2.1 installs
         // and not for people who upgrade from 2.0.
-        if profile.prefs.stringForKey(LatestAppVersionProfileKey) != "2.1" && DeviceInfo.hasConnectivity() {
+        if profile.prefs.stringForKey(LatestAppVersionProfileKey) != "2.0" && DeviceInfo.hasConnectivity() {
             if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
                 self.openURLInNewTab(whatsNewURL)
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)


### PR DESCRIPTION
This is a temporary fix to make sure the What's New page will only show for new 2.1 installs and not for people who upgrade from 2.0. We obviously need to put a better fix in place for future versions.