### PR TITLE
Bug 1252087 - Add touch ID/passcode authentication for changing require interval and turning off Touch ID

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		E65C5BE41BEA525800D28BEF /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E65C5BE21BEA525800D28BEF /* Info.plist */; };
 		E65D895A1C8753CE0006EA35 /* SystemUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89591C8753CE0006EA35 /* SystemUtils.swift */; };
 		E65D89811C8778940006EA35 /* AuthenticationKeychainInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89801C8778940006EA35 /* AuthenticationKeychainInfo.swift */; };
+		E65D89181C8647420006EA35 /* AppAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D89171C8647420006EA35 /* AppAuthenticator.swift */; };
 		E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BDD81BB06521009AC090 /* TabsButton.swift */; };
 		E660BE061BB0666D009AC090 /* InnerStrokedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E660BE051BB0666D009AC090 /* InnerStrokedView.swift */; };
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
@@ -1519,6 +1520,7 @@
 		E65C5BE31BEA525800D28BEF /* NativeRefTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NativeRefTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E65D89591C8753CE0006EA35 /* SystemUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemUtils.swift; sourceTree = "<group>"; };
 		E65D89801C8778940006EA35 /* AuthenticationKeychainInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationKeychainInfo.swift; sourceTree = "<group>"; };
+		E65D89171C8647420006EA35 /* AppAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppAuthenticator.swift; sourceTree = "<group>"; };
 		E660BDD81BB06521009AC090 /* TabsButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsButton.swift; sourceTree = "<group>"; };
 		E660BE051BB0666D009AC090 /* InnerStrokedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InnerStrokedView.swift; sourceTree = "<group>"; };
 		E6639F171BF11E17002D0853 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -2697,6 +2699,7 @@
 			isa = PBXGroup;
 			children = (
 				E69E06C81C76198000D0F926 /* AuthenticationManagerConstants.swift */,
+				E65D89171C8647420006EA35 /* AppAuthenticator.swift */,
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
 				E640E8691C73A47C00C5F072 /* PasscodeViews.swift */,
 				E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */,
@@ -4392,6 +4395,7 @@
 				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				E633E2DA1C21EAF8001FFF6C /* LoginDetailViewController.swift in Sources */,
 				59A68B280D62462B85CF57A4 /* HistoryPanel.swift in Sources */,
+				E65D89181C8647420006EA35 /* AppAuthenticator.swift in Sources */,
 				28FDFF0C1C1F725800840F86 /* SeparatorTableCell.swift in Sources */,
 				D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */,
 				59A68E0B4ABBF55E14819668 /* BookmarksPanel.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import SwiftKeychainWrapper
+import LocalAuthentication
+
+class AppAuthenticator {
+    static func presentAuthenticationUsingInfo(authenticationInfo: AuthenticationKeychainInfo, success: (() -> Void)?, fallback: (() -> Void)?) {
+        if authenticationInfo.useTouchID {
+            let localAuthContext = LAContext()
+            localAuthContext.localizedFallbackTitle = AuthenticationStrings.enterPasscode
+            localAuthContext.evaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, localizedReason: AuthenticationStrings.loginsTouchReason) { didSucceed, error in
+                if didSucceed {
+                    // Update our authentication info's last validation timestamp so we don't ask again based
+                    // on the set required interval
+                    authenticationInfo.recordValidation()
+                    KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+
+                    dispatch_async(dispatch_get_main_queue()) {
+                        success?()
+                    }
+                } else if let authError = error where authError.code == LAError.UserFallback.rawValue {
+                    dispatch_async(dispatch_get_main_queue()) {
+                        fallback?()
+                    }
+                }
+            }
+        } else {
+            fallback?()
+        }
+    }
+
+    static func presentPasscodeAuthentication(presentingNavController: UINavigationController?, delegate: PasscodeEntryDelegate) {
+        let passcodeVC = PasscodeEntryViewController()
+        passcodeVC.delegate = delegate
+        let navController = UINavigationController(rootViewController: passcodeVC)
+        navController.modalPresentationStyle = .FormSheet
+        presentingNavController?.presentViewController(navController, animated: true, completion: nil)
+    }
+}

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -100,6 +100,9 @@ class AuthenticationManagerTests: KIFTestCase {
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Require Passcode")
 
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        enterPasscodeWithDigits("1337")
+
         let tableView = tester().waitForViewWithAccessibilityIdentifier("AuthenticationManager.passcodeIntervalTableView") as! UITableView
         var immediatelyCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0))!
         var oneHourCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 5, inSection: 0))!

--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -39,6 +39,7 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
     private(set) public var requiredPasscodeInterval: PasscodeInterval?
     private(set) public var lockOutInterval: NSTimeInterval?
     private(set) public var failedAttempts: Int
+    public var useTouchID: Bool
 
     // Timeout period before user can retry entering passcodes
     public var lockTimeInterval: NSTimeInterval = 15 * 60
@@ -47,6 +48,7 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         self.passcode = passcode
         self.requiredPasscodeInterval = .Immediately
         self.failedAttempts = 0
+        self.useTouchID = false
     }
 
     public func encodeWithCoder(aCoder: NSCoder) {
@@ -63,6 +65,7 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         aCoder.encodeObject(passcode, forKey: "passcode")
         aCoder.encodeObject(requiredPasscodeInterval?.rawValue, forKey: "requiredPasscodeInterval")
         aCoder.encodeInteger(failedAttempts, forKey: "failedAttempts")
+        aCoder.encodeBool(useTouchID, forKey: "useTouchID")
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -70,6 +73,7 @@ public class AuthenticationKeychainInfo: NSObject, NSCoding {
         self.lockOutInterval = (aDecoder.decodeObjectForKey("lockOutInterval") as? NSNumber)?.doubleValue
         self.passcode = aDecoder.decodeObjectForKey("passcode") as? String
         self.failedAttempts = aDecoder.decodeIntegerForKey("failedAttempts")
+        self.useTouchID = aDecoder.decodeBoolForKey("useTouchID")
         if let interval = aDecoder.decodeObjectForKey("requiredPasscodeInterval") as? NSNumber {
             self.requiredPasscodeInterval = PasscodeInterval(rawValue: interval.integerValue)
         }


### PR DESCRIPTION
* Turning off Touch ID now requires authentication using Touch or Passcode.
* Changing the required remember interval for passcode now requires passcode/touch validation.
* Extraction/refactoring of validation logic associated with setting items.