### PR TITLE
Bug 1258810 - Remove Base32 Dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,4 @@
 github "Alamofire/Alamofire"      	"2.0.2"
-github "mozilla/Base32"             "swift-2.0"        # So we don't have to tag a release for Emily's fixes.
 github "mozilla/Deferred"           "2.0.1"           # Making Deferred extensible in swift 2.0
 github "swisspol/GCDWebServer"		"3.3.2"			     
 github "kif-framework/KIF"          "v3.3.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "Alamofire/Alamofire" "2.0.2"
-github "mozilla/Base32" "d2136486487a77336ae18b1bd2f9a3f689ec44e5"
 github "mozilla/Deferred" "2.0.1"
 github "swisspol/GCDWebServer" "3.3.2"
 github "kif-framework/KIF" "v3.3.2"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -270,9 +270,6 @@
 		7B604F8A1C4949C1006EEEC3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F851C494983006EEEC3 /* Alamofire.framework */; };
 		7B604F901C494B0F006EEEC3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F851C494983006EEEC3 /* Alamofire.framework */; };
 		7B604F911C494B3C006EEEC3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F851C494983006EEEC3 /* Alamofire.framework */; };
-		7B604F931C494C3A006EEEC3 /* Base32.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F921C494C3A006EEEC3 /* Base32.framework */; };
-		7B604F941C494C47006EEEC3 /* Base32.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F921C494C3A006EEEC3 /* Base32.framework */; };
-		7B604F951C494D13006EEEC3 /* Base32.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F921C494C3A006EEEC3 /* Base32.framework */; };
 		7B604F971C494E2A006EEEC3 /* Breakpad.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F961C494E2A006EEEC3 /* Breakpad.framework */; };
 		7B604F991C494F74006EEEC3 /* KIF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F981C494F74006EEEC3 /* KIF.framework */; };
 		7B604F9B1C4950F2006EEEC3 /* WebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604F9A1C4950F2006EEEC3 /* WebImage.framework */; };
@@ -470,6 +467,7 @@
 		E4D567A51ADECEB800F1EFE7 /* ReadingListStorageTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D5679B1ADECEB800F1EFE7 /* ReadingListStorageTestCase.swift */; };
 		E4D6BEB91A0930EC00F538BD /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4D6BEB81A0930EC00F538BD /* LaunchScreen.xib */; };
 		E4D8F3B01ACDD5150005A2E4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E4D8F3B21ACDD5150005A2E4 /* InfoPlist.strings */; };
+		E4E25CCB1CA99E7400D0F088 /* HexExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E25CCA1CA99E7400D0F088 /* HexExtensionsTests.swift */; };
 		E4E7EB6B1C4A86430094275D /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E7EB451C4A85D80094275D /* SupportUtils.swift */; };
 		E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */; };
 		E4ECCD8D1AB091470005E717 /* Reader.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4ECCD8C1AB091470005E717 /* Reader.xcassets */; };
@@ -1422,6 +1420,7 @@
 		E4D8F3B11ACDD5150005A2E4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E4E0BB151AFBC9E4008D6260 /* Shared-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Shared-Bridging-Header.h"; sourceTree = "<group>"; };
 		E4E0BB171AFBC9E4008D6260 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E4E25CCA1CA99E7400D0F088 /* HexExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HexExtensionsTests.swift; sourceTree = "<group>"; };
 		E4E7EB451C4A85D80094275D /* SupportUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtils.swift; sourceTree = "<group>"; };
 		E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtilsTests.swift; sourceTree = "<group>"; };
 		E4ECCD8C1AB091470005E717 /* Reader.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Reader.xcassets; sourceTree = "<group>"; };
@@ -1566,7 +1565,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B604F881C4949A4006EEEC3 /* Alamofire.framework in Frameworks */,
-				7B604F941C494C47006EEEC3 /* Base32.framework in Frameworks */,
 				7BA4A9641C4CFE840091D032 /* Deferred.framework in Frameworks */,
 				7BA4A94C1C4CF03B0091D032 /* SwiftKeychainWrapper.framework in Frameworks */,
 				7B604FBC1C495E1E006EEEC3 /* XCGLogger.framework in Frameworks */,
@@ -1578,7 +1576,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B604F861C494983006EEEC3 /* Alamofire.framework in Frameworks */,
-				7B604F931C494C3A006EEEC3 /* Base32.framework in Frameworks */,
 				7B604F971C494E2A006EEEC3 /* Breakpad.framework in Frameworks */,
 				7B604F9B1C4950F2006EEEC3 /* WebImage.framework in Frameworks */,
 				7B604FB71C495782006EEEC3 /* SWXMLHash.framework in Frameworks */,
@@ -1718,7 +1715,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B604F951C494D13006EEEC3 /* Base32.framework in Frameworks */,
 				E6231C081B90A71E005ABB0D /* libz.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2682,6 +2678,7 @@
 			children = (
 				28786E541AB0F5FA009EA9EF /* DeferredTests.swift */,
 				E695D8671C03804F00D3FCCE /* FSUtilsTests.swift */,
