### PR TITLE
Bug 1259020 - Update setting/VC title depending on if Touch ID is supported

### DIFF
--- a/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationManagerConstants.swift
@@ -21,6 +21,12 @@ extension PasscodeInterval {
 
 // Strings used in multiple areas within the Authentication Manager
 struct AuthenticationStrings {
+    static let passcode =
+        NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings")
+
+    static let touchIDPasscodeSetting =
+        NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
+
     static let requirePasscode =
         NSLocalizedString("Require Passcode", tableName: "AuthenticationManager", comment: "Title for setting to require a passcode")
 

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -190,7 +190,7 @@ class TouchIDSetting: Setting {
 class AuthenticationSettingsViewController: SettingsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
+        updateTitleForTouchIDState()
 
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.addObserver(self, selector: Selector("refreshSettings:"), name: NotificationPasscodeDidRemove, object: nil)
@@ -215,10 +215,18 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
         }
     }
 
+    private func updateTitleForTouchIDState() {
+        if LAContext().canEvaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, error: nil) {
+            navigationItem.title = AuthenticationStrings.touchIDPasscodeSetting
+        } else {
+            navigationItem.title = AuthenticationStrings.passcode
+        }
+    }
+
     private func passcodeEnabledSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        let passcodeSectionTitle = NSAttributedString(string: NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings"))
+        let passcodeSectionTitle = NSAttributedString(string: AuthenticationStrings.passcode)
         let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
             TurnPasscodeOffSetting(settings: self),
             ChangePasscodeSetting(settings: self, delegate: nil, enabled: true)
@@ -257,7 +265,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
     private func passcodeDisabledSettings() -> [SettingSection] {
         var settings = [SettingSection]()
 
-        let passcodeSectionTitle = NSAttributedString(string: NSLocalizedString("Passcode", tableName: "AuthenticationManager", comment: "List section title for passcode settings"))
+        let passcodeSectionTitle = NSAttributedString(string: AuthenticationStrings.passcode)
         let passcodeSection = SettingSection(title: passcodeSectionTitle, children: [
             TurnPasscodeOnSetting(settings: self),
             ChangePasscodeSetting(settings: self, delegate: nil, enabled: false)
@@ -278,6 +286,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
 
 extension AuthenticationSettingsViewController {
     func refreshSettings(notification: NSNotification) {
+        updateTitleForTouchIDState()
         settings = generateSettings()
         tableView.reloadData()
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -527,7 +527,12 @@ class TouchIDPasscodeSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
 
-        let title = NSLocalizedString("Touch ID & Passcode", tableName: "AuthenticationManager", comment: "Title for Touch ID/Passcode settings option")
+        let title: String
+        if LAContext().canEvaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, error: nil) {
+            title = AuthenticationStrings.touchIDPasscodeSetting
+        } else {
+            title = AuthenticationStrings.passcode
+        }
         super.init(title: NSAttributedString(string: title, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
                    delegate: delegate)
     }


### PR DESCRIPTION
This patch checks to see if the user has Touch ID functionality on their device as well as if they have it enabled. If both of these conditions are satisfied, the titles for the passcode setting and authentication screens are 'Touch ID & Passcode'. Otherwise, we set the title to be just 'Set Passcode'.