### PR TITLE
Bug 1222424 - Tapping "Mark as Read" button from Reading List panel won't disappear on Ipad Air

### DIFF
--- a/ThirdParty/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/ThirdParty/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -300,7 +300,15 @@ static NSString * const kTableViewPanState = @"state";
 
 - (void)layoutSubviews
 {
-    [super layoutSubviews];
+    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 9 &&
+        [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        // Handle for iOS 9+ iPads
+        layoutUpdating = YES;
+        [super layoutSubviews];
+        layoutUpdating = NO;
+    } else {
+        [super layoutSubviews];
+    }
     
     // Offset the contentView origin so that it appears correctly w/rt the enclosing scroll view (to which we moved it).
     CGRect frame = self.contentView.frame;


### PR DESCRIPTION
Made a little change to SWTableViewCell to fix the problem. Original SWTableViewCell has not been updated since the release of iOS 9.