### PR TITLE
Bug 1240041 - Fix Top Sites concurrency issues

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -121,10 +121,6 @@ class TopSitesPanel: UIViewController {
         if let data = result.successValue {
             self.dataSource.setHistorySites(data.asArray())
             self.dataSource.profile = self.profile
-
-            // redraw now we've updated our sources
-            self.collection?.collectionViewLayout.invalidateLayout()
-            self.collection?.setNeedsLayout()
         }
     }
 
@@ -154,7 +150,8 @@ class TopSitesPanel: UIViewController {
             // Update the UICollectionView.
             self.deleteOrUpdateSites(indexPath) >>> {
                 // Finally, requery to pull in the latest sites.
-                self.reloadTopSitesWithLimit(self.maxFrecencyLimit).uponQueue(dispatch_get_main_queue()) { _ in
+                self.profile.history.getTopSitesWithLimit(self.maxFrecencyLimit).uponQueue(dispatch_get_main_queue()) { result in
+                    self.updateDataSourceWithSites(result)
                     self.collection?.userInteractionEnabled = true
                 }
             }

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -172,6 +172,12 @@ class TopSitesPanel: UIViewController {
     }
 
     private func refreshTopSites(frecencyLimit: Int) {
+        // Don't allow Sync or other notifications to change the data source if we're deleting a thumbnail.
+        // If we are, we'll refresh at the end, so we can drop this one.
+        if !(self.collection?.userInteractionEnabled ?? true) {
+            return
+        }
+
         // Reload right away with whatever is in the cache, then check to see if the cache is invalid. If it's invalid,
         // invalidate the cache and requery. This allows us to always show results right away if they are cached but
         // also load in the up-to-date results asynchronously if needed

--- a/UITests/TopSitesTests.swift
+++ b/UITests/TopSitesTests.swift
@@ -89,29 +89,57 @@ class TopSitesTests: KIFTestCase {
     }
 
     func testRemovingSite() {
-        // Load a page
-        tester().tapViewWithAccessibilityIdentifier("url")
-        let url1 = "\(webRoot)/numberedPage.html?page=1"
-        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(url1)\n")
-        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+        // Switch to the Bookmarks panel so we can later reload Top Sites.
+        tester().tapViewWithAccessibilityLabel("Bookmarks")
 
-        // Open top sites
-        tester().tapViewWithAccessibilityIdentifier("url")
+        // Load a set of dummy domains.
+        for i in 1...10 {
+            BrowserUtils.addHistoryEntry("", url: NSURL(string: "https://test\(i).com")!)
+        }
+
+        // Switch back to the Top Sites panel.
         tester().tapViewWithAccessibilityLabel("Top sites")
 
-        // Verify the row exists and that the Remove Page button is hidden
-        let row = tester().waitForViewWithAccessibilityLabel("127.0.0.1")
+        // Remove the first site and verify that all other sites shift to replace it.
+        let collection = tester().waitForViewWithAccessibilityIdentifier("Top Sites View") as! UICollectionView
+
+        // Ensure that the last sites added are the first in the view. We don't know exactly
+        // how many thumbnails are visible since that's device-specific, but we can check a few.
+        verifyTopSites(collection, range: 5...10)
+
+        // Get the first cell (test10.com).
+        let cell = collection.visibleCells().first!
+
+        // Each thumbnail will have a remove button with the "Remove site" accessibility label, so
+        // we can't uniquely identify which remove button we want. Instead, just verify that "Remove site"
+        // labels are visible, and click the thumbnail at the top left (where the remove button is).
+        cell.longPressAtPoint(CGPointZero, duration: 1)
+        tester().waitForViewWithAccessibilityLabel("Remove page")
+        cell.tapAtPoint(CGPointZero)
+
+        // test9.com should now be first, followed by test8.com, etc.
+        verifyTopSites(collection, range: 4...9)
+
+        // Simulate loading a page in the background.
+        BrowserUtils.addHistoryEntry("", url: NSURL(string: "https://test99.com")!)
+
+        // Close editing mode.
+        tester().tapViewWithAccessibilityLabel("Done")
         tester().waitForAbsenceOfViewWithAccessibilityLabel("Remove page")
 
-        // Long press the row and click the remove button
-        row.longPressAtPoint(CGPointZero, duration: 1)
-        tester().tapViewWithAccessibilityLabel("Remove page")
+        // Remove our dummy sites.
+        // TODO: This is painfully slow...let's find a better way to reset (bug 1191476).
+        BrowserUtils.clearHistoryItems(tester())
+    }
 
-        // Close editing mode
-        tester().tapViewWithAccessibilityLabel("Done")
-
-        // Close top sites
-        tester().tapViewWithAccessibilityLabel("Cancel")
+    private func verifyTopSites(collection: UICollectionView, range: Range<Int>) {
+        var item = 0
+        for i in range.reverse() {
+            let expected = tester().waitForViewWithAccessibilityLabel("test\(i).com") as! UICollectionViewCell
+            let cell = collection.cellForItemAtIndexPath(NSIndexPath(forItem: item, inSection: 0))
+            XCTAssertEqual(cell, expected)
+            item++
+        }
     }
 
     func testRotationAndDeleteShowsCorrectTile() {


### PR DESCRIPTION
As mentioned this morning, the issue here is that sync triggers while we're acting on a stale UI, causing the UI to be out-of-sync with the data source count. There are two places this can affect us:
 1. A sync complete notification triggers while we're in the middle of a deletion. This calls `refreshTopSites`, which can results in inconsistency between the stale post-deletion data and the newly updated sync data.
 2. A partial sync happens while we're in the middle of a deletion. There's not necessarily a notification, but because we do a requery after deleting the site, we could inadvertently pull in Sync additions (or deletions!), or new pages that have since loaded in the background.

To address the first case, I proposed we simply drop sync notifications while the view is visible; @rnewman suggested postponing Sync (and other) refreshes until we're done editing. I went with the latter here since that's closer to our current behavior, and we can discuss how we want to handle Sync (and location change) updates in [bug 1257592](https://bugzilla.mozilla.org/show_bug.cgi?id=1257592).

The fix to the second case is to simply act on the existing data source instead of pulling it in after a deletion, which can cause bad things to happen. Right now, for sync additions, we hit [bug 1257291](https://bugzilla.mozilla.org/show_bug.cgi?id=1257291); for sync deletions, we'll crash.