### PR TITLE
Bug 1252637 - Added clearing of existing authentication info along with profile clearing on app installation

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 		E65C5BE01BEA522600D28BEF /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = E65C5BDD1BEA522600D28BEF /* UIImage+Snapshot.m */; };
 		E65C5BE41BEA525800D28BEF /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E65C5BE21BEA525800D28BEF /* Info.plist */; };
 		E65D895A1C8753CE0006EA35 /* SystemUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89591C8753CE0006EA35 /* SystemUtils.swift */; };
+		E65D89811C8778940006EA35 /* AuthenticationKeychainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89801C8778940006EA35 /* AuthenticationKeychainInfo.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
@@ -540,7 +541,6 @@
 		E6927ECF1C7B722300D03F75 /* ErrorToastRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6927ECE1C7B722300D03F75 /* ErrorToastRefTests.swift */; };
 		E692E3291C46E62D009D1240 /* AuthenticationSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */; };
 		E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */; };
-		E694AAF01C77AFEC00415F4B /* AuthenticationKeychainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */; };
 		E695D8651C037E9F00D3FCCE /* FSUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E695D8631C037E9F00D3FCCE /* FSUtils.h */; };
 		E695D8661C037E9F00D3FCCE /* FSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E695D8641C037E9F00D3FCCE /* FSUtils.m */; };
 		E695D8681C03804F00D3FCCE /* FSUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */; };
@@ -1518,6 +1518,7 @@
 		E65C5BE21BEA525800D28BEF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E65C5BE31BEA525800D28BEF /* NativeRefTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NativeRefTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E65D89591C8753CE0006EA35 /* SystemUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemUtils.swift; sourceTree = "<group>"; };
+		E65D89801C8778940006EA35 /* AuthenticationKeychainInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfo.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E6639F171BF11E17002D0853 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -1533,7 +1534,6 @@
 		E6927ECE1C7B722300D03F75 /* ErrorToastRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorToastRefTests.swift; sourceTree = "<group>"; };
 		E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationSettingsViewController.swift; sourceTree = "<group>"; };
 		E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsOptions.swift; sourceTree = "<group>"; };
-		E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfo.swift; sourceTree = "<group>"; };
 		E695D8631C037E9F00D3FCCE /* FSUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSUtils.h; sourceTree = "<group>"; };
 		E695D8641C037E9F00D3FCCE /* FSUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSUtils.m; sourceTree = "<group>"; };
 		E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSUtilsTests.swift; sourceTree = "<group>"; };
@@ -2471,6 +2471,7 @@
 				6BE4ACF81B0657180092AEBE /* Accessibility.swift */,
 				0BAC7A7F1AC4B135006018CB /* AppConstants.swift */,
 				28E8BE7E1B792A89002CC733 /* AppInfo.swift */,
+				E65D89801C8778940006EA35 /* AuthenticationKeychainInfo.swift */,
 				E4E7EB451C4A85D80094275D /* SupportUtils.swift */,
 				E66464ED1C10D98000AF05CE /* AssertionUtils.swift */,
 				2FCAE2401ABB531100877008 /* Bytes.swift */,
