### PR TITLE
Bug 1254561 - menu config

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -307,6 +307,10 @@
 		7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB20B6C1B71160200F1657F /* TopSitesTests.swift */; };
 		7BBFEE741BB405D900A305AA /* TabManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE731BB405D900A305AA /* TabManagerTests.swift */; };
 		7BBFEEA01BB409F300A305AA /* AboutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3E7DB51B27A7E900E2E84D /* AboutUtils.swift */; };
+		7BC7B4661C903A900046E9D2 /* MenuConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC7B4651C903A900046E9D2 /* MenuConfiguration.swift */; };
+		7BC7B4741C903B8F0046E9D2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC7B4731C903B8F0046E9D2 /* MenuItem.swift */; };
+		7BC7B48B1C9046A40046E9D2 /* MenuToolbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC7B48A1C9046A40046E9D2 /* MenuToolbarItem.swift */; };
+		7BC7B4BE1C904BF90046E9D2 /* MenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC7B4BD1C904BF90046E9D2 /* MenuTests.swift */; };
 		7BEB64441C7345600092C02E /* L10nSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3632D31C2983F000D12AF9 /* L10nSnapshotTests.swift */; };
 		7BEB64451C7345600092C02E /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B60B0071BDE3AE10090C984 /* SnapshotHelper.swift */; };
 		7BEB64511C7345990092C02E /* MarketingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B95CD191C3AB2EE00638E31 /* MarketingUITests.swift */; };
@@ -1259,6 +1263,10 @@
 		7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenPdfHelper.swift; sourceTree = "<group>"; };
 		7BB20B6C1B71160200F1657F /* TopSitesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopSitesTests.swift; sourceTree = "<group>"; };
 		7BBFEE731BB405D900A305AA /* TabManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManagerTests.swift; sourceTree = "<group>"; };
+		7BC7B4651C903A900046E9D2 /* MenuConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MenuConfiguration.swift; path = Menu/MenuConfiguration.swift; sourceTree = "<group>"; };
+		7BC7B4731C903B8F0046E9D2 /* MenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
+		7BC7B48A1C9046A40046E9D2 /* MenuToolbarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuToolbarItem.swift; sourceTree = "<group>"; };
+		7BC7B4BD1C904BF90046E9D2 /* MenuTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuTests.swift; sourceTree = "<group>"; };
 		7BEB644D1C7345600092C02E /* L10nSnapshotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = L10nSnapshotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BEB644E1C7345600092C02E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = L10nSnapshotTests/Info.plist; sourceTree = SOURCE_ROOT; };
 		7BEB645A1C7345990092C02E /* MarketingUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarketingUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2242,6 +2250,34 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7BC7B4571C903A6A0046E9D2 /* Menu */ = {
+			isa = PBXGroup;
+			children = (
+				7BC7B4711C903B690046E9D2 /* Items */,
+				7BC7B4721C903B690046E9D2 /* Toolbar */,
+				7BC7B4651C903A900046E9D2 /* MenuConfiguration.swift */,
+			);
+			name = Menu;
+			sourceTree = "<group>";
+		};
+		7BC7B4711C903B690046E9D2 /* Items */ = {
+			isa = PBXGroup;
+			children = (
+				7BC7B4731C903B8F0046E9D2 /* MenuItem.swift */,
+			);
+			name = Items;
+			path = Menu/Items;
+			sourceTree = "<group>";
+		};
+		7BC7B4721C903B690046E9D2 /* Toolbar */ = {
+			isa = PBXGroup;
+			children = (
+				7BC7B48A1C9046A40046E9D2 /* MenuToolbarItem.swift */,
+			);
+			name = Toolbar;
+			path = Menu/Toolbar;
+			sourceTree = "<group>";
+		};
 		7BD997001C68D9A4001CE131 /* SWTableViewCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -2767,6 +2803,7 @@
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
 				E60A60A01B6BFDDC00F850D4 /* CrashReporterTests.swift */,
 				D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */,
