### PR TITLE
Bug-1234899 fix cell height in ReaderPanel for better formatting.

### DIFF
--- a/Client/Frontend/Home/ReaderPanel.swift
+++ b/Client/Frontend/Home/ReaderPanel.swift
@@ -247,7 +247,8 @@ class ReadingListPanel: UITableViewController, HomePanel, SWTableViewCellDelegat
         super.viewDidLoad()
 
         tableView.accessibilityIdentifier = "ReadingTable"
-        tableView.rowHeight = ReadingListTableViewCellUX.RowHeight
+        tableView.estimatedRowHeight = ReadingListTableViewCellUX.RowHeight
+        tableView.rowHeight = UITableViewAutomaticDimension
         tableView.separatorInset = UIEdgeInsetsZero
         tableView.layoutMargins = UIEdgeInsetsZero
         tableView.separatorColor = UIConstants.SeparatorColor


### PR DESCRIPTION
Using UITableViewAutomaticDimension here creates better spacing in the ReaderPanel. 
![largeriosfontsize](https://cloud.githubusercontent.com/assets/522281/13549706/9190b12e-e2c0-11e5-8a96-7ce2afc4a33d.png)
![defaultiosfontsize](https://cloud.githubusercontent.com/assets/522281/13549707/936fb1ca-e2c0-11e5-8943-90758c70d427.png)

