### PR TITLE
Bug 1255571 — Disable bookmark merge telemetry upload for release.

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -614,6 +614,11 @@ public class BrowserProfile: Profile {
         }
 
         func onBookmarkBufferValidated(notification: NSNotification) {
+            // We don't send this ad hoc telemetry on the release channel.
+            guard AppConstants.BuildChannel != AppBuildChannel.Release else {
+                return
+            }
+
             guard profile.prefs.boolForKey("settings.sendUsageData") ?? true else {
                 log.debug("Profile isn't sending usage data. Not sending bookmark event.")
                 return

--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -119,13 +119,18 @@ public class BufferingBookmarksSynchronizer: TimestampedSingleCollectionSynchron
 
         let run: SyncResult
         if !AppConstants.shouldMergeBookmarks {
-            run = doMirror >>== effect({ result in
-                // Just validate to report statistics.
-                if case .Completed = result {
-                    log.debug("Validating completed buffer download.")
-                    buffer.validate()
-                }
-            })
+            if case .Release = AppConstants.BuildChannel {
+                // On release, just mirror; don't validate.
+                run = doMirror
+            } else {
+                run = doMirror >>== effect({ result in
+                    // Just validate to report statistics.
+                    if case .Completed = result {
+                        log.debug("Validating completed buffer download.")
+                        buffer.validate()
+                    }
+                })
+            }
         } else {
             run = doMirror >>== { result in
                 // Only bother trying to sync if the mirror operation wasn't interrupted or partial.


### PR DESCRIPTION
I haven't tested this, but it's pretty trivial.