### PR TITLE
Bug 1259201 — Malformed bookmark items can result in a non-bufferable record.

### DIFF
--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -61,35 +61,33 @@ public enum BookmarkType: String {
     }
 
     public static func payloadFromJSON(json: JSON) -> BookmarkBasePayload? {
+        if json["deleted"].asBool ?? false {
+            // Deleted records won't have a type.
+            return BookmarkBasePayload(json)
+        }
+
         guard let typeString = json["type"].asString else {
             return nil
         }
+
         guard let type = BookmarkType.init(rawValue: typeString) else {
             return nil
         }
 
-        let result: BookmarkBasePayload
         switch type {
         case microsummary:
             fallthrough
         case bookmark:
-            result = BookmarkPayload(json)
+            return BookmarkPayload(json)
         case folder:
-            result = FolderPayload(json)
+            return FolderPayload(json)
         case livemark:
-            result = LivemarkPayload(json)
+            return LivemarkPayload(json)
         case separator:
-            result = SeparatorPayload(json)
+            return SeparatorPayload(json)
         case query:
-            result = BookmarkQueryPayload(json)
+            return BookmarkQueryPayload(json)
         }
-
-        if result.isValid() {
-            return result
-        }
-        let id = json["id"].asString ?? "<unknown>"
-        log.warning("Record \(id) of type \(type) was invalid.")
-        return nil
     }
 }
 

--- a/Sync/BookmarkPayload.swift
+++ b/Sync/BookmarkPayload.swift
@@ -89,6 +89,14 @@ public enum BookmarkType: String {
             return BookmarkQueryPayload(json)
         }
     }
+
+    public static func isValid(type: String?) -> Bool {
+        guard let type = type else {
+            return false
+        }
+
+        return BookmarkType.init(rawValue: type) != nil
+    }
 }
 
 public class LivemarkPayload: BookmarkBasePayload {
@@ -481,6 +489,11 @@ public class BookmarkBasePayload: CleartextPayloadJSON, MirrorItemable {
 
         if self["deleted"].asBool ?? false {
             return true
+        }
+
+        // If not deleted, we must be a specific, known, type!
+        if !BookmarkType.isValid(self["type"].asString) {
+            return false
         }
 
         if !(self["parentName"].isString || self.id == "places") {

--- a/Sync/EnvelopeJSON.swift
+++ b/Sync/EnvelopeJSON.swift
@@ -36,7 +36,8 @@ public class EnvelopeJSON {
     }
 
     public var sortindex: Int {
-        return self.json["sortindex"].asInt ?? 0
+        let s = self.json["sortindex"]
+        return s.asInt ?? 0
     }
 
     public var modified: Timestamp {

--- a/Sync/Record.swift
+++ b/Sync/Record.swift
@@ -50,18 +50,16 @@ public class Record<T: CleartextPayloadJSON> {
             return nil
         }
 
-        let payload = payloadFactory(envelope.payload)
-        if (payload == nil) {
+        guard let payload = payloadFactory(envelope.payload) else {
             log.error("Unable to parse payload.")
             return nil
         }
 
-        if payload!.isValid() {
-            return Record<T>(envelope: envelope, payload: payload!)
+        if !payload.isValid() {
+            log.warning("Invalid payload \(payload.toString(true)).")
         }
 
-        log.error("Invalid payload \(payload!.toString(true)).")
-        return nil
+        return Record<T>(envelope: envelope, payload: payload)
     }
 
     /**

--- a/Sync/Synchronizers/LoginsSynchronizer.swift
+++ b/Sync/Synchronizers/LoginsSynchronizer.swift
@@ -92,6 +92,11 @@ public class LoginsSynchronizer: IndependentRecordSynchronizer, Synchronizer {
             let guid = rec.id
             let payload = rec.payload
 
+            guard payload.isValid() else {
+                log.warning("Login record \(guid) is invalid. Skipping.")
+                return succeed()
+            }
+
             // We apply deletions immediately. That might not be exactly what we want -- perhaps you changed
             // a password locally after deleting it remotely -- but it's expedient.
             if payload.deleted {

--- a/Sync/Synchronizers/TabsSynchronizer.swift
+++ b/Sync/Synchronizers/TabsSynchronizer.swift
@@ -85,7 +85,7 @@ public class TabsSynchronizer: TimestampedSingleCollectionSynchronizer, Synchron
 
             func afterWipe() -> Success {
                 let doInsert: (Record<TabsPayload>) -> Deferred<Maybe<(Int)>> = { record in
-                    let remotes = record.payload.remoteTabs
+                    let remotes = record.payload.isValid() ? record.payload.remoteTabs : []
                     let ins = localTabs.insertOrUpdateTabsForClientGUID(record.id, tabs: remotes)
                     ins.upon() { res in
                         if let inserted = res.successValue {


### PR DESCRIPTION
This PR is fairly mechanical. The changes are:

- Propagate invalid records to one level up the stack: we no longer swallow them in the storage client, instead handing them to the caller. This will allow us to implement telemetry or recovery. All callers are modified to now check for validity.
- Fix the bug itself by allowing invalid bookmark payloads to be returned with specific types, rather than falling back to a (valid!) non-deleted generic type. This avoids the attempt to get a mirror item out of the payload, so we never hit the precondition that detected the bug. Win!
- Defines that bookmark payloads of unknown types are never valid. The set hasn't grown in 6 years.
- Adds lots of tests.