@@ -2695,7 +2696,6 @@
 		E692E3271C46E62D009D1240 /* AuthenticationManager */ = {
 			isa = PBXGroup;
 			children = (
-				E694AAEF1C77AFEC00415F4B /* AuthenticationKeychainInfo.swift */,
 				E69E06C81C76198000D0F926 /* AuthenticationManagerConstants.swift */,
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
 				E640E8691C73A47C00C5F072 /* PasscodeViews.swift */,
@@ -4005,6 +4005,7 @@
 				D339C2831AD354B400C087BD /* Loader.swift in Sources */,
 				288501FB1AC0F63800E7F670 /* NSScannerExtensions.swift in Sources */,
 				E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */,
+				E65D89811C8778940006EA35 /* AuthenticationKeychainInfo.swift in Sources */,
 				6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
 				281B2C081ADF4F29002917DC /* DeferredUtils.swift in Sources */,
@@ -4376,7 +4377,6 @@
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
-				E694AAF01C77AFEC00415F4B /* AuthenticationKeychainInfo.swift in Sources */,
 				7B59FC471C68E9B600F58EF5 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
 				D39949F51C22461A00E2A03C /* RequestDesktopSiteActivity.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Browser.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -5,8 +5,8 @@
 import Foundation
 import Shared
 
-// Passcode intervals with rawValue in seconds.
-enum PasscodeInterval: Int {
+// Strings for the passcode intervals.
+extension PasscodeInterval {
     var settingTitle: String {
         switch self {
         case .Immediately:      return AuthenticationStrings.immediately
@@ -17,13 +17,6 @@ enum PasscodeInterval: Int {
         case .OneHour:          return AuthenticationStrings.oneHour
         }
     }
-
-    case Immediately    = 0
-    case OneMinute      = 60
-    case FiveMinutes    = 300
-    case TenMinutes     = 600
-    case FifteenMinutes = 900
-    case OneHour        = 3600
 }
 
 // Strings used in multiple areas within the Authentication Manager

--- a/ClientTests/ProfileTest.swift
+++ b/ClientTests/ProfileTest.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Shared
 import Storage
+import SwiftKeychainWrapper
 
 import XCTest
 
@@ -15,5 +16,13 @@ import XCTest
 class ProfileTest: XCTestCase {
     func withTestProfile(callback: (profile: Profile) -> Void) {
         callback(profile: MockProfile())
+    }
+
+    func testNewProfileClearsExistingAuthenticationInfo() {
+        let authInfo = AuthenticationKeychainInfo(passcode: "1234")
+        KeychainWrapper.setAuthenticationInfo(authInfo)
+        XCTAssertNotNil(KeychainWrapper.authenticationInfo())
+        let _ = BrowserProfile(localName: "my_profile")
+        XCTAssertNil(KeychainWrapper.authenticationInfo())
     }
 }

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -219,6 +219,7 @@ public class BrowserProfile: Profile {
             log.info("New profile. Removing old account metadata.")
             self.removeAccountMetadata()
             self.syncManager.onNewProfile()
+            self.removeExistingAuthenticationInfo()
             prefs.clearAll()
         }
 
@@ -466,6 +467,10 @@ public class BrowserProfile: Profile {
     func removeAccountMetadata() {
         self.prefs.removeObjectForKey(PrefsKeys.KeyLastRemoteTabSyncTime)
         KeychainWrapper.removeObjectForKey(self.name + ".account")
+    }
+
+    func removeExistingAuthenticationInfo() {
+        KeychainWrapper.setAuthenticationInfo(nil)
     }
 
     func removeAccount() {

--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -3,14 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
-import Shared
 import SwiftKeychainWrapper
 
 public let KeychainKeyAuthenticationInfo = "authenticationInfo"
 public let AllowedPasscodeFailedAttempts = 3
 
+// Passcode intervals with rawValue in seconds.
+public enum PasscodeInterval: Int {
+    case Immediately    = 0
+    case OneMinute      = 60
+    case FiveMinutes    = 300
+    case TenMinutes     = 600
+    case FifteenMinutes = 900
+    case OneHour        = 3600
+}
+
 // MARK: - Helper methods for accessing Authentication information from the Keychain
-extension KeychainWrapper {
+public extension KeychainWrapper {
     class func authenticationInfo() -> AuthenticationKeychainInfo? {
         return KeychainWrapper.objectForKey(KeychainKeyAuthenticationInfo) as? AuthenticationKeychainInfo
     }
@@ -24,23 +33,23 @@ extension KeychainWrapper {
     }
 }
 
-class AuthenticationKeychainInfo: NSObject, NSCoding {
-    private(set) var lastPasscodeValidationInterval: NSTimeInterval?
-    private(set) var passcode: String?
-    private(set) var requiredPasscodeInterval: PasscodeInterval?
-    private(set) var lockOutInterval: NSTimeInterval?
-    private(set) var failedAttempts: Int
+public class AuthenticationKeychainInfo: NSObject, NSCoding {
+    private(set) public var lastPasscodeValidationInterval: NSTimeInterval?
+    private(set) public var passcode: String?
+    private(set) public var requiredPasscodeInterval: PasscodeInterval?
+    private(set) public var lockOutInterval: NSTimeInterval?
+    private(set) public var failedAttempts: Int
 
     // Timeout period before user can retry entering passcodes
-    var lockTimeInterval: NSTimeInterval = 15 * 60
+    public var lockTimeInterval: NSTimeInterval = 15 * 60
 
-    init(passcode: String) {
+    public init(passcode: String) {
         self.passcode = passcode
         self.requiredPasscodeInterval = .Immediately
         self.failedAttempts = 0
     }
 
-    func encodeWithCoder(aCoder: NSCoder) {
+    public func encodeWithCoder(aCoder: NSCoder) {
         if let lastPasscodeValidationInterval = lastPasscodeValidationInterval {
             let interval = NSNumber(double: lastPasscodeValidationInterval)
             aCoder.encodeObject(interval, forKey: "lastPasscodeValidationInterval")
@@ -56,7 +65,7 @@ class AuthenticationKeychainInfo: NSObject, NSCoding {
         aCoder.encodeInteger(failedAttempts, forKey: "failedAttempts")
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         self.lastPasscodeValidationInterval = (aDecoder.decodeObjectForKey("lastPasscodeValidationInterval") as? NSNumber)?.doubleValue
         self.lockOutInterval = (aDecoder.decodeObjectForKey("lockOutInterval") as? NSNumber)?.doubleValue
         self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
@@ -68,7 +77,7 @@ class AuthenticationKeychainInfo: NSObject, NSCoding {
 }
 
 // MARK: - API
-extension AuthenticationKeychainInfo {
+public extension AuthenticationKeychainInfo {
     private func resetLockoutState() {
         self.failedAttempts = 0
         self.lockOutInterval = nil


### PR DESCRIPTION
* Moves AuthenticationKeychainInfo into Shared to allow access from BrowserProfile to combine profile clearing lifecycle with authentication.