+				7BC7B4BD1C904BF90046E9D2 /* MenuTests.swift */,
 				281B2BE91ADF4D90002917DC /* MockProfile.swift */,
 				2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */,
 				0BA896491A250E6500C1010C /* ProfileTest.swift */,
@@ -2844,6 +2881,7 @@
 				F84B22211A09122500AAB793 /* Home */,
 				E49943F31AE6879C00BF9DE4 /* Intro */,
 				E63ED8DF1BFD254E0097D08E /* Login Management */,
+				7BC7B4571C903A6A0046E9D2 /* Menu */,
 				F84B21F51A0910F600AAB793 /* Reader */,
 				2F44FC551A9E83E200FD20CC /* Settings */,
 				D3972BF01C22412B00035B87 /* Share */,
@@ -4296,6 +4334,7 @@
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
 				0B7100481B4C72D60046AF87 /* FaviconFetcher.swift in Sources */,
 				E4252A0E1AF01AE40028C684 /* Swizzling.m in Sources */,
+				7BC7B4741C903B8F0046E9D2 /* MenuItem.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
 				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
@@ -4309,6 +4348,7 @@
 				E65AB12C1B7CDADF00C2B47A /* SessionRestoreHelper.swift in Sources */,
 				2F44FCC51A9E85E900FD20CC /* SettingsTableViewController.swift in Sources */,
 				E660BDD91BB06521009AC090 /* TabsButton.swift in Sources */,
+				7BC7B48B1C9046A40046E9D2 /* MenuToolbarItem.swift in Sources */,
 				2F44FCCB1A9E972E00FD20CC /* SearchEnginePicker.swift in Sources */,
 				2F834D1A1A80629A006A0B7B /* FxAContentViewController.swift in Sources */,
 				D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */,
@@ -4322,6 +4362,7 @@
 				D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */,
 				28EADE5D1AFC3A78007FB2FB /* UIImageViewExtensions.swift in Sources */,
 				D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */,
+				7BC7B4661C903A900046E9D2 /* MenuConfiguration.swift in Sources */,
 				2816F0001B33E05400522243 /* UIConstants.swift in Sources */,
 				7B59FC471C68E9B600F58EF5 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
 				D39949F51C22461A00E2A03C /* RequestDesktopSiteActivity.swift in Sources */,
@@ -4375,6 +4416,7 @@
 				2F697F7E1A9FD22D009E03AE /* SearchEnginesTests.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				7FB63CEF1C08D4910047F9A4 /* DynamicFontHelper.swift in Sources */,
+				7BC7B4BE1C904BF90046E9D2 /* MenuTests.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
 				7BBFEEA01BB409F300A305AA /* AboutUtils.swift in Sources */,

