### PR TITLE
Bug 1245217 - L10N Snapshots

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -172,8 +172,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let profile = self.profile {
             return profile
         }
-        let clearProfile = NSProcessInfo.processInfo().environment["MOZ_WIPE_PROFILE"] != nil
-        let p = BrowserProfile(localName: "profile", app: application, clear: clearProfile)
+        let p = BrowserProfile(localName: "profile", app: application)
         self.profile = p
         return p
     }

--- a/Client/Application/TestAppDelegate.swift
+++ b/Client/Application/TestAppDelegate.swift
@@ -19,8 +19,11 @@ class TestAppDelegate: AppDelegate {
         // Don't show the What's New page.
         profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
 
-        // Skip the first run UI.
-        profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
+        // Skip the first run UI except when we are running Fastlane Snapshot tests
+        if !AppConstants.IsRunningFastlaneSnapshot {
+            profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
+        }
+
         self.profile = profile
         return profile
     }

--- a/Client/Application/main.swift
+++ b/Client/Application/main.swift
@@ -6,7 +6,7 @@ import Shared
 
 private var appDelegate: AppDelegate.Type
 
-if AppConstants.IsRunningTest {
+if AppConstants.IsRunningTest || AppConstants.IsRunningFastlaneSnapshot {
     appDelegate = TestAppDelegate.self
 } else {
     switch AppConstants.BuildChannel {

--- a/Client/Frontend/Browser/BrowserToolbar.swift
+++ b/Client/Frontend/Browser/BrowserToolbar.swift
@@ -201,10 +201,15 @@ class BrowserToolbar: Toolbar, BrowserToolbarProtocol {
     private override init(frame: CGRect) {
         // And these have to be initialized in here or the compiler will get angry
         backButton = UIButton()
+        backButton.accessibilityIdentifier = "BrowserToolbar.backButton"
         forwardButton = UIButton()
+        forwardButton.accessibilityIdentifier = "BrowserToolbar.forwardButton"
         stopReloadButton = UIButton()
+        stopReloadButton.accessibilityIdentifier = "BrowserToolbar.stopReloadButton"
         shareButton = UIButton()
+        shareButton.accessibilityIdentifier = "BrowserToolbar.shareButton"
         bookmarkButton = UIButton()
+        bookmarkButton.accessibilityIdentifier = "BrowserToolbar.bookmarkButton"
         actionButtons = [backButton, forwardButton, stopReloadButton, shareButton, bookmarkButton]
 
         super.init(frame: frame)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1785,7 +1785,7 @@ extension BrowserViewController: WKNavigationDelegate {
             removeOpenInView()
         }
     }
-    
+
     // Recognize an Apple Maps URL. This will trigger the native app. But only if a search query is present. Otherwise
     // it could just be a visit to a regular page on maps.apple.com.
     private func isAppleMapsURL(url: NSURL) -> Bool {
@@ -1796,7 +1796,7 @@ extension BrowserViewController: WKNavigationDelegate {
         }
         return false
     }
-    
+
     // Recognize a iTunes Store URL. These all trigger the native apps. Note that appstore.com and phobos.apple.com
     // used to be in this list. I have removed them because they now redirect to itunes.apple.com. If we special case
     // them then iOS will actually first open Safari, which then redirects to the app store. This works but it will
@@ -1819,11 +1819,11 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(WKNavigationActionPolicy.Cancel)
             return
         }
-        
+
         // First special case are some schemes that are about Calling. We prompt the user to confirm this action. This
         // gives us the exact same behaviour as Safari. The only thing we do not do is nicely format the phone number,
         // instead we present it as it was put in the URL.
-        
+
         if url.scheme == "tel" || url.scheme == "facetime" || url.scheme == "facetime-audio" {
             if let phoneNumber = url.resourceSpecifier.stringByRemovingPercentEncoding {
                 let alert = UIAlertController(title: phoneNumber, message: nil, preferredStyle: UIAlertControllerStyle.Alert)
@@ -1836,17 +1836,17 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(WKNavigationActionPolicy.Cancel)
             return
         }
-        
+
         // Second special case are a set of URLs that look like regular http links, but should be handed over to iOS
         // instead of being loaded in the webview. Note that there is no point in calling canOpenURL() here, because
         // iOS will always say yes. TODO Is this the same as isWhitelisted?
-        
+
         if isAppleMapsURL(url) || isStoreURL(url) {
             UIApplication.sharedApplication().openURL(url)
             decisionHandler(WKNavigationActionPolicy.Cancel)
             return
         }
-        
+
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView. We
         // always allow this.
 
@@ -1859,11 +1859,11 @@ extension BrowserViewController: WKNavigationDelegate {
             decisionHandler(WKNavigationActionPolicy.Allow)
             return
         }
-        
+
         // Default to calling openURL(). What this does depends on the iOS version. On iOS 8, it will just work without
         // prompting. On iOS9, depending on the scheme, iOS will prompt: "Firefox" wants to open "Twitter". It will ask
         // every time. There is no way around this prompt. (TODO Confirm this is true by adding them to the Info.plist)
-        
+
         UIApplication.sharedApplication().openURL(url)
         decisionHandler(WKNavigationActionPolicy.Cancel)
     }
@@ -1986,14 +1986,14 @@ extension BrowserViewController: WKUIDelegate {
             newTab = tabManager.addTab(navigationAction.request, configuration: configuration)
         }
         tabManager.selectTab(newTab)
-        
+
         // If the page we just opened has a bad scheme, we return nil here so that JavaScript does not
         // get a reference to it which it can return from window.open() - this will end up as a
         // CFErrorHTTPBadURL being presented.
         guard let scheme = navigationAction.request.URL?.scheme.lowercaseString where SchemesAllowedToOpenPopups.contains(scheme) else {
             return nil
         }
-        
+
         return newTab.webView
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -271,6 +271,7 @@ class TabTrayController: UIViewController {
         button.accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
         button.accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
         button.accessibilityValue = self.privateMode ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
+        button.accessibilityIdentifier = "TabTrayController.togglePrivateMode"
         return button
     }()
 
@@ -346,7 +347,7 @@ class TabTrayController: UIViewController {
         settingsButton.setImage(UIImage(named: "settings"), forState: .Normal)
         settingsButton.addTarget(self, action: "SELdidClickSettingsItem", forControlEvents: .TouchUpInside)
         settingsButton.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button in the Tab Tray.")
-        settingsButton.accessibilityIdentifier = "Settings"
+        settingsButton.accessibilityIdentifier = "TabTrayController.settingsButton"
 
         let flowLayout = TabTrayCollectionViewLayout()
         collectionView = UICollectionView(frame: view.frame, collectionViewLayout: flowLayout)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -141,7 +141,7 @@ class URLBarView: UIView {
         let tabsButton = TabsButton()
         tabsButton.titleLabel.text = "0"
         tabsButton.addTarget(self, action: "SELdidClickAddTab", forControlEvents: UIControlEvents.TouchUpInside)
-        tabsButton.accessibilityIdentifier = "ShowTabs"
+        tabsButton.accessibilityIdentifier = "URLBarView.tabsButton"
         tabsButton.accessibilityLabel = NSLocalizedString("Show Tabs", comment: "Accessibility Label for the tabs button in the browser toolbar")
         return tabsButton
     }()

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -213,6 +213,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
                 button.setImage(image, forState: UIControlState.Selected)
             }
             button.accessibilityLabel = panel.accessibilityLabel
+            button.accessibilityIdentifier = panel.accessibilityIdentifier
             buttons.append(button)
 
             button.snp_remakeConstraints { make in

--- a/Client/Frontend/Home/HomePanels.swift
+++ b/Client/Frontend/Home/HomePanels.swift
@@ -12,6 +12,7 @@ struct HomePanelDescriptor {
     let makeViewController: (profile: Profile) -> UIViewController
     let imageName: String
     let accessibilityLabel: String
+    let accessibilityIdentifier: String
 }
 
 class HomePanels {
@@ -21,7 +22,8 @@ class HomePanels {
                 TopSitesPanel(profile: profile)
             },
             imageName: "TopSites",
-            accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label")),
+            accessibilityLabel: NSLocalizedString("Top sites", comment: "Panel accessibility label"),
+            accessibilityIdentifier: "HomePanels.TopSites"),
 
         HomePanelDescriptor(
             makeViewController: { profile in
@@ -37,7 +39,8 @@ class HomePanels {
                 return controller
             },
             imageName: "Bookmarks",
-            accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label")),
+            accessibilityLabel: NSLocalizedString("Bookmarks", comment: "Panel accessibility label"),
+            accessibilityIdentifier: "HomePanels.Bookmarks"),
 
         HomePanelDescriptor(
             makeViewController: { profile in
@@ -46,7 +49,8 @@ class HomePanels {
                 return controller
             },
             imageName: "History",
-            accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label")),
+            accessibilityLabel: NSLocalizedString("History", comment: "Panel accessibility label"),
+            accessibilityIdentifier: "HomePanels.History"),
 
         HomePanelDescriptor(
             makeViewController: { profile in
@@ -55,7 +59,8 @@ class HomePanels {
                 return controller
             },
             imageName: "SyncedTabs",
-            accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label")),
+            accessibilityLabel: NSLocalizedString("Synced tabs", comment: "Panel accessibility label"),
+            accessibilityIdentifier: "HomePanels.SyncedTabs"),
 
         HomePanelDescriptor(
             makeViewController: { profile in
@@ -64,6 +69,7 @@ class HomePanels {
                 return controller
             },
             imageName: "ReadingList",
-            accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label")),
+            accessibilityLabel: NSLocalizedString("Reading list", comment: "Panel accessibility label"),
+            accessibilityIdentifier: "HomePanels.ReadingList"),
     ]
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -448,6 +448,8 @@ class SearchSetting: Setting {
 
     override var status: NSAttributedString { return NSAttributedString(string: profile.searchEngines.defaultEngine.shortName) }
 
+    override var accessibilityIdentifier: String? { return "Search" }
+
     init(settings: SettingsTableViewController) {
         self.profile = settings.profile
         super.init(title: NSAttributedString(string: NSLocalizedString("Search", comment: "Open search section of settings"), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
@@ -466,6 +468,8 @@ class LoginsSetting: Setting {
     weak var navigationController: UINavigationController?
 
     override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "Logins" }
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate?) {
         self.profile = settings.profile
@@ -552,6 +556,8 @@ class TouchIDPasscodeSetting: Setting {
     var tabManager: TabManager!
 
     override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "TouchIDPasscode" }
 
     init(settings: SettingsTableViewController, delegate: SettingsDelegate? = nil) {
         self.profile = settings.profile

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -19,6 +19,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
             title: NSLocalizedString("Done", comment: "Done button on left side of the Settings view controller title bar"),
             style: UIBarButtonItemStyle.Done,
             target: navigationController, action: "SELdone")
+        navigationItem.leftBarButtonItem?.accessibilityIdentifier = "AppSettingsTableViewController.navigationItem.leftBarButtonItem"
     }
 
     override func generateSettings() -> [SettingSection] {

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -387,6 +387,7 @@ class SettingsTableFooterView: UIView {
     var logo: UIImageView = {
         var image =  UIImageView(image: UIImage(named: "settingsFlatfox"))
         image.contentMode = UIViewContentMode.Center
+        image.accessibilityIdentifier = "SettingsTableFooterView.logo"
         return image
     }()
 

--- a/L10nSnapshotTests/L10nSnapshotTests.swift
+++ b/L10nSnapshotTests/L10nSnapshotTests.swift
@@ -13,72 +13,205 @@ import XCTest
  * Thank You.
  */
 class L10nSnapshotTests: XCTestCase {
-        
     override func setUp() {
         super.setUp()
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        
+
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
         let app = XCUIApplication()
         setupSnapshot(app)
-        app.launchEnvironment["WIPE_PROFILE"] = "YES"
         app.launch()
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func test1Intro() {
+
+    // TODO Refactor this into a common superlcass for snapshots
+    func loadWebPage(url: String, waitForLoadToFinish: Bool = true) {
+        let LoadingTimeout: NSTimeInterval = 60
+        let exists = NSPredicate(format: "exists = true")
+        let loaded = NSPredicate(format: "value BEGINSWITH '100'")
+
         let app = XCUIApplication()
 
-        snapshot("00Intro-1")
+        UIPasteboard.generalPasteboard().string = url
+        app.textFields["url"].pressForDuration(2.0)
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
 
+        if waitForLoadToFinish {
+            let progressIndicator = app.progressIndicators.elementBoundByIndex(0)
+            expectationForPredicate(exists, evaluatedWithObject: progressIndicator, handler: nil)
+            expectationForPredicate(loaded, evaluatedWithObject: progressIndicator, handler: nil)
+            waitForExpectationsWithTimeout(LoadingTimeout, handler: nil)
+        }
+    }
+
+    func test01Intro() {
+        let app = XCUIApplication()
+        snapshot("01Intro-1")
         app.swipeLeft()
         sleep(2)
         snapshot("01Intro-2")
-
         app.swipeLeft()
         sleep(2)
-        snapshot("02Intro-3")
-
+        snapshot("01Intro-3")
         app.swipeLeft()
         sleep(2)
-        snapshot("03Intro-4")
-
+        snapshot("01Intro-4")
         app.swipeLeft()
         sleep(2)
-        snapshot("04Intro-5")
+        snapshot("01Intro-5")
     }
 
+    func test02DefaultTopSites() {
+        snapshot("02DefaultTopSites-01")
+    }
 
-    func testSettingsTableView() {
+    func test03Settings() {
         let app = XCUIApplication()
-        app.buttons.matchingIdentifier("Show Tabs").element.tap()
+        app.buttons["URLBarView.tabsButton"].tap()
+        app.buttons["TabTrayController.settingsButton"].tap()
 
-        sleep(2)
-        app.buttons.matchingIdentifier("settings").element.tap()
+        var index = 1
 
-        sleep(2)
-        snapshot("SettingsTableView")
+        // Screenshot the settings by scrolling through it
+        snapshot("03Settings-\(index)")
+        let element = app.images["SettingsTableFooterView.logo"]
+        while !element.visible() {
+            app.swipeUp()
+            sleep(2)
+            index += 1
+            snapshot("03Settings-\(index)")
+        }
+
+        // Screenshot all the settings that have a separate page
+        for cellName in ["Search", "Logins", "TouchIDPasscode", "ClearPrivateData"] {
+            app.tables.cells[cellName].tap()
+            index++
+            snapshot("03Settings-\(index)")
+            app.navigationBars.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+        }
     }
-    func test2ClearPrivateData() {
+
+    func test04PrivateBrowsingTabsEmptyState() {
+        let app = XCUIApplication()
+        app.buttons["URLBarView.tabsButton"].tap() // Open tabs tray
+        app.buttons["TabTrayController.togglePrivateMode"].tap() // Switch to private mode
+        snapshot("04PrivateBrowsingTabsEmptyState-01")
+    }
+
+    func test05PanelsEmptyState() {
+        let app = XCUIApplication()
+        app.textFields["url"].tap()
+        app.buttons["HomePanels.Bookmarks"].tap()
+        snapshot("05PanelsEmptyState-01")
+        app.buttons["HomePanels.History"].tap()
+        snapshot("05PanelsEmptyState-02")
+        app.buttons["HomePanels.SyncedTabs"].tap()
+        snapshot("05PanelsEmptyState-03")
+        app.buttons["HomePanels.ReadingList"].tap()
+        snapshot("05PanelsEmptyState-04")
+    }
+
+    func test06URLBar() {
+        let app = XCUIApplication()
+        app.textFields["url"].tap()
+        snapshot("06URLBar-01")
+        app.textFields["address"].typeText("moz")
+        snapshot("06URLBar-02")
+    }
+
+    func test07URLBarContextMenu() {
+        let app = XCUIApplication()
+        // Long press with nothing on the clipboard
+        app.textFields["url"].pressForDuration(2.0)
+        snapshot("07LocationBarContextMenu-01")
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+        sleep(2)
+
+        // Long press with a URL on the clipboard
+        UIPasteboard.generalPasteboard().string = "https://www.mozilla.com"
+        app.textFields["url"].pressForDuration(2.0)
+        snapshot("07LocationBarContextMenu-02")
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+        sleep(2)
+    }
+
+    func test08WebViewContextMenu() {
+        let app = XCUIApplication()
+
+        // TODO Do we have more types of content that trigger a different kind of context menu?
+        let urls = [
+            "http://people.mozilla.org/~sarentz/fxios/testpages/link.html",
+            "http://people.mozilla.org/~sarentz/fxios/testpages/image.html",
+            "http://people.mozilla.org/~sarentz/fxios/testpages/imageWithLink.html"
+        ]
+
+        for (index, url) in urls.enumerate() {
+            loadWebPage(url)
+            let webView = app.webViews.elementBoundByIndex(0)
+            let coordinate = webView.coordinateWithNormalizedOffset(CGVector(dx: 0.01, dy: 0.01))
+            coordinate.pressForDuration(2.0)
+            snapshot("08WebViewContextMenu-\(index + 1)")
+            // TODO Is there a nicer way to tap the bottom button in a sheet?
+            app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(app.sheets.elementBoundByIndex(0).buttons.count-1).tap()
+        }
+    }
+
+    func test09WebViewAuthenticationDialog() {
+        loadWebPage("https://phonebook.mozilla.org", waitForLoadToFinish: false)
+        let predicate = NSPredicate(format: "exists == 1")
+        let query = XCUIApplication().alerts.elementBoundByIndex(0)
+        expectationForPredicate(predicate, evaluatedWithObject: query, handler: nil)
+        self.waitForExpectationsWithTimeout(3, handler: nil)
+        snapshot("09WebViewAuthenticationDialog-01", waitForLoadingIndicator: false)
+    }
+
+    func test10ReloadButtonContextMenu() {
+        let app = XCUIApplication()
+        loadWebPage("http://people.mozilla.org")
+        app.buttons["BrowserToolbar.stopReloadButton"].pressForDuration(2.0)
+        snapshot("10ContextMenuReloadButton-01", waitForLoadingIndicator: false)
+        app.sheets.elementBoundByIndex(0).buttons.elementBoundByIndex(0).tap()
+        app.buttons["BrowserToolbar.stopReloadButton"].pressForDuration(2.0)
+        snapshot("10ContextMenuReloadButton-02", waitForLoadingIndicator: false)
+    }
+
+    func test50ClearPrivateData() {
+        let app = XCUIApplication()
+        var index = 1
+
+        func mySnapshot(name: String) {
+            snapshot(name)
+            index += 1
+        }
+
+        func clearPrivateData() {
+            let clearPrivateDataCell = app.tables.cells["ClearPrivateData"]
+            clearPrivateDataCell.tap()
+            mySnapshot("50ClearPrivateData-\(index)")
+            let clearPrivateDataButton = app.tables.cells["ClearPrivateData"]
+            clearPrivateDataButton.tap()
+            mySnapshot("50ClearPrivateData-\(index)")
+            let button = app.alerts.elementBoundByIndex(0).collectionViews.buttons.elementBoundByIndex(0)
+            button.tap()
+            let navBar = app.navigationBars.elementBoundByIndex(0)
+            navBar.buttons.elementBoundByIndex(0).tap()
+        }
 
         let loginUsername = "testtesto@mockmyid.com"
         let loginPassword = "testtesto@mockmyid.com"
-        
 
-        let app = XCUIApplication()
-        app.buttons["ShowTabs"].tap()
-        app.buttons["Settings"].tap()
+        app.buttons["URLBarView.tabsButton"].tap()
+        app.buttons["TabTrayController.settingsButton"].tap()
 
-        snapshot("10SettingsTopNoAccount")
+        mySnapshot("50ClearPrivateData-\(index)")
 
-        clearPrivateData(prefix: "1", position: 1, postfix: "NoAccount")
+        var logOutCell = app.tables.cells["LogOut"]
+        if logOutCell.exists {
+            logOutCell.tap()
+            app.alerts.elementBoundByIndex(0).collectionViews.buttons.elementBoundByIndex(1).tap()
+        }
+
+        clearPrivateData()
 
         app.tables.cells["SignInToFirefox"].tap()
 
@@ -88,50 +221,35 @@ class L10nSnapshotTests: XCTestCase {
 
         waitForExpectationsWithTimeout(10, handler: nil)
 
-        if app.webViews.textFields.elementBoundByIndex(0).exists {
-            app.webViews.textFields.elementBoundByIndex(0).tap()
-            app.webViews.textFields.elementBoundByIndex(0).typeText(loginUsername)
+        let usernameField = app.webViews.textFields.elementBoundByIndex(0)
+        if !usernameField.exists {
+            app.webViews.links.elementBoundByIndex(1).tap()
+            expectationForPredicate(exists, evaluatedWithObject: usernameField, handler: nil)
+            waitForExpectationsWithTimeout(10, handler: nil)
         }
+        usernameField.tap()
+        usernameField.typeText(loginUsername)
 
         passwordField.tap()
+        sleep(2)
         passwordField.typeText(loginPassword)
         app.webViews.buttons.elementBoundByIndex(0).tap()
 
-        snapshot("13SettingsTopWithAccount")
+        mySnapshot("50ClearPrivateData-\(index)")
 
-        clearPrivateData(prefix: "1", position: 4, postfix: "WithAccount")
+        clearPrivateData()
 
-        let logOutCell = app.tables.cells["LogOut"]
+        logOutCell = app.tables.cells["LogOut"]
         app.tables.elementBoundByIndex(0).scrollToElement(logOutCell)
-        snapshot("16SettingsBottomWithAccount")
+        mySnapshot("50ClearPrivateData-\(index)")
         logOutCell.tap()
-        snapshot("17LogOutConfirm")
+        mySnapshot("50ClearPrivateData-\(index)")
         app.alerts.elementBoundByIndex(0).collectionViews.buttons.elementBoundByIndex(1).tap()
-        snapshot("18SettingsBottomNoAccount")
-    }
-
-    private func clearPrivateData(prefix prefix: String, var position: Int, postfix: String = "") {
-
-        let app = XCUIApplication()
-
-        let clearPrivateDataCell = app.tables.cells["ClearPrivateData"]
-        clearPrivateDataCell.tap()
-        snapshot("\(prefix)\(position++)ClearPrivateData\(postfix)")
-
-        let clearPrivateDataButton = app.tables.cells["ClearPrivateData"]
-        clearPrivateDataButton.tap()
-        snapshot("\(prefix)\(position++)ClearPrivateDataConfirm\(postfix)")
-
-        let button = app.alerts.elementBoundByIndex(0).collectionViews.buttons.elementBoundByIndex(0)
-        button.tap()
-
-        let navBar = app.navigationBars.elementBoundByIndex(0)
-        navBar.buttons.elementBoundByIndex(0).tap()
+        mySnapshot("50ClearPrivateData-\(index)")
     }
 }
 
 extension XCUIElement {
-
     func scrollToElement(element: XCUIElement) {
         while !element.visible() {
             swipeUp()
@@ -142,5 +260,4 @@ extension XCUIElement {
         guard self.exists && !CGRectIsEmpty(self.frame) else { return false }
         return CGRectContainsRect(XCUIApplication().windows.elementBoundByIndex(0).frame, self.frame)
     }
-
 }

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -14,6 +14,9 @@ public struct AppConstants {
 
     public static let IsRunningTest = NSClassFromString("XCTestCase") != nil
 
+    // True if this process is executed as part of a Fastlane Snapshot test
+    public static let IsRunningFastlaneSnapshot = NSProcessInfo.processInfo().arguments.contains("FASTLANE_SNAPSHOT")
+
     /// Build Channel.
     public static let BuildChannel: AppBuildChannel = {
 #if MOZ_CHANNEL_AURORA

--- a/l10n-screenshots.sh
+++ b/l10n-screenshots.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ -d l10n-screenshots ]; then
+  echo "The l10n-screenshots directory already exists. You decide."
+  exit 1
+fi
+
+if [ ! -d firefox-ios-l10n ]; then
+    echo "Did not find a firefox-ios-l10n checkout. Are you running this on a localized build?"
+    exit 1
+fi
+
+mkdir l10n-screenshots
+
+for d in firefox-ios-l10n/?? firefox-ios-l10n/??? firefox-ios-l10n/??-??; do
+    lang=$(basename $d)
+    echo "Snapshotting $lang"
+    mkdir "l10n-screenshots/$lang"
+    snapshot --project Client.xcodeproj --scheme L10nSnapshotTests \
+             --erase_simulator --number_of_retries 3 \
+             --devices "iPhone 4s,iPhone 5s,iPhone 6s" --languages "$lang" \
+             --output_directory "l10n-screenshots/$lang" > "l10n-screenshots/$lang/snapshot.log" 2>&1
+done


### PR DESCRIPTION
This patch improves L10N snapshots. The output can be seen at:

http://people.mozilla.org/~sarentz/fxios/screenshots/

This patch now has three main parts:

* Adding more accessibility identifiers throughout the UI code. These are needed to properly locate UI elements.
* The `TestAppDelegate` and `main.swift` are now aware when the app is run as part of a *Fastlane Snapshot* test. In that case the `TestAppDelegate` is used. And we skip the *What's New* page.
* Added a bunch more snapshot test cases to get better coverage of the application

The last commit in the patch is about adding `l10n-screenshots.sh`, which is a *temporary* script to run these screenshots. This only exists because I can't get Fastlane to work. I'm also happy to remove this script from this patch and just run a local copy until we have resolved the Fastlane issues.
