### PR TITLE
Bug 1252888 - Fix reader mode Unavailable message string

### DIFF
--- a/Client/Frontend/Reader/ReaderMode.js
+++ b/Client/Frontend/Reader/ReaderMode.js
@@ -55,8 +55,8 @@ var _firefox_ReaderMode = {
             return;
         }
 
-        this.debug({Type: "ReaderModeStateChange", Value: "StatusUnavailable"});
-        webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderModeStateChange", Value: "StatusUnavailable"});
+        this.debug({Type: "ReaderModeStateChange", Value: "Unavailable"});
+        webkit.messageHandlers.readerModeMessageHandler.postMessage({Type: "ReaderModeStateChange", Value: "Unavailable"});
     },
 
     // Readerize the document. Since we did the actual readerization already in checkReadability, we


### PR DESCRIPTION
Silly error -- we're sending "StatusUnavailable" as the string, but the enum uses "Unavailable". Since it doesn't match, we fall back to "Invalid", which is a no-op. That causes the page to be stuck in "Available".