### PR TITLE
Bug 1254566 - Implemented dynamic height cells for settings screens along with custom subtitle/switch cell subclass

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		E60222E31C6E57B20061C436 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9A62DB1C4002B1005C83DC /* SQLite.framework */; };
 		E60A60821B6BFC0B00F850D4 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A60811B6BFC0B00F850D4 /* CrashReporter.swift */; };
 		E60A60A11B6BFDDC00F850D4 /* CrashReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A60A01B6BFDDC00F850D4 /* CrashReporterTests.swift */; };
+		E60A7E001C989C9A0029B65F /* BoolSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A7DFF1C989C9A0029B65F /* BoolSettingTableViewCell.swift */; };
 		E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */; };
 		E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */; };
 		E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C001B90A44F005ABB0D /* libz.tbd */; };
@@ -1430,6 +1431,7 @@
 		E60961891B62B8C800DD640F /* Firefox.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Firefox.xcconfig; path = Configuration/Firefox.xcconfig; sourceTree = "<group>"; };
 		E60A60811B6BFC0B00F850D4 /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		E60A60A01B6BFDDC00F850D4 /* CrashReporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporterTests.swift; sourceTree = "<group>"; };
+		E60A7DFF1C989C9A0029B65F /* BoolSettingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BoolSettingTableViewCell.swift; sourceTree = "<group>"; };
 		E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePasscodeViewController.swift; sourceTree = "<group>"; };
 		E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RollingFileLoggerTests.swift; sourceTree = "<group>"; };
 		E6231C001B90A44F005ABB0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -2001,6 +2003,7 @@
 				E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */,
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
 				2F44FCC41A9E85E900FD20CC /* SettingsTableViewController.swift */,
+				E60A7DFF1C989C9A0029B65F /* BoolSettingTableViewCell.swift */,
 				E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */,
 				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
 				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
@@ -4308,6 +4311,7 @@
 				7BA0601B1C0F4DE200DFADB6 /* TabPeekViewController.swift in Sources */,
 				D3994A4A1C22813200E2A03C /* FindInPageActivity.swift in Sources */,
 				7B9A61CD1C3EBFAE005C83DC /* RXMLElement.m in Sources */,
+				E60A7E001C989C9A0029B65F /* BoolSettingTableViewCell.swift in Sources */,
 				E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */,
 				E63ED7D81BFCD9990097D08E /* LoginTableViewCell.swift in Sources */,
 				F84B22241A09122500AAB793 /* HomePanelViewController.swift in Sources */,

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -140,18 +140,6 @@ class AppSettingsTableViewController: SettingsTableViewController {
         return settings
     }
 
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        // Make account/sign-in and close private tabs rows taller, as per design specs.
-        let section = settings[indexPath.section]
-        if let setting = section[indexPath.row] as? BoolSetting where setting.prefKey == "settings.closePrivateTabs" || setting.prefKey == AllowThirdPartyKeyboardsKey {
-            return 64
-        } else if section[indexPath.row] is ConnectSetting {
-            return 64
-        }
-
-        return super.tableView(tableView, heightForRowAtIndexPath: indexPath)
-    }
-
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if !profile.hasAccount() {
             let headerView = tableView.dequeueReusableHeaderFooterViewWithIdentifier(SectionHeaderIdentifier) as! SettingsTableSectionHeaderFooterView

--- a/Client/Frontend/Settings/BoolSettingTableViewCell.swift
+++ b/Client/Frontend/Settings/BoolSettingTableViewCell.swift
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import SnapKit
+
+/// A cell subclass that implements a dynamic height title and subtitle label with
+/// a switch control centered on the right side. Unfortunately the default
+/// cell subtitle style doesn't support dynamic height calculations for a sublabel.
+class BoolSettingTableViewCell: UITableViewCell {
+    private lazy var _textLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
+        return label
+    }()
+
+    private lazy var _detailTextLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFontForTextStyle(UIFontTextStyleCaption1)
+        return label
+    }()
+
+    lazy var switchControl: UISwitch = {
+        let control = UISwitch()
+        control.onTintColor = UIConstants.ControlTintColor
+        return control
+    }()
+
+    private lazy var labelContainer = UIView()
+
+    override var textLabel: UILabel {
+        return _textLabel
+    }
+
+    override var detailTextLabel: UILabel {
+        return _detailTextLabel
+    }
+
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        labelContainer.addSubview(_textLabel)
+        labelContainer.addSubview(_detailTextLabel)
+        contentView.addSubview(labelContainer)
+        contentView.addSubview(switchControl)
+
+        // These values may seem random but were chosen to map closely to the default padding/margins 
+        // of the subtitle cell style.
+        _textLabel.snp_makeConstraints { make in
+            make.left.right.equalTo(labelContainer).inset(16)
+            make.top.equalTo(labelContainer).inset(8)
+        }
+
+        _detailTextLabel.snp_makeConstraints { make in
+            make.top.equalTo(_textLabel.snp_bottom).offset(4)
+            make.bottom.equalTo(labelContainer).inset(8)
+            make.left.right.equalTo(_textLabel)
+        }
+
+        labelContainer.snp_makeConstraints { make in
+            make.left.top.bottom.equalTo(contentView)
+            make.right.equalTo(switchControl.snp_left).inset(16)
+        }
+
+        switchControl.snp_makeConstraints { make in
+            make.centerY.equalTo(contentView)
+            make.right.equalTo(contentView).inset(16)
+        }
+
+        // Make sure the switch part of the cell never gets squeezed.
+        switchControl.setContentCompressionResistancePriority(UILayoutPriorityRequired, forAxis: UILayoutConstraintAxis.Horizontal)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
To accommodate the dynamic height of the labels, I followed this guide [1] and removed our `heightForCellAtIndexPath` call to allow autolayout to calculate the heights needed. This works great for the basic cells with a single title but the cells with a subtitle underneath the title don't properly factor in the subtitle text in the autolayout calculation. My guess is that internally autolayout isn't used for the labels of default cells which this SO post also mentions [2]. I ended up creating a subclass that properly setups up the label and switch control using autolayout so the height can be properly calculated. See the following screenshots taken with the double pseudolanguage flag on/.

[1] https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/AutolayoutPG/WorkingwithSelf-SizingTableViewCells.html

[2] http://stackoverflow.com/questions/32387200/automatic-cell-height-without-custom-cell

![simulator screen shot mar 16 2016 9 50 50 am](https://cloud.githubusercontent.com/assets/434322/13814675/9c054296-eb5d-11e5-82b7-c7a9220926aa.png)
![simulator screen shot mar 16 2016 9 50 54 am](https://cloud.githubusercontent.com/assets/434322/13814680/9ebdcf08-eb5d-11e5-9c8d-9920c048baf5.png)
