### PR TITLE
Bug 1255098 - Pressing close button on a tab too quickly causes the Browser to enter a hung state

### DIFF
--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -23,7 +23,7 @@ private let DefaultParameters =
         recenterAnimationDuration: 0.15)
 
 protocol SwipeAnimatorDelegate: class {
-    func swipeAnimator(animator: SwipeAnimator, viewDidExitContainerBounds: UIView)
+    func swipeAnimator(animator: SwipeAnimator, viewWillExitContainerBounds: UIView)
 }
 
 class SwipeAnimator: NSObject {
@@ -64,13 +64,13 @@ extension SwipeAnimator {
         // Calculate the edge to calculate distance from
         let translation = velocity.x >= 0 ? CGRectGetWidth(container.frame) : -CGRectGetWidth(container.frame)
         let timeStep = NSTimeInterval(abs(translation) / speed)
+        self.delegate?.swipeAnimator(self, viewWillExitContainerBounds: self.animatingView)
         UIView.animateWithDuration(timeStep, animations: {
             self.animatingView.transform = self.transformForTranslation(translation)
             self.animatingView.alpha = self.alphaForDistanceFromCenter(abs(translation))
         }, completion: { finished in
             if finished {
                 self.animatingView.alpha = 0
-                self.delegate?.swipeAnimator(self, viewDidExitContainerBounds: self.animatingView)
             }
         })
     }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -678,7 +678,7 @@ extension TabTrayController: UIScrollViewAccessibilityDelegate {
 }
 
 extension TabTrayController: SwipeAnimatorDelegate {
-    func swipeAnimator(animator: SwipeAnimator, viewDidExitContainerBounds: UIView) {
+    func swipeAnimator(animator: SwipeAnimator, viewWillExitContainerBounds: UIView) {
         let tabCell = animator.container as! TabCell
         if let indexPath = collectionView.indexPathForCell(tabCell) {
             let tab = tabsToDisplay[indexPath.item]


### PR DESCRIPTION
The issue is fixed by allowing the deletion of the cell to happen before the animation starts.

This might have some adverse affects that I might not understand yet so please make sure I'm not breaking anything else.