### PR TITLE
Bug 1251689 — Rudimentary telemetry for bookmark buffer validation.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		28A17B671BEC727500BC14ED /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A17B661BEC727500BC14ED /* Downloader.swift */; };
 		28AA941D1B97DCA800703DC6 /* BookmarkPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AA941C1B97DCA800703DC6 /* BookmarkPayload.swift */; };
 		28B62ACE1BC745E7004A585A /* Syncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B62ACD1BC745E7004A585A /* Syncable.swift */; };
+		28BFA7251C8E5C3F0017C2BD /* TelemetryPing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BFA7241C8E5C3F0017C2BD /* TelemetryPing.swift */; };
 		28C28BFD1C51A3B900D5460E /* Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C28BFC1C51A3B900D5460E /* Merging.swift */; };
 		28C4AB721AD42D4300D9ACE3 /* Clients.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C4AB711AD42D4300D9ACE3 /* Clients.swift */; };
 		28C8B7851C852535006D8318 /* BookmarksPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C8B7841C852535006D8318 /* BookmarksPanelTests.swift */; };
@@ -1100,6 +1101,7 @@
 		28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		28AA941C1B97DCA800703DC6 /* BookmarkPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkPayload.swift; sourceTree = "<group>"; };
 		28B62ACD1BC745E7004A585A /* Syncable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncable.swift; sourceTree = "<group>"; };
+		28BFA7241C8E5C3F0017C2BD /* TelemetryPing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TelemetryPing.swift; path = Telemetry/TelemetryPing.swift; sourceTree = "<group>"; };
 		28C077971A3B064000834FE5 /* CryptoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CryptoTests.swift; path = SyncTests/CryptoTests.swift; sourceTree = "<group>"; };
 		28C0779D1A3B066000834FE5 /* RecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecordTests.swift; path = SyncTests/RecordTests.swift; sourceTree = "<group>"; };
 		28C28BFC1C51A3B900D5460E /* Merging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Merging.swift; sourceTree = "<group>"; };
@@ -1890,6 +1892,14 @@
 				2894C1651AE89DD200F1F92F /* TabsSynchronizer.swift */,
 			);
 			name = Synchronizers;
