### PR TITLE
Bug 1210131 - Fixes Wrong Favicon shown after tapping back quickly.

### DIFF
--- a/Client/Assets/Favicons.js
+++ b/Client/Assets/Favicons.js
@@ -2,47 +2,49 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function() {
- // These integers should be kept in sync with the IconType raw-values
- var ICON = 0;
- var APPLE = 1;
- var APPLE_PRECOMPOSED = 2;
- var GUESS = 3;
 
- var Favicons = {
-  selectors: { "link[rel~='icon']": ICON,
-              "link[rel='apple-touch-icon']": APPLE,
-              "link[rel='apple-touch-icon-precomposed']": APPLE_PRECOMPOSED },
-
- getAll: function() {
-    var res = {}
-    var foundIcons = false
-
-    for (selector in this.selectors) {
-      var icons = document.querySelectorAll(selector)
-      if (icons.length) {
-        res = {}
-      }
-      for (var i = 0; i < icons.length; i++) {
-        var href = icons[i].href;
-        res[href] = this.selectors[selector];
-          foundIcons = true
-        }
-      }
-
-    // If we didn't find anything in the page, look to see if a favicon.ico file exists for the domain
-    if (!foundIcons) {
-      var href = document.location.origin + "/favicon.ico";
-      res[href] = GUESS;
-    }
-
-    return res;
-  }
+if (!window.__firefox__) {
+  window.__firefox__ = {};
 }
 
-window.addEventListener("load", function() {
-  var favicons = Favicons.getAll();
-  webkit.messageHandlers.faviconsMessageHandler.postMessage(favicons);
-});
-
-})()
+window.__firefox__.favicons = function() {
+  // These integers should be kept in sync with the IconType raw-values
+  var ICON = 0;
+  var APPLE = 1;
+  var APPLE_PRECOMPOSED = 2;
+  var GUESS = 3;
+  
+  var selectors = { "link[rel~='icon']": ICON,
+    "link[rel='apple-touch-icon']": APPLE,
+    "link[rel='apple-touch-icon-precomposed']": APPLE_PRECOMPOSED
+  };
+  
+  function getAll() {
+    var favicons = {};
+    
+    for (var selector in selectors) {
+      var icons = document.head.querySelectorAll(selector);
+      for (var i = 0; i < icons.length; i++) {
+        var href = icons[i].href;
+        favicons[href] = selectors[selector];
+      }
+    }
+    
+    // If we didn't find anything in the page, look to see if a favicon.ico file exists for the domain
+    if (Object.keys(favicons).length === 0) {
+      var href = document.location.origin + "/favicon.ico";
+      favicons[href] = GUESS;
+    }
+    return favicons;
+  }
+  
+  function getFavicons() {
+    var favicons = getAll();
+    webkit.messageHandlers.faviconsMessageHandler.postMessage(favicons);
+  }
+  
+  return {
+    getFavicons : getFavicons
+  };
+  
+}();

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -869,6 +869,9 @@ class BrowserViewController: UIViewController {
             guard let loading = change?[NSKeyValueChangeNewKey] as? Bool else { break }
             toolbar?.updateReloadStatus(loading)
             urlBar.updateReloadStatus(loading)
+            if (!loading) {
+                runScriptsOnWebView(webView)
+            }
         case KVOURL:
             if let tab = tabManager.selectedTab where tab.webView?.URL == nil {
                 log.debug("URL is nil!")
@@ -888,6 +891,10 @@ class BrowserViewController: UIViewController {
         }
     }
 
+    private func runScriptsOnWebView(webView: WKWebView) {
+        webView.evaluateJavaScript("__firefox__.favicons.getFavicons()", completionHandler:nil)
+    }
+    
     private func updateUIForReaderHomeStateForTab(tab: Browser) {
         updateURLBarDisplayURL(tab)
         scrollController.showToolbars(animated: false)


### PR DESCRIPTION
When tapping back quickly the favicon fails to update because the page is loaded from the WKWebView cache instead of rendered again. This causes the script responsible for fetching the favicons never to be run. Now instead wait till loading is finished and then run the script to fetch favicons.

Sidenote: this also fixes [Bug-1252888](https://bugzilla.mozilla.org/show_bug.cgi?id=1252888) but I'll update that with a separate PR.