### PR TITLE
Bug 12509147 – Mitigate OnePassword crash.

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -122,6 +122,10 @@ private extension ShareExtensionHelper {
             return
         }
 
+        if selectedWebView.URL?.absoluteString == nil {
+            return
+        }
+
         // Add 1Password to share sheet
         OnePasswordExtension.sharedExtension().createExtensionItemForWebView(selectedWebView, completion: {(extensionItem, error) -> Void in
             if extensionItem == nil {


### PR DESCRIPTION
This is not expected to _fix_ the problem in one-password-extension, though will make it better. It will not make things worse.

The expected best case fix is for AgileBits to add a nil check in at https://github.com/AgileBits/onepassword-app-extension/blob/master/OnePasswordExtension.m#L271