### PR TITLE
Bug 1258156 — Include date and client count in upload telemetry.

### DIFF
--- a/Telemetry/TelemetryPing.swift
+++ b/Telemetry/TelemetryPing.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-public func makeAdHocBookmarkMergePing(bundle: NSBundle, clientID: String, attempt: Int32, bufferRows: Int?, valid: [String: Bool]) -> JSON {
+public func makeAdHocBookmarkMergePing(bundle: NSBundle, clientID: String, attempt: Int32, bufferRows: Int?, valid: [String: Bool], clientCount: Int) -> JSON {
     let anyFailed = valid.reduce(false, combine: { $0 || $1.1 })
 
     var out: [String: AnyObject] = [
@@ -12,6 +12,8 @@ public func makeAdHocBookmarkMergePing(bundle: NSBundle, clientID: String, attem
         "id": clientID,
         "attempt": Int(attempt),
         "success": !anyFailed,
+        "date": NSDate().descriptionWithLocale(nil),
+        "clientCount": clientCount,
     ]
 
     if let bufferRows = bufferRows {


### PR DESCRIPTION
Payload now looks like this:

```
{"rows":1731,"build":"","id":"EB6D82C7-B5A6-45CF-825E-CCC1F50BE8E3","date":"2016-03-20 01:06:32 +0000","success":true,"v":1,"appV":"4.0.0","attempt":155,"clientCount":4}
```