--- a/Client/Frontend/Menu/Items/MenuItem.swift
+++ b/Client/Frontend/Menu/Items/MenuItem.swift
@@ -6,7 +6,6 @@ import Foundation
 
 
 struct MenuItem {
-    let name: String
     let title: String
     private let iconName: String
     private let selectedIconName: String
@@ -19,8 +18,7 @@ struct MenuItem {
         return UIImage(named: selectedIconName)
     }
 
-    init(name: String, title: String, icon: String, selectedIcon: String) {
-        self.name = name
+    init(title: String, icon: String, selectedIcon: String) {
         self.title = title
         self.iconName = icon
         self.selectedIconName = selectedIcon

--- a/Client/Frontend/Menu/Items/MenuItem.swift
+++ b/Client/Frontend/Menu/Items/MenuItem.swift
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+
+struct MenuItem {
+    let name: String
+    let title: String
+    private let iconName: String
+    private let selectedIconName: String
+
+    var icon: UIImage? {
+        return UIImage(named: iconName)
+    }
+
+    var selectedIcon: UIImage? {
+        return UIImage(named: selectedIconName)
+    }
+
+    init(name: String, title: String, icon: String, selectedIcon: String) {
+        self.name = name
+        self.title = title
+        self.iconName = icon
+        self.selectedIconName = selectedIcon
+    }
+}

--- a/Client/Frontend/Menu/MenuConfiguration.swift
+++ b/Client/Frontend/Menu/MenuConfiguration.swift
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+enum MenuLocation {
+    case Browser
+    case HomePanels
+    case TabTray
+}
+
+struct MenuConfiguration {
+
+    let menuItems: [MenuItem]
+    let menuToolbarItems: [MenuToolbarItem]?
+    let location: MenuLocation
+
+    static func menuConfigurationForLocation(location: MenuLocation) -> MenuConfiguration {
+        return MenuConfiguration(location: location, menuItems: menuItemsForLocation(location), toolbarItems: menuToolbarItemsForLocation(location))
+    }
+
+    init(location: MenuLocation, menuItems: [MenuItem], toolbarItems: [MenuToolbarItem]?) {
+        self.location = location
+        self.menuItems = menuItems
+        self.menuToolbarItems = toolbarItems
+    }
+
+    // the items should be added to the array according to desired display order
+    private static func menuItemsForLocation(location: MenuLocation) -> [MenuItem] {
+        let menuItems: [MenuItem]
+        switch location {
+        case .Browser:
+            // TODO: filter out menu items that are not to be displayed given the current app state
+            // (i.e. whether the current browser URL is bookmarked or not)
+            menuItems = [FindInPageMenuItem, RequestDesktopMenuItem, RequestMobileMenuItem, SettingsMenuItem, NewTabMenuItem, NewPrivateTabMenuItem, AddBookmarkMenuItem, RemoveBookmarkMenuItem]
+        case .HomePanels:
+            menuItems = [NewTabMenuItem, NewPrivateTabMenuItem, SettingsMenuItem]
+        case .TabTray:
+            menuItems = [NewTabMenuItem, NewPrivateTabMenuItem, CloseAllTabsMenuItem, SettingsMenuItem]
+        }
+        return menuItems
+    }
+
+    // the items should be added to the array according to desired display order
+    private static func menuToolbarItemsForLocation(location: MenuLocation) -> [MenuToolbarItem]? {
+        let menuToolbarItems: [MenuToolbarItem]?
+        switch location {
+        case .Browser, .TabTray:
+            menuToolbarItems = [TopSitesMenuToolbarItem, BookmarksMenuToolbarItem, HistoryMenuToolbarItem, ReadingListMenuToolbarItem]
+        case .HomePanels:
+            menuToolbarItems = nil
+        }
+        return menuToolbarItems
+    }
+
+    private static var NewTabMenuItem: MenuItem {
+        return MenuItem(title: NewTabTitleString, icon: "add", selectedIcon: "add")
+    }
+
+    private static var NewPrivateTabMenuItem: MenuItem {
+        return MenuItem(title: NewPrivateTabTitleString, icon: "smallPrivateMask", selectedIcon: "smallPrivateMask")
+    }
+
+    private static var AddBookmarkMenuItem: MenuItem {
+        return MenuItem(title: AddBookmarkTitleString, icon: "bookmark", selectedIcon: "bookmarkHighlighted")
+    }
+
+    private static var RemoveBookmarkMenuItem: MenuItem {
+        return MenuItem(title: RemoveBookmarkTitleString, icon: "bookmark", selectedIcon: "bookmarkHighlighted")
+    }
+
+    private static var FindInPageMenuItem: MenuItem {
+        return MenuItem(title: FindInPageTitleString, icon: "shareFindInPage", selectedIcon: "shareFindInPage")
+    }
+
+    private static var RequestDesktopMenuItem: MenuItem {
+        return MenuItem(title: ViewDesktopSiteTitleString, icon: "shareRequestDesktopSite", selectedIcon: "shareRequestDesktopSite")
+    }
+
+    private static var RequestMobileMenuItem: MenuItem {
+        return MenuItem(title: ViewMobileSiteTitleString, icon: "shareRequestMobileSite", selectedIcon: "shareRequestMobileSite")
+    }
+
+    private static var SettingsMenuItem: MenuItem {
+        return MenuItem(title: SettingsTitleString, icon: "settings", selectedIcon: "settings")
+    }
+
+    private static var CloseAllTabsMenuItem: MenuItem {
+        return MenuItem(title: CloseAllTabsTitleString, icon: "find_close", selectedIcon: "find_close")
+    }
+
+    private static var TopSitesMenuToolbarItem: MenuToolbarItem {
+        return MenuToolbarItem(title: TopSitesTitleString, icon: "panelIconTopSites", selectedIcon: "panelIconTopSitesSelected")
+    }
+
+    private static var BookmarksMenuToolbarItem: MenuToolbarItem {
+        return MenuToolbarItem(title: BookmarksTitleString, icon: "panelIconBookmarks", selectedIcon: "panelIconBookmarksSelected")
+    }
+
+    private static var HistoryMenuToolbarItem: MenuToolbarItem {
+        return MenuToolbarItem(title: HistoryTitleString, icon: "panelIconHistory", selectedIcon: "panelIconHistorySelected")
+    }
+
+    private static var ReadingListMenuToolbarItem: MenuToolbarItem {
+        return  MenuToolbarItem(title: ReadingListTitleString, icon: "panelIconReadingList", selectedIcon: "panelIconReadingListSelected")
+    }
+
+    static let NewTabTitleString = NSLocalizedString("New Tab", tableName: "Menu", comment: "String describing the action of creating a new tab from the menu")
+    static let NewPrivateTabTitleString = NSLocalizedString("New Private Tab", tableName: "Menu", comment: "String describing the action of creating a new private tab from the menu")
+    static let AddBookmarkTitleString = NSLocalizedString("Add Bookmark", tableName: "Menu", comment: "String describing the action of adding the current site as a bookmark from the menu")
+    static let RemoveBookmarkTitleString = NSLocalizedString("Remove Bookmark", tableName: "Menu", comment: "String describing the action of remove the current site as a bookmark from the menu")
+    static let FindInPageTitleString = NSLocalizedString("Find In Page", tableName: "Menu", comment: "String describing the action of opening the toolbar that allows users to search for items within a webpage from the menu")
+    static let ViewDesktopSiteTitleString = NSLocalizedString("View Desktop Site", tableName: "Menu", comment: "String describing the action of switching a website from a mobile optimized view to a desktop view from the menu")
+    static let ViewMobileSiteTitleString = NSLocalizedString("View Mobile Site", tableName: "Menu", comment: "String describing the action of switching a website from a desktop view to a mobile optimized view from the menu")
+    static let SettingsTitleString = NSLocalizedString("Settings", tableName: "Menu", comment: "String describing the action of opening the settings menu from the menu")
+    static let CloseAllTabsTitleString = NSLocalizedString("Close All Tabs", tableName: "Menu", comment: "String describing the action of closing all tabs in the tab tray at once from the menu")
+    static let TopSitesTitleString = NSLocalizedString("Top Sites", tableName: "Menu", comment: "String describing the action of opening the Top Sites home panel from the menu")
+    static let BookmarksTitleString = NSLocalizedString("Bookmarks", tableName: "Menu", comment: "String describing the action of opening the bookmarks home panel from the menu")
+    static let HistoryTitleString = NSLocalizedString("History", tableName: "Menu", comment: "String describing the action of opening the history home panel from the menu")
+    static let ReadingListTitleString = NSLocalizedString("Reading List", tableName: "Menu", comment: "String describing the action of opening the reading list home panel from the menu")
+}

--- a/Client/Frontend/Menu/Toolbar/MenuToolbarItem.swift
+++ b/Client/Frontend/Menu/Toolbar/MenuToolbarItem.swift
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+struct MenuToolbarItem {
+
+    private let iconName: String
+    private let selectedIconName: String
+
+    let title: String
+
+    var icon: UIImage? {
+        return UIImage(named: iconName)
+    }
+
+    var selectedIcon: UIImage? {
+        return UIImage(named: selectedIconName)
+    }
+
+    init(title: String, icon: String, selectedIcon: String) {
+        self.title = title
+        self.iconName = icon
+        self.selectedIconName = selectedIcon
+    }
+}

--- a/ClientTests/MenuTests.swift
+++ b/ClientTests/MenuTests.swift
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+@testable import Client
+
+class MenuTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testMenuConfigurationForBrowser() {
+        let browserConfiguration = MenuConfiguration.menuConfigurationForLocation(.Browser)
+        XCTAssertEqual(browserConfiguration.menuItems.count, 8)
+        XCTAssertEqual(browserConfiguration.menuItems[0].title, MenuConfiguration.FindInPageTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[1].title, MenuConfiguration.ViewDesktopSiteTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[2].title, MenuConfiguration.ViewMobileSiteTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[3].title, MenuConfiguration.SettingsTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[4].title, MenuConfiguration.NewTabTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[5].title, MenuConfiguration.NewPrivateTabTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[6].title, MenuConfiguration.AddBookmarkTitleString)
+        XCTAssertEqual(browserConfiguration.menuItems[7].title, MenuConfiguration.RemoveBookmarkTitleString)
+
+
+        XCTAssertNotNil(browserConfiguration.menuToolbarItems)
+        XCTAssertEqual(browserConfiguration.menuToolbarItems!.count, 4)
+        XCTAssertEqual(browserConfiguration.menuToolbarItems![0].title, MenuConfiguration.TopSitesTitleString)
+        XCTAssertEqual(browserConfiguration.menuToolbarItems![1].title, MenuConfiguration.BookmarksTitleString)
+        XCTAssertEqual(browserConfiguration.menuToolbarItems![2].title, MenuConfiguration.HistoryTitleString)
+        XCTAssertEqual(browserConfiguration.menuToolbarItems![3].title, MenuConfiguration.ReadingListTitleString)
+    }
+
+    func testMenuConfigurationForHomePanels() {
+        let homePanelConfiguration = MenuConfiguration.menuConfigurationForLocation(.HomePanels)
+        XCTAssertEqual(homePanelConfiguration.menuItems.count, 3)
+        XCTAssertEqual(homePanelConfiguration.menuItems[0].title, MenuConfiguration.NewTabTitleString)
+        XCTAssertEqual(homePanelConfiguration.menuItems[1].title, MenuConfiguration.NewPrivateTabTitleString)
+        XCTAssertEqual(homePanelConfiguration.menuItems[2].title, MenuConfiguration.SettingsTitleString)
+
+        XCTAssertNil(homePanelConfiguration.menuToolbarItems)
+    }
+
+    func testMenuConfigurationForTabTray() {
+        let tabTrayConfiguration = MenuConfiguration.menuConfigurationForLocation(.TabTray)
+        XCTAssertEqual(tabTrayConfiguration.menuItems.count, 4)
+        XCTAssertEqual(tabTrayConfiguration.menuItems[0].title, MenuConfiguration.NewTabTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuItems[1].title, MenuConfiguration.NewPrivateTabTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuItems[2].title, MenuConfiguration.CloseAllTabsTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuItems[3].title, MenuConfiguration.SettingsTitleString)
+
+        XCTAssertNotNil(tabTrayConfiguration.menuToolbarItems)
+        XCTAssertEqual(tabTrayConfiguration.menuToolbarItems!.count, 4)
+        XCTAssertEqual(tabTrayConfiguration.menuToolbarItems![0].title, MenuConfiguration.TopSitesTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuToolbarItems![1].title, MenuConfiguration.BookmarksTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuToolbarItems![2].title, MenuConfiguration.HistoryTitleString)
+        XCTAssertEqual(tabTrayConfiguration.menuToolbarItems![3].title, MenuConfiguration.ReadingListTitleString)
+    }
+
+}


### PR DESCRIPTION
This is the first, most basic implementation of the menu configuration. This provides 2 static functions for retrieving ordered menu items based upon the current location of the menu. For both toolbar items and menu items, the current location (passed in in the form of an enum) is used to determine which statically defined menu items should appear in which locations.

The menu items and toolbar items themselves are also defined at their most basic. The are currently using existing images for icon images as we don't have the real images yet. This will be fleshed out in later commits to contain links to Actions and Animations that the items will perform when tapped or long pressed.