### PR TITLE
Bug 1250514/1250518 - Domain autocomplete improvements

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -50,6 +50,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         }
     }
 
+    var normalizedEnteredText: String {
+        return enteredText.lowercaseString
+    }
+
     override var text: String? {
         didSet {
             // SELtextDidChange is not called when directly setting the text property, so fire it manually.
@@ -142,7 +146,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     private func removeCompletionIfRequiredForEnteredString(string: String) {
         // If user-entered text does not start with previous suggestion then remove the completion.
         let actualEnteredString = enteredText + string
-        if !previousSuggestion.startsWith(actualEnteredString) {
+        if !previousSuggestion.startsWith(normalizedEnteredText) {
             removeCompletion()
         }
         enteredText = actualEnteredString
@@ -156,9 +160,9 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).
-            if suggestion.startsWith(enteredText) && (enteredText).characters.count < suggestion.characters.count {
+            if suggestion.startsWith(normalizedEnteredText) && (enteredText).characters.count < suggestion.characters.count {
                 let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(enteredText.characters.count))
-                let completedAndMarkedString = NSMutableAttributedString(string: suggestion)
+                let completedAndMarkedString = NSMutableAttributedString(string: enteredText + endingString)
                 completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(enteredText.characters.count, endingString.characters.count))
                 attributedText = completedAndMarkedString
                 completionActive = true

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -51,7 +51,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     var normalizedEnteredText: String {
-        return enteredText.lowercaseString
+        return enteredText.lowercaseString.stringByTrimmingLeadingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
     }
 
     override var text: String? {
@@ -76,7 +76,7 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         super.addTarget(self, action: "SELtextDidChange:", forControlEvents: UIControlEvents.EditingChanged)
         notifyTextChanged = debounce(0.1, action: {
             if self.editing {
-                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.enteredText)
+                self.autocompleteDelegate?.autocompleteTextField(self, didEnterText: self.enteredText.stringByTrimmingLeadingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()))
             }
         })
     }
@@ -160,8 +160,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).
-            if suggestion.startsWith(normalizedEnteredText) && (enteredText).characters.count < suggestion.characters.count {
-                let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(enteredText.characters.count))
+            if suggestion.startsWith(normalizedEnteredText) && normalizedEnteredText.characters.count < suggestion.characters.count {
+                let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(normalizedEnteredText.characters.count))
                 let completedAndMarkedString = NSMutableAttributedString(string: enteredText + endingString)
                 completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(enteredText.characters.count, endingString.characters.count))
                 attributedText = completedAndMarkedString

--- a/ClientTests/StringExtensionsTests.swift
+++ b/ClientTests/StringExtensionsTests.swift
@@ -52,4 +52,10 @@ class StringExtensionsTests: XCTestCase {
         // maxLength < 2.
         XCTAssertEqual("abcdefgh", "abcdefgh".ellipsize(maxLength: 0))
     }
+
+    func testStringByTrimmingLeadingCharactersInSet() {
+        XCTAssertEqual("foo   ", "   foo   ".stringByTrimmingLeadingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()))
+        XCTAssertEqual("foo456", "123foo456".stringByTrimmingLeadingCharactersInSet(NSCharacterSet.decimalDigitCharacterSet()))
+        XCTAssertEqual("", "123456".stringByTrimmingLeadingCharactersInSet(NSCharacterSet.decimalDigitCharacterSet()))
+    }
 }

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -96,6 +96,14 @@ class DomainAutocompleteTests: KIFTestCase {
         BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "YaH", completion: "oo.com/")
         tester().clearTextFromFirstResponder()
 
+        // Test that leading spaces still show suggestions.
+        tester().enterTextIntoCurrentFirstResponder("   yah")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "   yah", completion: "oo.com/")
+
+        // Test that trailing spaces do *not* show suggestions.
+        tester().enterTextIntoCurrentFirstResponder(" ")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "   yah ", completion: "")
+
         tester().tapViewWithAccessibilityLabel("Cancel")
     }
 

--- a/UITests/DomainAutocompleteTests.swift
+++ b/UITests/DomainAutocompleteTests.swift
@@ -89,6 +89,12 @@ class DomainAutocompleteTests: KIFTestCase {
         BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "an", completion: "swers.com/")
         tester().enterTextIntoCurrentFirstResponder("c")
         BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "anc", completion: "estry.com/")
+        tester().clearTextFromFirstResponder()
+
+        // Test mixed case autocompletion.
+        tester().enterTextIntoCurrentFirstResponder("YaH")
+        BrowserUtils.ensureAutocompletionResult(tester(), textField: textField, prefix: "YaH", completion: "oo.com/")
+        tester().clearTextFromFirstResponder()
 
         tester().tapViewWithAccessibilityLabel("Cancel")
     }

--- a/Utils/Extensions/StringExtensions.swift
+++ b/Utils/Extensions/StringExtensions.swift
@@ -84,4 +84,14 @@ public extension String {
         return NSURL(string: self) ??
                NSURL(string: self.stringWithAdditionalEscaping)
     }
+
+    /// Returns a new string made by removing the leading String characters contained
+    /// in a given character set.
+    public func stringByTrimmingLeadingCharactersInSet(set: NSCharacterSet) -> String {
+        var trimmed = self
+        while trimmed.rangeOfCharacterFromSet(set)?.startIndex == trimmed.startIndex {
+            trimmed.removeAtIndex(trimmed.startIndex)
+        }
+        return trimmed
+    }
 }


### PR DESCRIPTION
Fixes [bug 1250514](https://bugzilla.mozilla.org/show_bug.cgi?id=1250514) (capitalization in queries) and [bug 1250518](https://bugzilla.mozilla.org/show_bug.cgi?id=1250518) (queries with leading spaces).