+				E4E25CCA1CA99E7400D0F088 /* HexExtensionsTests.swift */,
 				E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */,
 				E6F965411B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift */,
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
@@ -3853,7 +3850,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Base32.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Breakpad.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/WebImage.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SnapKit.framework",
@@ -4228,6 +4224,7 @@
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,
 				E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */,
 				E4E7EB6D1C4AED5E0094275D /* SupportUtilsTests.swift in Sources */,
+				E4E25CCB1CA99E7400D0F088 /* HexExtensionsTests.swift in Sources */,
 				E6F965421B2F25110034B023 /* NSMutableAttributedStringExtensionsTests.swift in Sources */,
 				E695D8681C03804F00D3FCCE /* FSUtilsTests.swift in Sources */,
 				28532BE91C471FFB000072D9 /* ResultTests.swift in Sources */,

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Account
-import Base32
 import Shared
 import UIKit
 import XCGLogger

--- a/ClientTests/TestHashExtensions.swift
+++ b/ClientTests/TestHashExtensions.swift
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Base32
 import Foundation
 import XCTest
 

--- a/SharedTests/HexExtensionsTests.swift
+++ b/SharedTests/HexExtensionsTests.swift
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import XCTest
+
+class HexExtensionsTests: XCTestCase {
+    func testHexEncodedString() {
+        XCTAssertEqual("Hello, world!".dataUsingEncoding(NSUTF8StringEncoding)!.hexEncodedString, "48656c6c6f2c20776f726c6421")
+        XCTAssertEqual("Hello, world!!".dataUsingEncoding(NSUTF8StringEncoding)!.hexEncodedString, "48656c6c6f2c20776f726c642121")
+    }
+
+    func testHexDecodedData() {
+        XCTAssertEqual("48656c6c6f2c20776f726c6421".hexDecodedData, "Hello, world!".dataUsingEncoding(NSUTF8StringEncoding))
+        XCTAssertEqual("48656c6c6f2c20776f726c642121".hexDecodedData, "Hello, world!!".dataUsingEncoding(NSUTF8StringEncoding))
+    }
+
+    func testHexDecodedDataWithInvalidInput() {
+        XCTAssertEqual("".hexDecodedData, NSData())
+        XCTAssertEqual("cheese".hexDecodedData, NSData())
+        XCTAssertEqual("a".hexDecodedData, NSData())
+    }
+}

--- a/Utils/Extensions/HexExtensions.swift
+++ b/Utils/Extensions/HexExtensions.swift
@@ -2,18 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Base32
 import Foundation
 
 extension String {
     public var hexDecodedData: NSData {
-        return base16DecodeToData(self)!
+        // Convert to a CString and make sure it has an even number of characters (terminating 0 is included, so we
+        // check for uneven!)
+        guard let cString = self.cStringUsingEncoding(NSASCIIStringEncoding) where (cString.count % 2) == 1 else {
+            return NSData()
+        }
+        guard let result = NSMutableData(capacity: (cString.count - 1) / 2) else {
+            return NSData()
+        }
+        for i in 0.stride(to: (cString.count - 1), by: 2) {
+            guard let l = hexCharToByte(cString[i]), r = hexCharToByte(cString[i+1]) else {
+                return NSData()
+            }
+            var value: UInt8 = (l << 4) | r
+            result.appendBytes(&value, length: sizeofValue(value))
+        }
+        return result
+    }
+
+    private func hexCharToByte(c: CChar) -> UInt8? {
+        if c >= 48 && c <= 57 { // 0 - 9
+            return UInt8(c - 48)
+        }
+        if c >= 97 && c <= 102 { // a - f
+            return 10 + UInt8(c - 97)
+        }
+        if c >= 65 && c <= 70 { // A - F
+            return 10 + UInt8(c - 65)
+        }
+        return nil
     }
 }
 
+private let HexDigits: [String] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]
+
 extension NSData {
     public var hexEncodedString: String {
-        return base16Encode(self, uppercase: false)
+        let result = NSMutableString(capacity: length * 2)
+        let p = UnsafePointer<UInt8>(bytes)
+        for i in 0..<length {
+            result.appendString(HexDigits[Int((p[i] & 0xf0) >> 4)])
+            result.appendString(HexDigits[Int(p[i] & 0x0f)])
+        }
+        return String(result)
     }
 
     public class func randomOfLength(length: UInt) -> NSData? {


### PR DESCRIPTION
This patch removes the need for the *Base32* dependency. We only use that library for converting between hexadecimal `String` and `NSData`. That is a lot of overhead.

This patch implements simple and unoptimized hex encoding/decoding. We only use this on short values like hashes so I did not spend a lot of time on making sure this uses as little memory as possible or runs as fast as it can.

The advantages of getting rid of a dependency, and this on in particular:

* We forked this dependency, so we don't have to own it anymore
* Our `.ipa` size shrinks a bit
* Build and Link times go down
* App startup time goes down
* Simplified build because there is less to do

:8ball: 