### PR TITLE
Bug 1257831 Snapshot tests fail on loading web pages

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -335,6 +335,7 @@ class TabTrayController: UIViewController {
         addTabButton.setImage(UIImage(named: "add"), forState: .Normal)
         addTabButton.addTarget(self, action: "SELdidClickAddTab", forControlEvents: .TouchUpInside)
         addTabButton.accessibilityLabel = NSLocalizedString("Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
+        addTabButton.accessibilityIdentifier = "TabTrayController.addTabButton"
 
         settingsButton = UIButton()
         settingsButton.setImage(UIImage(named: "settings"), forState: .Normal)


### PR DESCRIPTION
This patch moves away from using the progress bar to find out of a page has loaded and instead waits for a specific element to appear. The element has to have an `aria-label` attached.

For example, this is what one of our test pages now looks like:

```
<html>
<head>
<meta name="viewport" content="width=device-width">
</head>
<body aria-label="body">
<a href="http://www.mozilla.org" aria-label="link"><img src="image.png"></a>
</body>
</html>
```

We load it with:

```
loadWebPage("http://people.mozilla.org/~sarentz/fxios/testpages/link.html",
    waitForOtherElementWithAriaLabel: "body")
```

And you can reference the link with:

```
app.webViews.elementBoundByIndex(0).links["link"].pressForDuration(2.0)
```

(Future work, move the test pages into our repo too)
