### PR TITLE
Bug 1249828 Correct title for synced tabs

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -133,10 +133,6 @@ class Browser: NSObject, BrowserWebViewDelegate {
 
             self.webView = webView
             browserDelegate?.browser?(self, didCreateWebView: webView)
-
-            // lastTitle is used only when showing zombie tabs after a session restore.
-            // Since we now have a web view, lastTitle is no longer useful.
-            lastTitle = nil
         }
     }
 
@@ -208,7 +204,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
                 return title
             }
         }
-        return displayURL?.absoluteString ?? lastTitle ?? ""
+        return lastTitle ?? displayURL?.absoluteString ?? ""
     }
 
     var currentInitialURL: NSURL? {

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -80,7 +80,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
     }
 
     class func toTab(browser: Browser) -> RemoteTab? {
-        if let displayURL = browser.displayURL where !isIgnoredURL(displayURL) {
+        if let displayURL = browser.displayURL where RemoteTab.shouldIncludeURL(displayURL) {
             let history = Array(browser.historyList.filter(RemoteTab.shouldIncludeURL).reverse())
             return RemoteTab(clientGUID: nil,
                 URL: displayURL,
@@ -90,7 +90,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
                 icon: nil)
         } else if let sessionData = browser.sessionData where !sessionData.urls.isEmpty {
             let history = Array(sessionData.urls.reverse())
-            if let displayURL = history.first where !isIgnoredURL(displayURL) {
+            if let displayURL = history.first where RemoteTab.shouldIncludeURL(displayURL) {
                 return RemoteTab(clientGUID: nil,
                     URL: displayURL,
                     title: browser.displayTitle,
@@ -208,7 +208,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
         }
 
         guard let lastTitle = lastTitle where !lastTitle.isEmpty else {
-            return  displayURL?.absoluteString ??  ""
+            return displayURL?.absoluteString ??  ""
         }
 
         return lastTitle

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -89,8 +89,8 @@ class Browser: NSObject, BrowserWebViewDelegate {
                 lastUsed: NSDate.now(),
                 icon: nil)
         } else if let sessionData = browser.sessionData where !sessionData.urls.isEmpty {
-            let history = Array(sessionData.urls.reverse())
-            if let displayURL = history.first where RemoteTab.shouldIncludeURL(displayURL) {
+            let history = Array(sessionData.urls.filter(RemoteTab.shouldIncludeURL).reverse())
+            if let displayURL = history.first {
                 return RemoteTab(clientGUID: nil,
                     URL: displayURL,
                     title: browser.displayTitle,


### PR DESCRIPTION
There are 2 issues in this bug.

1) Tabs are being synced with the URL as the title.

The cause of this is that when we restore tabs, as soon as the webview is created we delete the lastTitle value. However, if we subsequently don't load a URL for that restored tab, then the lastTitle is nil. In the case that the tab we are saving for sync doesn't have a title (i.e, has never been loaded in this browsing session) then when we come to save, we prioritize the URL over the lastTab, which in any case is empty.

To resolve this, I have ensured that we don't nullify the lastTitle variable when creating a webView and prioritized lastTitle over the URL in the case of the webView having no title.

2) Tabs are being synced with localhost URLs

The cause of why we are attempting to store localhost URLs is uncertain - I have been unable to replicate this case. To cover our back though, I have added some code here that fails to create a `RemoteTab` instance on sync tab save if the main URL is in the ignore list.