### PR TITLE
Bug 1252172 - Carthage 0.15 Compatibility

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Client.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/ClientNoTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/ClientNoTests.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/ClientRefTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/ClientRefTests.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/ClientUnitTests.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/ClientUnitTests.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/FennecAurora.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FennecAurora.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/FennecNightly.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/FennecNightly.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Firefox.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
-CARTHAGE_VERSION=$(carthage version)
-if which carthage ==/dev/null || [[ $CARTHAGE_VERSION<0.11.0 || $CARTHAGE_VERSION>0.11.0 ]]; then
-	echo "Installing Carthage 0.11"
-	brew update
-	brew install https://raw.githubusercontent.com/Homebrew/homebrew/09c09d73779d3854cd54206c41e38668cd4d2d0c/Library/Formula/carthage.rb
+
+if [ ! -f "/usr/local/bin/carthage" ]; then
+    echo "Cannot find Carthage at /usr/local/bin/carthage - See https://github.com/mozilla/firefox-ios/blob/master/BUILDING.md"
+    exit 1
 fi
 
-if [[ ! -e "Carthage/Checkouts/google-breakpad-ios/Breakpad.xcodeproj" ]]; then 
-	echo "Breakpad needs to be deleted" 
-	rm -rf "Carthage/Checkouts/google-breakpad-ios"
+if [[ "$(/usr/local/bin/carthage version)" != "0.15" ]]; then
+    echo "Only Carthage 0.15 is currently supported"
+    exit 1
 fi
+

--- a/checkout.sh
+++ b/checkout.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
 
-./carthage.sh
-
-carthage bootstrap --platform ios --no-use-binaries
+./carthage.sh && carthage bootstrap --platform ios --no-use-binaries

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
 
-./carthage.sh
-
-carthage update --platform ios --no-use-binaries
+./carthage.sh && carthage update --platform ios --no-use-binaries


### PR DESCRIPTION
This patch does two things:

* It disabled `parallelizeBuildables` in all the application schemes - This works around the issues we are having with Carthage
* It changes the Carthage version check to 0.15 instead of 0.11

I restructured the `carthage.sh`, `checkout.sh` and `update.sh` scripts a bit. I don't think they worked correctly. They would still continue if the `carthage.sh` check failed. The `carthage.sh` script now just fails and it does not automatically install carthage. Instead it will point the user to our `BUILD.md` page. (Which we need to update if this lands)