+			sourceTree = "<group>";
+		};
+		28BFA7101C8E5C1A0017C2BD /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				28BFA7241C8E5C3F0017C2BD /* TelemetryPing.swift */,
+			);
+			name = Telemetry;
 			sourceTree = "<group>";
 		};
 		28C077911A3B05C200834FE5 /* SyncTests */ = {
@@ -2713,6 +2723,7 @@
 				28CE83B91A1D1D3200576538 /* Sync */,
 				28C077911A3B05C200834FE5 /* SyncTests */,
 				E6231BFF1B90A34F005ABB0D /* System Dependencies */,
+				28BFA7101C8E5C1A0017C2BD /* Telemetry */,
 				28CE83EF1A1D246900576538 /* Third-Party Source */,
 				D39FA1601A83E0EC00EE869C /* UITests */,
 				E42CCDFF1A24C4E300B794D3 /* Utils */,
@@ -3948,6 +3959,7 @@
 				E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */,
 				E65D89811C8778940006EA35 /* AuthenticationKeychainInfo.swift in Sources */,
 				6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */,
+				28BFA7251C8E5C3F0017C2BD /* TelemetryPing.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
 				281B2C081ADF4F29002917DC /* DeferredUtils.swift in Sources */,
 				B729F06A1B75CBEF00745F7A /* UserAgent.swift in Sources */,

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -631,7 +631,8 @@ public class BrowserProfile: Profile {
             let bufferRows = (self.profile.bookmarks as? MergedSQLiteBookmarks)?.synchronousBufferCount()
 
             self.doInBackgroundAfter(millis: 300) {
-                let ping = makeAdHocBookmarkMergePing(NSBundle.mainBundle(), attempt: attempt, bufferRows: bufferRows, valid: validations)
+                let id = DeviceInfo.clientIdentifier(self.prefs)
+                let ping = makeAdHocBookmarkMergePing(NSBundle.mainBundle(), clientID: id, attempt: attempt, bufferRows: bufferRows, valid: validations)
                 let payload = ping.toString()
                 guard let body = payload.dataUsingEncoding(NSUTF8StringEncoding) else {
                     log.debug("Invalid JSON!")

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Alamofire
 import Foundation
 import Account
 import ReadingList
@@ -609,6 +610,44 @@ public class BrowserProfile: Profile {
             center.addObserver(self, selector: "onDatabaseWasRecreated:", name: NotificationDatabaseWasRecreated, object: nil)
             center.addObserver(self, selector: "onLoginDidChange:", name: NotificationDataLoginDidChange, object: nil)
             center.addObserver(self, selector: "onFinishSyncing:", name: NotificationProfileDidFinishSyncing, object: nil)
+            center.addObserver(self, selector: "onBookmarkBufferValidated:", name: NotificationBookmarkBufferValidated, object: nil)
+        }
+
+        func onBookmarkBufferValidated(notification: NSNotification) {
+            guard profile.prefs.boolForKey("settings.sendUsageData") ?? true else {
+                log.debug("Profile isn't sending usage data. Not sending bookmark event.")
+                return
+            }
+
+            guard let validations = (notification.object as? Box<[String: Bool]>)?.value else {
+                log.warning("Notification didn't have validations.")
+                return
+            }
+
+            let attempt: Int32 = self.prefs.intForKey("bookmarkvalidationattempt") ?? 1
+            self.prefs.setInt(attempt + 1, forKey: "bookmarkvalidationattempt")
+
+            // Capture the buffer count ASAP, not in the delayed op, because the merge could wipe it!
+            let bufferRows = (self.profile.bookmarks as? MergedSQLiteBookmarks)?.synchronousBufferCount()
+
+            self.doInBackgroundAfter(millis: 300) {
+                let ping = makeAdHocBookmarkMergePing(NSBundle.mainBundle(), attempt: attempt, bufferRows: bufferRows, valid: validations)
+                let payload = ping.toString()
+                guard let body = payload.dataUsingEncoding(NSUTF8StringEncoding) else {
+                    log.debug("Invalid JSON!")
+                    return
+                }
+
+                let url = "https://mozilla-anonymous-sync-metrics.moo.mx/post/bookmarkvalidation".asURL!
+                let request = NSMutableURLRequest(URL: url)
+                request.HTTPMethod = "POST"
+                request.HTTPBody = body
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+                Alamofire.Manager.sharedInstance.request(request).response { (request, response, data, error) in
+                    log.debug("Bookmark validation upload response: \(response?.statusCode ?? -1).")
+                }
+            }
         }
 
         deinit {
@@ -617,6 +656,7 @@ public class BrowserProfile: Profile {
             center.removeObserver(self, name: NotificationDatabaseWasRecreated, object: nil)
             center.removeObserver(self, name: NotificationDataLoginDidChange, object: nil)
             center.removeObserver(self, name: NotificationProfileDidFinishSyncing, object: nil)
+            center.removeObserver(self, name: NotificationBookmarkBufferValidated, object: nil)
         }
 
         private func handleRecreationOfDatabaseNamed(name: String?) -> Success {

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -30,6 +30,9 @@ public protocol BookmarkBufferStorage: class {
     func validate() -> Success
     func getBufferedDeletions() -> Deferred<Maybe<[(GUID, Timestamp)]>>
     func applyBufferCompletionOp(op: BufferCompletionOp, itemSources: ItemSources) -> Success
+
+    // Only use for diagnostics.
+    func synchronousBufferCount() -> Int?
 }
 
 public protocol MirrorItemSource: class {

--- a/Storage/Bookmarks/Bookmarks.swift
+++ b/Storage/Bookmarks/Bookmarks.swift
@@ -22,6 +22,8 @@ public protocol SyncableBookmarks: class, ResettableSyncStorage, AccountRemovalD
     func applyLocalOverrideCompletionOp(op: LocalOverrideCompletionOp, itemSources: ItemSources) -> Success
 }
 
+public let NotificationBookmarkBufferValidated = "NotificationBookmarkBufferValidated"
+
 public protocol BookmarkBufferStorage: class {
     func isEmpty() -> Deferred<Maybe<Bool>>
     func applyRecords(records: [BookmarkMirrorItem]) -> Success

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -390,6 +390,10 @@ public class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
         self.db = db
     }
 
+    public func synchronousBufferCount() -> Int? {
+        return self.db.runQuery("SELECT COUNT(*) FROM \(TableBookmarksBuffer)", args: nil, factory: IntFactory).value.successValue?[0]
+    }
+
     /**
      * Remove child records for any folders that've been deleted or are empty.
      */
@@ -554,6 +558,10 @@ extension BrowserDB {
 }
 
 extension MergedSQLiteBookmarks: BookmarkBufferStorage {
+    public func synchronousBufferCount() -> Int? {
+        return self.buffer.synchronousBufferCount()
+    }
+
     public func isEmpty() -> Deferred<Maybe<Bool>> {
         return self.buffer.isEmpty()
     }

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -676,6 +676,12 @@ extension MergedSQLiteBookmarks: SyncableBookmarks {
 
 // MARK: - Validation of buffer contents.
 
+// Note that these queries tend to not have exceptions for deletions.
+// That's because a record can't be deleted in isolation -- if it's
+// deleted its parent should be changed, too -- and so our views will
+// correctly reflect that. We'll have updated rows in the structure table,
+// and updated values -- and thus a complete override -- for the parent and
+// the deleted child.
 private let allBufferStructuresReferToRecords = [
 "SELECT s.child AS pointee, s.parent AS pointer FROM",
 ViewBookmarksBufferStructureOnMirror,
@@ -707,26 +713,76 @@ TableBookmarksBuffer, "b JOIN", TableBookmarksBufferStructure,
 "s ON b.guid = s.child WHERE b.parentid IS NOT s.parent",
 ].joinWithSeparator(" ")
 
+public enum BufferInconsistency {
+    case MissingValues
+    case MissingStructure
+    case OverlappingStructure
+    case ParentIDDisagreement
+
+    public var query: String {
+        switch self {
+        case .MissingValues:
+            return allBufferStructuresReferToRecords
+        case .MissingStructure:
+            return allNonDeletedBufferRecordsAreInStructure
+        case .OverlappingStructure:
+            return allRecordsAreChildrenOnce
+        case .ParentIDDisagreement:
+            return bufferParentidMatchesStructure
+        }
+    }
+
+    public var trackingEvent: String {
+        switch self {
+        case .MissingValues:
+            return "missingvalues"
+        case .MissingStructure:
+            return "missingstructure"
+        case .OverlappingStructure:
+            return "overlappingstructure"
+        case .ParentIDDisagreement:
+            return "parentiddisagreement"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .MissingValues:
+            return "Not all buffer structures refer to records."
+        case .MissingStructure:
+            return "Not all buffer records are in structure."
+        case .OverlappingStructure:
+            return "Some buffer structures refer to the same records."
+        case .ParentIDDisagreement:
+            return "Some buffer record parent IDs don't match structure."
+        }
+    }
+
+    public static let all: [BufferInconsistency] = [.MissingValues, .MissingStructure, .OverlappingStructure, .ParentIDDisagreement]
+}
+
 extension SQLiteBookmarkBufferStorage {
     public func validate() -> Success {
-        func yup(message: String) -> Bool -> Success {
-            return { truth in
-                guard truth else {
+        let notificationCenter = NSNotificationCenter.defaultCenter()
+
+        var validations: [String: Bool] = [:]
+        let deferred = BufferInconsistency.all.map { inc in
+            self.db.queryReturnsNoResults(inc.query) >>== { yes in
+                validations[inc.trackingEvent] = !yes
+                guard yes else {
+                    let message = inc.description
                     log.warning(message)
                     return deferMaybe(DatabaseError(description: message))
                 }
                 return succeed()
             }
+        }.allSucceed()
+
+        deferred.upon { success in
+            notificationCenter.postNotificationName(NotificationBookmarkBufferValidated, object: Box(validations))
         }
 
-        return [
-            (allBufferStructuresReferToRecords, "Not all buffer structures refer to records. Buffer is inconsistent."),
-            (allNonDeletedBufferRecordsAreInStructure, "Not all buffer records are in structure. Buffer is inconsistent."),
-            (allRecordsAreChildrenOnce, "Some buffer structures refer to the same records. Buffer is inconsistent."),
-            (bufferParentidMatchesStructure, "Some buffer records don't match structure. Buffer is inconsistent."),
-        ].map { (query, message) in
-            return self.db.queryReturnsNoResults(query) >>== yup(message)
-        }.allSucceed()
+        return deferred
     }
 
     public func getBufferedDeletions() -> Deferred<Maybe<[(GUID, Timestamp)]>> {

--- a/Telemetry/TelemetryPing.swift
+++ b/Telemetry/TelemetryPing.swift
@@ -2,16 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-public func makeAdHocBookmarkMergePing(bundle: NSBundle, attempt: Int32, bufferRows: Int?, valid: [String: Bool]) -> JSON {
+public func makeAdHocBookmarkMergePing(bundle: NSBundle, clientID: String, attempt: Int32, bufferRows: Int?, valid: [String: Bool]) -> JSON {
     let anyFailed = valid.reduce(false, combine: { $0 || $1.1 })
 
     var out: [String: AnyObject] = [
         "v": 1,
         "appV": AppInfo.appVersion,
         "build": bundle.objectForInfoDictionaryKey("BuildID") as? String ?? "unknown",
-
-        // The ID can be nil if the device is locked.
-        "id": DeviceInfo.identifierForVendor()?.UUIDString ?? "unknown",
+        "id": clientID,
         "attempt": Int(attempt),
         "success": !anyFailed,
     ]

--- a/Telemetry/TelemetryPing.swift
+++ b/Telemetry/TelemetryPing.swift
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+public func makeAdHocBookmarkMergePing(bundle: NSBundle, attempt: Int32, bufferRows: Int?, valid: [String: Bool]) -> JSON {
+    let anyFailed = valid.reduce(false, combine: { $0 || $1.1 })
+
+    var out: [String: AnyObject] = [
+        "v": 1,
+        "appV": AppInfo.appVersion,
+        "build": bundle.objectForInfoDictionaryKey("BuildID") as? String ?? "unknown",
+
+        // The ID can be nil if the device is locked.
+        "id": DeviceInfo.identifierForVendor()?.UUIDString ?? "unknown",
+        "attempt": Int(attempt),
+        "success": !anyFailed,
+    ]
+
+    if let bufferRows = bufferRows {
+        out["rows"] = bufferRows
+    }
+
+    if anyFailed {
+        valid.forEach { key, value in
+            out[key] = value
+        }
+    }
+
+    return JSON(out)
+}

--- a/Utils/DeviceInfo.swift
+++ b/Utils/DeviceInfo.swift
@@ -49,8 +49,13 @@ public class DeviceInfo {
         return String(format: f, appName(), device)
     }
 
-    public class func identifierForVendor() -> NSUUID? {
-        return UIDevice.currentDevice().identifierForVendor
+    public class func clientIdentifier(prefs: Prefs) -> String {
+        if let id = prefs.stringForKey("clientIdentifier") {
+            return id
+        }
+        let id = NSUUID().UUIDString
+        prefs.setString(id, forKey: "clientIdentifier")
+        return id
     }
 
     public class func deviceModel() -> String {

--- a/Utils/DeviceInfo.swift
+++ b/Utils/DeviceInfo.swift
@@ -49,6 +49,10 @@ public class DeviceInfo {
         return String(format: f, appName(), device)
     }
 
+    public class func identifierForVendor() -> NSUUID? {
+        return UIDevice.currentDevice().identifierForVendor
+    }
+
     public class func deviceModel() -> String {
         return UIDevice.currentDevice().model
     }


### PR DESCRIPTION
This dumps stuff into MongoDB. Yup, MongoDB.

There are some metadata fields and then some validation fields. If any validation fields are 'true', something went wrong.

Validation isn't even attempted if the buffer is empty (upload-only sync), so these pings will only be sent when incoming data was being processed. We mostly care about attempt = 1 including any failures: this will be a first attempt at merging. Repeated attempts with the same row count are just a result of scheduling.