### PR TITLE
Bug 1254601 - Added new toolbar with menu to Tab Tray

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -48,7 +48,7 @@ private extension TrayToBrowserAnimator {
         let tabCollectionViewSnapshot = tabTray.collectionView.snapshotViewAfterScreenUpdates(false)
         tabTray.collectionView.alpha = 0
         tabCollectionViewSnapshot.frame = tabTray.collectionView.frame
-        container.insertSubview(tabCollectionViewSnapshot, aboveSubview: tabTray.view)
+        container.insertSubview(tabCollectionViewSnapshot, atIndex: 0)
 
         // Create a fake cell to use for the upscaling animation
         let startingFrame = calculateCollapsedCellFrameUsingCollectionView(tabTray.collectionView, atIndex: expandFromIndex)
@@ -82,23 +82,9 @@ private extension TrayToBrowserAnimator {
             cell.title.transform = CGAffineTransformMakeTranslation(0, -cell.title.frame.height)
 
             bvc.tabTrayDidDismiss(tabTray)
-
+            tabTray.toolbar.transform = CGAffineTransformMakeTranslation(0, UIConstants.ToolbarHeight)
             tabCollectionViewSnapshot.transform = CGAffineTransformMakeScale(0.9, 0.9)
             tabCollectionViewSnapshot.alpha = 0
-
-            // Push out the navigation bar buttons
-            let buttonOffset: CGFloat
-            if AppConstants.MOZ_MENU {
-                buttonOffset = tabTray.menuButton!.frame.width + TabTrayControllerUX.ToolbarButtonOffset
-                tabTray.menuButton!.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, buttonOffset , 0)
-            } else {
-                buttonOffset = tabTray.addTabButton!.frame.width + TabTrayControllerUX.ToolbarButtonOffset
-                tabTray.addTabButton!.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, buttonOffset , 0)
-                tabTray.settingsButton?.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, -buttonOffset , 0)
-            }
-            if #available(iOS 9, *) {
-                tabTray.togglePrivateMode.transform = CGAffineTransformTranslate(CGAffineTransformIdentity, buttonOffset , 0)
-            }
         }, completion: { finished in
             // Remove any of the views we used for the animation
             cell.removeFromSuperview()
@@ -156,7 +142,7 @@ private extension BrowserToTrayAnimator {
         tabCollectionViewSnapshot.frame = tabTray.collectionView.frame
         tabCollectionViewSnapshot.transform = CGAffineTransformMakeScale(0.9, 0.9)
         tabCollectionViewSnapshot.alpha = 0
-        tabTray.view.addSubview(tabCollectionViewSnapshot)
+        tabTray.view.insertSubview(tabCollectionViewSnapshot, belowSubview: tabTray.toolbar)
 
         container.addSubview(cell)
         cell.layoutIfNeeded()
@@ -175,6 +161,7 @@ private extension BrowserToTrayAnimator {
             tabTray.collectionView.hidden = true
             let finalFrame = calculateCollapsedCellFrameUsingCollectionView(tabTray.collectionView,
                 atIndex: scrollToIndex)
+            tabTray.toolbar.transform = CGAffineTransformMakeTranslation(0, UIConstants.ToolbarHeight)
 
             UIView.animateWithDuration(self.transitionDuration(transitionContext),
                 delay: 0, usingSpringWithDamping: 1,
@@ -192,11 +179,8 @@ private extension BrowserToTrayAnimator {
                 bvc.footer.alpha = 0
                 tabCollectionViewSnapshot.alpha = 1
 
-                var viewsToReset: [UIView?] = [tabCollectionViewSnapshot, tabTray.addTabButton, tabTray.settingsButton]
-                if #available(iOS 9, *) {
-                    viewsToReset.append(tabTray.togglePrivateMode)
-                }
-                resetTransformsForViews(viewsToReset)
+                tabTray.toolbar.transform = CGAffineTransformIdentity
+                resetTransformsForViews([tabCollectionViewSnapshot])
             }, completion: { finished in
                 // Remove any of the views we used for the animation
                 cell.removeFromSuperview()

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -111,7 +111,7 @@ public class TabToolbarHelper: NSObject {
         if AppConstants.MOZ_MENU {
             toolbar.menuButton.contentMode = UIViewContentMode.Center
             toolbar.menuButton.setImage(UIImage.templateImageNamed("bottomNav-menu"), forState: .Normal)
-            toolbar.menuButton.accessibilityLabel = NSLocalizedString("Menu", comment: "Accessibility Label for the tab toolbar Menu button")
+            toolbar.menuButton.accessibilityLabel = Strings.MenuButtonAccessibilityLabel
             toolbar.menuButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickMenu), forControlEvents: UIControlEvents.TouchUpInside)
         } else {
             toolbar.bookmarkButton.contentMode = UIViewContentMode.Center

--- a/Client/Frontend/Browser/TabToolbar.swift
+++ b/Client/Frontend/Browser/TabToolbar.swift
@@ -111,7 +111,7 @@ public class TabToolbarHelper: NSObject {
         if AppConstants.MOZ_MENU {
             toolbar.menuButton.contentMode = UIViewContentMode.Center
             toolbar.menuButton.setImage(UIImage.templateImageNamed("bottomNav-menu"), forState: .Normal)
-            toolbar.menuButton.accessibilityLabel = Strings.MenuButtonAccessibilityLabel
+            toolbar.menuButton.accessibilityLabel = AppMenuConfiguration.MenuButtonAccessibilityLabel
             toolbar.menuButton.addTarget(self, action: #selector(TabToolbarHelper.SELdidClickMenu), forControlEvents: UIControlEvents.TouchUpInside)
         } else {
             toolbar.bookmarkButton.contentMode = UIViewContentMode.Center

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -462,22 +462,12 @@ class TabTrayController: UIViewController {
 
     @objc
     private func didTapMenu() {
-        let presentationStyle: MenuViewPresentationStyle = (self.traitCollection.horizontalSizeClass == .Compact && traitCollection.verticalSizeClass == .Regular) ? .Modal : .Popover
-        let mvc = MenuViewController(withAppState: .TabTray(tabTrayState: self.tabTrayState), presentationStyle: presentationStyle)
+        let mvc = MenuViewController(withAppState: .TabTray(tabTrayState: self.tabTrayState), presentationStyle: .Modal)
         mvc.delegate = self
         mvc.actionDelegate = self
         mvc.menuTransitionDelegate = MenuPresentationAnimator()
-        mvc.modalPresentationStyle = presentationStyle == .Modal ? .OverCurrentContext : .Popover
-
-        if let popoverPresentationController = mvc.popoverPresentationController {
-            let menuButton = toolbar.menuButton
-            popoverPresentationController.delegate = self
-            popoverPresentationController.sourceView = menuButton
-            popoverPresentationController.sourceRect = CGRect(x: menuButton.frame.width/2, y: 0, width: 0, height: 0)
-            popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.Down
-        }
-
-        displayedMenu = mvc
+        mvc.modalPresentationStyle = .OverCurrentContext
+        self.menuViewController = mvc
         self.presentViewController(mvc, animated: true, completion: nil)
     }
 
@@ -1118,7 +1108,7 @@ class TrayToolbar: UIView {
     lazy var menuButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("bottomNav-menu-pbm"), forState: .Normal)
-        button.accessibilityLabel = Strings.MenuButtonAccessibilityLabel
+        button.accessibilityLabel = AppMenuConfiguration.MenuButtonAccessibilityLabel
         button.accessibilityIdentifier = "TabTrayController.menuButton"
         return button
     }()
@@ -1181,13 +1171,13 @@ class TrayToolbar: UIView {
             settingsButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
         }
         maskButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
-        backgroundColor = isPrivate ? .toolbarTintColor() : .whiteColor()
+        backgroundColor = isPrivate ? UIConstants.PrivateModeToolbarTintColor : .whiteColor()
         updateMaskButtonState(isPrivate: isPrivate)
     }
 
     private func updateMaskButtonState(isPrivate isPrivate: Bool) {
         let maskImage = UIImage(named: "smallPrivateMask")?.imageWithRenderingMode(.AlwaysTemplate)
-        maskButton.imageView?.tintColor = isPrivate ? .whiteColor() : .toolbarTintColor()
+        maskButton.imageView?.tintColor = isPrivate ? .whiteColor() : UIConstants.PrivateModeToolbarTintColor
         maskButton.setImage(maskImage, forState: .Normal)
         maskButton.selected = isPrivate
         maskButton.accessibilityValue = isPrivate ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -223,7 +223,6 @@ class TabCell: UICollectionViewCell {
     }
 }
 
-@available(iOS 9, *)
 struct PrivateModeStrings {
     static let toggleAccessibilityLabel = NSLocalizedString("Private Mode", tableName: "PrivateBrowsing", comment: "Accessibility label for toggling on/off private mode")
     static let toggleAccessibilityHint = NSLocalizedString("Turns private mode on or off", tableName: "PrivateBrowsing", comment: "Accessiblity hint for toggling on/off private mode")
@@ -1141,5 +1140,84 @@ extension TabTrayController: MenuActionDelegate {
             default: break
             }
         }
+    }
+}
+
+// MARK: - Toolbar
+class TrayToolbar: UIView {
+    private let toolbarButtonSize = CGSize(width: 44, height: 44)
+
+    lazy var addTabButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage.templateImageNamed("add"), forState: .Normal)
+        button.accessibilityLabel = NSLocalizedString("Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
+        button.accessibilityIdentifier = "TabTrayController.addTabButton"
+        return button
+    }()
+
+    lazy var menuButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage.templateImageNamed("bottomNav-menu-pbm"), forState: .Normal)
+        button.accessibilityLabel = Strings.MenuButtonAccessibilityLabel
+        button.accessibilityIdentifier = "TabTrayController.menuButton"
+        return button
+    }()
+
+    lazy var maskButton: ToggleButton = {
+        let button = ToggleButton()
+        button.accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
+        button.accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
+        return button
+    }()
+
+    private let sideOffset: CGFloat = 32
+
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .whiteColor()
+        addSubview(addTabButton)
+        addSubview(menuButton)
+
+        menuButton.snp_makeConstraints { make in
+            make.center.equalTo(self)
+            make.size.equalTo(toolbarButtonSize)
+        }
+
+        addTabButton.snp_makeConstraints { make in
+            make.centerY.equalTo(self)
+            make.left.equalTo(self).offset(sideOffset)
+            make.size.equalTo(toolbarButtonSize)
+        }
+
+        if #available(iOS 9, *) {
+            addSubview(maskButton)
+            maskButton.snp_makeConstraints { make in
+                make.centerY.equalTo(self)
+                make.right.equalTo(self).offset(-sideOffset)
+                make.size.equalTo(toolbarButtonSize)
+            }
+        }
+
+        styleToolbar(isPrivate: false)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func styleToolbar(isPrivate isPrivate: Bool) {
+        addTabButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        menuButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        maskButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        backgroundColor = isPrivate ? .toolbarTintColor() : .whiteColor()
+        updateMaskButtonState(isPrivate: isPrivate)
+    }
+
+    private func updateMaskButtonState(isPrivate isPrivate: Bool) {
+        let maskImage = UIImage(named: "smallPrivateMask")?.imageWithRenderingMode(.AlwaysTemplate)
+        maskButton.imageView?.tintColor = isPrivate ? .whiteColor() : .toolbarTintColor()
+        maskButton.setImage(maskImage, forState: .Normal)
+        maskButton.selected = isPrivate
+        maskButton.accessibilityValue = isPrivate ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
     }
 }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -121,7 +121,7 @@ class TabCell: UICollectionViewCell {
         applyStyle(style)
 
         self.accessibilityCustomActions = [
-            UIAccessibilityCustomAction(name: NSLocalizedString("Close", comment: "Accessibility label for action denoting closing a tab in tab list (tray)"), target: self.animator, selector: Selector("SELcloseWithoutGesture"))
+            UIAccessibilityCustomAction(name: NSLocalizedString("Close", comment: "Accessibility label for action denoting closing a tab in tab list (tray)"), target: self.animator, selector: #selector(SwipeAnimator.SELcloseWithoutGesture))
         ]
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -26,6 +26,8 @@ struct TabTrayControllerUX {
     static let NumberOfColumnsWide = 3
     static let CompactNumberOfColumnsThin = 2
 
+    static let MenuFixedWidth: CGFloat = 320
+
     // Moved from UIConstants temporarily until animation code is merged
     static var StatusBarHeight: CGFloat {
         if UIScreen.mainScreen().traitCollection.verticalSizeClass == .Compact {
@@ -280,8 +282,6 @@ class TabTrayController: UIViewController {
         }
     }
 
-    private var displayedMenu: UIViewController?
-
     private(set) internal var privateMode: Bool = false {
         didSet {
             if oldValue != privateMode {
@@ -392,10 +392,6 @@ class TabTrayController: UIViewController {
 
         // Update the trait collection we reference in our layout delegate
         tabLayoutDelegate.traitCollection = traitCollection
-
-        // If we're displaying the menu as a modal and not a popover, make sure to dismiss here instead of 
-        // viewWillTransitionToSize to allow the animation to 'unwind' itself using the MenuPresenationAnimator.
-        displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
     }
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
@@ -459,15 +455,7 @@ class TabTrayController: UIViewController {
         mvc.actionDelegate = self
         mvc.menuTransitionDelegate = MenuPresentationAnimator()
         mvc.modalPresentationStyle = .OverCurrentContext
-
-        // Fix the width of the menu when we are in landscape or iPad
-        if (traitCollection.horizontalSizeClass == .Compact && traitCollection.verticalSizeClass == .Compact) ||
-            traitCollection.horizontalSizeClass == .Regular
-        {
-            mvc.fixedWidth = 320
-        }
-
-        self.displayedMenu = mvc
+        mvc.fixedWidth = TabTrayControllerUX.MenuFixedWidth
         self.presentViewController(mvc, animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -248,45 +248,55 @@ class TabTrayController: UIViewController {
     weak var appStateDelegate: AppStateDelegate?
 
     var collectionView: UICollectionView!
-    var navBar: UIView!
-    var addTabButton: UIButton?
-    var settingsButton: UIButton?
-    var menuButton: UIButton?
-    var collectionViewTransitionSnapshot: UIView?
+    lazy var toolbar: TrayToolbar = {
+        let toolbar = TrayToolbar()
+        toolbar.addTabButton.addTarget(self, action: #selector(TabTrayController.SELdidClickAddTab), forControlEvents: .TouchUpInside)
+
+        if AppConstants.MOZ_MENU {
+            toolbar.menuButton.addTarget(self, action: #selector(TabTrayController.didTapMenu), forControlEvents: .TouchUpInside)
+        } else {
+            toolbar.settingsButton.addTarget(self, action: #selector(TabTrayController.SELdidClickSettingsItem), forControlEvents: .TouchUpInside)
+        }
+
+        if #available(iOS 9, *) {
+            toolbar.maskButton.addTarget(self, action: #selector(TabTrayController.SELdidTogglePrivateMode), forControlEvents: .TouchUpInside)
+        }
+        return toolbar
+    }()
 
     var tabTrayState: TabTrayState {
         return TabTrayState(isPrivate: self.privateMode)
     }
 
+    var leftToolbarButtons: [UIButton] {
+        return [toolbar.addTabButton]
+    }
+
+    var rightToolbarButtons: [UIButton]? {
+        if #available(iOS 9, *) {
+            return [toolbar.maskButton]
+        } else {
+            return []
+        }
+    }
+
+    private var displayedMenu: UIViewController?
+
     private(set) internal var privateMode: Bool = false {
         didSet {
-            if #available(iOS 9, *) {
-                togglePrivateMode.selected = privateMode
-                togglePrivateMode.accessibilityValue = privateMode ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
-                tabDataSource.tabs = tabsToDisplay
-                collectionView?.reloadData()
-            }
             if oldValue != privateMode {
                 updateAppState()
             }
+
+            tabDataSource.tabs = tabsToDisplay
+            toolbar.styleToolbar(isPrivate: privateMode)
+            collectionView?.reloadData()
         }
     }
 
     private var tabsToDisplay: [Tab] {
         return self.privateMode ? tabManager.privateTabs : tabManager.normalTabs
     }
-
-    @available(iOS 9, *)
-    lazy var togglePrivateMode: ToggleButton = {
-        let button = ToggleButton()
-        button.setImage(UIImage(named: "smallPrivateMask"), forState: UIControlState.Normal)
-        button.addTarget(self, action: #selector(TabTrayController.SELdidTogglePrivateMode), forControlEvents: .TouchUpInside)
-        button.accessibilityLabel = PrivateModeStrings.toggleAccessibilityLabel
-        button.accessibilityHint = PrivateModeStrings.toggleAccessibilityHint
-        button.accessibilityValue = self.privateMode ? PrivateModeStrings.toggleAccessibilityValueOn : PrivateModeStrings.toggleAccessibilityValueOff
-        button.accessibilityIdentifier = "TabTrayController.togglePrivateMode"
-        return button
-    }()
 
     @available(iOS 9, *)
     private lazy var emptyPrivateTabsView: EmptyPrivateTabsView = {
@@ -341,64 +351,25 @@ class TabTrayController: UIViewController {
 
         view.accessibilityLabel = NSLocalizedString("Tabs Tray", comment: "Accessibility label for the Tabs Tray view.")
 
-        navBar = UIView()
-        navBar.backgroundColor = TabTrayControllerUX.BackgroundColor
-
-        let flowLayout = TabTrayCollectionViewLayout()
-        collectionView = UICollectionView(frame: view.frame, collectionViewLayout: flowLayout)
+        collectionView = UICollectionView(frame: view.frame, collectionViewLayout: UICollectionViewFlowLayout())
 
         collectionView.dataSource = tabDataSource
         collectionView.delegate = tabLayoutDelegate
-
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: UIConstants.ToolbarHeight, right: 0)
         collectionView.registerClass(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
         collectionView.backgroundColor = TabTrayControllerUX.BackgroundColor
 
         view.addSubview(collectionView)
-        view.addSubview(navBar)
-
-        if AppConstants.MOZ_MENU {
-            self.menuButton = UIButton()
-            menuButton?.setImage(UIImage(named: "bottomNav-menu-pbm"), forState: .Normal)
-            menuButton?.addTarget(self, action: #selector(TabTrayController.didTapMenu), forControlEvents: .TouchUpInside)
-            menuButton?.accessibilityLabel = NSLocalizedString("Menu", comment: "Accessibility label for opening the Menu button in the Tab Tray.")
-            menuButton?.accessibilityIdentifier = "TabTrayController.menuButton"
-            view.addSubview(menuButton!)
-        } else {
-            addTabButton = UIButton()
-            addTabButton?.setImage(UIImage(named: "add"), forState: .Normal)
-            addTabButton?.addTarget(self, action: #selector(TabTrayController.SELdidClickAddTab), forControlEvents: .TouchUpInside)
-            addTabButton?.accessibilityLabel = NSLocalizedString("Add Tab", comment: "Accessibility label for the Add Tab button in the Tab Tray.")
-            addTabButton?.accessibilityIdentifier = "TabTrayController.addTabButton"
-            view.addSubview(addTabButton!)
-
-            settingsButton = UIButton()
-            settingsButton?.setImage(UIImage(named: "settings"), forState: .Normal)
-            settingsButton?.addTarget(self, action: #selector(TabTrayController.SELdidClickSettingsItem), forControlEvents: .TouchUpInside)
-            settingsButton?.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button in the Tab Tray.")
-            settingsButton?.accessibilityIdentifier = "TabTrayController.settingsButton"
-            view.addSubview(settingsButton!)
-        }
-
-
+        view.addSubview(toolbar)
 
         makeConstraints()
 
         if #available(iOS 9, *) {
-            view.addSubview(togglePrivateMode)
-            togglePrivateMode.snp_makeConstraints { make in
-                if AppConstants.MOZ_MENU {
-                    make.right.equalTo(menuButton!.snp_left).offset(-10)
-                } else {
-                    make.right.equalTo(addTabButton!.snp_left).offset(-10)
-                }
-                make.size.equalTo(UIConstants.ToolbarHeight)
-                make.centerY.equalTo(self.navBar)
-            }
-
             view.insertSubview(emptyPrivateTabsView, aboveSubview: collectionView)
             emptyPrivateTabsView.alpha = privateMode && tabManager.privateTabs.count == 0 ? 1 : 0
             emptyPrivateTabsView.snp_makeConstraints { make in
-                make.edges.equalTo(self.view)
+                make.top.left.right.equalTo(self.collectionView)
+                make.bottom.equalTo(self.collectionView).offset(-UIConstants.ToolbarHeight)
             }
 
             if let tab = tabManager.selectedTab where tab.isPrivate {
@@ -421,10 +392,23 @@ class TabTrayController: UIViewController {
 
         // Update the trait collection we reference in our layout delegate
         tabLayoutDelegate.traitCollection = traitCollection
+
+        // If we're displaying the menu as a modal and not a popover, make sure to dismiss here instead of 
+        // viewWillTransitionToSize to allow the animation to 'unwind' itself using the MenuPresenationAnimator.
+        if displayedMenu?.modalPresentationStyle == .OverCurrentContext {
+            displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
+        }
     }
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+        // If we're displaying the menu as a popover, hide it right away here instead of traitCollectionDidChange.
+        // Otherwise, the popover will briefly appear behind hiding again. Since we don't do any transforms during
+        // the popover animation, we don't need to 'unwind' the animation.
+        if displayedMenu?.modalPresentationStyle == .Popover {
+            displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
+        }
+
         coordinator.animateAlongsideTransition({ _ in
             self.collectionView.collectionViewLayout.invalidateLayout()
         }, completion: nil)
@@ -435,32 +419,14 @@ class TabTrayController: UIViewController {
     }
 
     private func makeConstraints() {
-        navBar.snp_makeConstraints { make in
-            make.top.equalTo(snp_topLayoutGuideBottom)
-            make.height.equalTo(UIConstants.ToolbarHeight)
-            make.left.right.equalTo(self.view)
-        }
-
-        if AppConstants.MOZ_MENU {
-            menuButton!.snp_makeConstraints { make in
-                make.trailing.bottom.equalTo(self.navBar)
-                make.size.equalTo(UIConstants.ToolbarHeight)
-            }
-        } else {
-            addTabButton!.snp_makeConstraints { make in
-                make.trailing.bottom.equalTo(self.navBar)
-                make.size.equalTo(UIConstants.ToolbarHeight)
-            }
-
-            settingsButton!.snp_makeConstraints { make in
-                make.leading.bottom.equalTo(self.navBar)
-                make.size.equalTo(UIConstants.ToolbarHeight)
-            }
-        }
-
         collectionView.snp_makeConstraints { make in
-            make.top.equalTo(navBar.snp_bottom)
-            make.left.right.bottom.equalTo(self.view)
+            make.left.bottom.right.equalTo(view)
+            make.top.equalTo(snp_topLayoutGuideBottom)
+        }
+
+        toolbar.snp_makeConstraints { make in
+            make.left.right.bottom.equalTo(view)
+            make.height.equalTo(UIConstants.ToolbarHeight)
         }
     }
 
@@ -496,19 +462,22 @@ class TabTrayController: UIViewController {
 
     @objc
     private func didTapMenu() {
-        let mvc = MenuViewController(withAppState: .TabTray(tabTrayState: self.tabTrayState), presentationStyle: .Popover)
+        let presentationStyle: MenuViewPresentationStyle = (self.traitCollection.horizontalSizeClass == .Compact && traitCollection.verticalSizeClass == .Regular) ? .Modal : .Popover
+        let mvc = MenuViewController(withAppState: .TabTray(tabTrayState: self.tabTrayState), presentationStyle: presentationStyle)
         mvc.delegate = self
         mvc.actionDelegate = self
-        mvc.modalPresentationStyle = .Popover
+        mvc.menuTransitionDelegate = MenuPresentationAnimator()
+        mvc.modalPresentationStyle = presentationStyle == .Modal ? .OverCurrentContext : .Popover
 
         if let popoverPresentationController = mvc.popoverPresentationController {
-            popoverPresentationController.backgroundColor = UIColor.clearColor()
+            let menuButton = toolbar.menuButton
             popoverPresentationController.delegate = self
-            popoverPresentationController.sourceView = menuButton!
-            popoverPresentationController.sourceRect = CGRect(x: menuButton!.frame.width/2, y: menuButton!.frame.size.height * 0.75, width: 1, height: 1)
-            popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.Up
+            popoverPresentationController.sourceView = menuButton
+            popoverPresentationController.sourceRect = CGRect(x: menuButton.frame.width/2, y: 0, width: 0, height: 0)
+            popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirection.Down
         }
 
+        displayedMenu = mvc
         self.presentViewController(mvc, animated: true, completion: nil)
     }
 
@@ -533,7 +502,7 @@ class TabTrayController: UIViewController {
             tabManager.removeAllPrivateTabsAndNotify(false)
         }
 
-        togglePrivateMode.setSelected(privateMode, animated: true)
+        toolbar.maskButton.setSelected(privateMode, animated: true)
         collectionView.layoutSubviews()
 
         let toView: UIView
@@ -905,23 +874,6 @@ private class TabLayoutDelegate: NSObject, UICollectionViewDelegateFlowLayout {
     }
 }
 
-// There seems to be a bug with UIKit where when the UICollectionView changes its contentSize
-// from > frame.size to <= frame.size: the contentSet animation doesn't properly happen and 'jumps' to the
-// final state.
-// This workaround forces the contentSize to always be larger than the frame size so the animation happens more
-// smoothly. This also makes the tabs be able to 'bounce' when there are not enough to fill the screen, which I
-// think is fine, but if needed we can disable user scrolling in this case.
-private class TabTrayCollectionViewLayout: UICollectionViewFlowLayout {
-    private override func collectionViewContentSize() -> CGSize {
-        var calculatedSize = super.collectionViewContentSize()
-        let collectionViewHeight = collectionView?.bounds.size.height ?? 0
-        if calculatedSize.height < collectionViewHeight && collectionViewHeight > 0 {
-            calculatedSize.height = collectionViewHeight + 1
-        }
-        return calculatedSize
-    }
-}
-
 struct EmptyPrivateTabsViewUX {
     static let TitleColor = UIColor.whiteColor()
     static let TitleFont = UIFont.systemFontOfSize(22, weight: UIFontWeightMedium)
@@ -1147,6 +1099,14 @@ extension TabTrayController: MenuActionDelegate {
 class TrayToolbar: UIView {
     private let toolbarButtonSize = CGSize(width: 44, height: 44)
 
+    lazy var settingsButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage.templateImageNamed("settings"), forState: .Normal)
+        button.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button in the Tab Tray.")
+        button.accessibilityIdentifier = "TabTrayController.settingsButton"
+        return button
+    }()
+
     lazy var addTabButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage.templateImageNamed("add"), forState: .Normal)
@@ -1176,9 +1136,17 @@ class TrayToolbar: UIView {
         super.init(frame: frame)
         backgroundColor = .whiteColor()
         addSubview(addTabButton)
-        addSubview(menuButton)
 
-        menuButton.snp_makeConstraints { make in
+        var buttonToCenter: UIButton?
+        if AppConstants.MOZ_MENU {
+            addSubview(menuButton)
+            buttonToCenter = menuButton
+        } else {
+            addSubview(settingsButton)
+            buttonToCenter = settingsButton
+        }
+
+        buttonToCenter?.snp_makeConstraints { make in
             make.center.equalTo(self)
             make.size.equalTo(toolbarButtonSize)
         }
@@ -1207,7 +1175,11 @@ class TrayToolbar: UIView {
 
     private func styleToolbar(isPrivate isPrivate: Bool) {
         addTabButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
-        menuButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        if AppConstants.MOZ_MENU {
+            menuButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        } else {
+            settingsButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
+        }
         maskButton.tintColor = isPrivate ? .whiteColor() : .darkGrayColor()
         backgroundColor = isPrivate ? .toolbarTintColor() : .whiteColor()
         updateMaskButtonState(isPrivate: isPrivate)

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -395,19 +395,11 @@ class TabTrayController: UIViewController {
 
         // If we're displaying the menu as a modal and not a popover, make sure to dismiss here instead of 
         // viewWillTransitionToSize to allow the animation to 'unwind' itself using the MenuPresenationAnimator.
-        if displayedMenu?.modalPresentationStyle == .OverCurrentContext {
-            displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
-        }
+        displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
     }
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        // If we're displaying the menu as a popover, hide it right away here instead of traitCollectionDidChange.
-        // Otherwise, the popover will briefly appear behind hiding again. Since we don't do any transforms during
-        // the popover animation, we don't need to 'unwind' the animation.
-        if displayedMenu?.modalPresentationStyle == .Popover {
-            displayedMenu?.dismissViewControllerAnimated(true, completion: nil)
-        }
 
         coordinator.animateAlongsideTransition({ _ in
             self.collectionView.collectionViewLayout.invalidateLayout()
@@ -467,7 +459,15 @@ class TabTrayController: UIViewController {
         mvc.actionDelegate = self
         mvc.menuTransitionDelegate = MenuPresentationAnimator()
         mvc.modalPresentationStyle = .OverCurrentContext
-        self.menuViewController = mvc
+
+        // Fix the width of the menu when we are in landscape or iPad
+        if (traitCollection.horizontalSizeClass == .Compact && traitCollection.verticalSizeClass == .Compact) ||
+            traitCollection.horizontalSizeClass == .Regular
+        {
+            mvc.fixedWidth = 320
+        }
+
+        self.displayedMenu = mvc
         self.presentViewController(mvc, animated: true, completion: nil)
     }
 

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -77,7 +77,11 @@ struct AppMenuConfiguration: MenuConfiguration {
     private func numberOfMenuItemsPerRowForAppState(appState: AppState) -> Int {
         switch appState {
         case .TabTray:
-            return 4
+            if #available(iOS 9, *) {
+                return 4
+            } else {
+                return 3
+            }
         default:
             return 3
         }

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -209,4 +209,5 @@ extension AppMenuConfiguration {
     static let BookmarksTitleString = NSLocalizedString("Menu.OpenBookmarksAction.AccessibilityLabel", value: "Bookmarks", tableName: "Menu", comment: "AccessibilityLabel describing the action of opening the bookmarks home panel from the menu")
     static let HistoryTitleString = NSLocalizedString("Menu.OpenHistoryAction.AccessibilityLabel", value: "History", tableName: "Menu", comment: "AccessibilityLabel describing the action of opening the history home panel from the menu")
     static let ReadingListTitleString = NSLocalizedString("Menu.OpenReadingListAction.AccessibilityLabel", value: "Reading List", tableName: "Menu", comment: "AccessibilityLabel describing the action of opening the reading list home panel from the menu")
+    static let MenuButtonAccessibilityLabel = NSLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility Label for the toolbar Menu button")
 }

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -77,11 +77,7 @@ struct AppMenuConfiguration: MenuConfiguration {
     private func numberOfMenuItemsPerRowForAppState(appState: AppState) -> Int {
         switch appState {
         case .TabTray:
-            if #available(iOS 9, *) {
-                return 4
-            } else {
-                return 3
-            }
+            return 4
         default:
             return 3
         }

--- a/Client/Frontend/Menu/MenuPresentationAnimator.swift
+++ b/Client/Frontend/Menu/MenuPresentationAnimator.swift
@@ -69,9 +69,8 @@ extension MenuPresentationAnimator {
         self.animateWithMenu(menu, baseController: bvc, viewsToAnimateLeft: leftViews, viewsToAnimateRight: rightViews, sourceView: sourceView, withTransitionContext: transitionContext)
     }
 
-    // TODO: when the tab tray toolbar comes into existence then this should be completed
     private func animateWithMenu(menu: MenuViewController, tabTrayController ttc: TabTrayController, transitionContext: UIViewControllerContextTransitioning) {
-        fatalError("animateWithMenu(menu: tabTrayController: transitionContext:) has not been implemented")
+        animateWithMenu(menu, baseController: ttc, viewsToAnimateLeft: ttc.leftToolbarButtons, viewsToAnimateRight: ttc.rightToolbarButtons, sourceView: ttc.toolbar.menuButton, withTransitionContext: transitionContext)
     }
 
     private func animateWithMenu(menuController: MenuViewController, baseController: UIViewController, viewsToAnimateLeft: [UIView]?, viewsToAnimateRight: [UIView]?, sourceView: UIView?, withTransitionContext transitionContext: UIViewControllerContextTransitioning) {

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -68,8 +68,3 @@ extension Strings {
     public static let SyncedTabsTableViewCellDescription = NSLocalizedString("HistoryPanel.SyncedTabsCell.Description", value: "devices connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel")
     public static let HistoryPanelEmptyStateTitle = NSLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you've visited recently will show up here.", comment: "Title for the History Panel empty state.")
 }
-
-// Accessibility 
-extension Strings {
-    public static let MenuButtonAccessibilityLabel = NSLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility Label for the toolbar Menu button")
-}

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -68,3 +68,8 @@ extension Strings {
     public static let SyncedTabsTableViewCellDescription = NSLocalizedString("HistoryPanel.SyncedTabsCell.Description", value: "devices connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel")
     public static let HistoryPanelEmptyStateTitle = NSLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you've visited recently will show up here.", comment: "Title for the History Panel empty state.")
 }
+
+// Accessibility 
+extension Strings {
+    public static let MenuButtonAccessibilityLabel = NSLocalizedString("Toolbar.Menu.AccessibilityLabel", value: "Menu", comment: "Accessibility Label for the toolbar Menu button")
+}

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -5,6 +5,12 @@
 import Foundation
 import Shared
 
+public extension UIColor {
+    class func toolbarTintColor() -> UIColor {
+        return UIColor(rgb: 0x4A4A4A)
+    }
+}
+
 public struct UIConstants {
     static let AboutHomePage = NSURL(string: "\(WebServer.sharedInstance.base)/about/home/")!
     static let DefaultHomePage = NSURL(string:"#panel=0", relativeToURL: AboutHomePage)!

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -5,12 +5,6 @@
 import Foundation
 import Shared
 
-public extension UIColor {
-    class func toolbarTintColor() -> UIColor {
-        return UIColor(rgb: 0x4A4A4A)
-    }
-}
-
 public struct UIConstants {
     static let AboutHomePage = NSURL(string: "\(WebServer.sharedInstance.base)/about/home/")!
     static let DefaultHomePage = NSURL(string:"#panel=0", relativeToURL: AboutHomePage)!
@@ -22,6 +16,7 @@ public struct UIConstants {
     static let PrivateModeActionButtonTintColor = UIColor(red: 255, green: 255, blue: 255, alpha: 0.8)
     static let PrivateModeTextHighlightColor = UIColor(red: 120 / 255, green: 120 / 255, blue: 165 / 255, alpha: 1)
     static let PrivateModeReaderModeBackgroundColor = UIColor(red: 89 / 255, green: 89 / 255, blue: 89 / 255, alpha: 1)
+    static let PrivateModeToolbarTintColor = UIColor(red: 74 / 255, green: 74 / 255, blue: 74 / 255, alpha: 1)
 
     static let ToolbarHeight: CGFloat = 44
     static let DefaultRowHeight: CGFloat = 58

--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -29,12 +29,31 @@ class MenuViewController: UIViewController {
         }
     }
 
-    var menuView: MenuView!
+    lazy var menuView: MenuView = MenuView(presentationStyle: self.presentationStyle)
 
     var appState: AppState {
         didSet {
             menuConfig = menuConfig.menuForState(appState)
             self.reloadView()
+        }
+    }
+
+    var fixedWidth: CGFloat? {
+        didSet {
+            defer {
+                menuView.setNeedsUpdateConstraints()
+            }
+
+            guard let fixedWidth = fixedWidth else {
+                self.setupDefaultModalMenuConstraints()
+                return
+            }
+
+            menuView.snp_remakeConstraints { make in
+                make.centerX.equalTo(view)
+                make.width.equalTo(fixedWidth)
+                make.bottom.equalTo(view)
+            }
         }
     }
 
@@ -62,7 +81,6 @@ class MenuViewController: UIViewController {
         self.view.addGestureRecognizer(gesture)
 
         // Do any additional setup after loading the view.
-        menuView = MenuView(presentationStyle: self.presentationStyle)
         self.view.addSubview(menuView)
 
         menuView.menuItemDataSource = self
@@ -97,14 +115,16 @@ class MenuViewController: UIViewController {
             menuView.openMenuImage.image = menuConfig.menuIcon()?.imageWithRenderingMode(.AlwaysTemplate)
             menuView.openMenuImage.tintColor = menuConfig.toolbarTintColor()
             menuView.openMenuImage.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(self.tapToDismissMenu(_:))))
-
-            menuView.snp_makeConstraints { make in
-                make.left.equalTo(view.snp_left).offset(24)
-                make.right.equalTo(view.snp_right).offset(-24)
-                make.bottom.equalTo(view.snp_bottom)
-            }
+            setupDefaultModalMenuConstraints()
         }
+    }
 
+    private func setupDefaultModalMenuConstraints() {
+        menuView.snp_remakeConstraints { make in
+            make.left.equalTo(view.snp_left).offset(24)
+            make.right.equalTo(view.snp_right).offset(-24)
+            make.bottom.equalTo(view.snp_bottom)
+        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -138,7 +138,6 @@ class MenuViewController: UIViewController {
         if presentationStyle == .Popover {
             self.preferredContentSize = CGSizeMake(view.bounds.size.width, menuView.bounds.size.height)
         }
-        self.popoverPresentationController?.backgroundColor = self.popoverBackgroundColor
     }
 
     override func viewDidAppear(animated: Bool) {


### PR DESCRIPTION
(This work has been done on top of the Swift 2.2 branch to allow people to run the code on Xcode 7.3)

This commit contains the first pass at implementing the updated toolbar design for the Tab Tray.

@fluffyemily After doing some research, I ended up using the provided `UIToolbar` class instead of using a custom view. So far the toolbar has everything I've needed so it hasn't been a problem. The code I ended up writing to create the toolbar is all specific to the tab tray so I don't think there is much we can reuse although the toolbar itself is constructed in ~40 lines so I don't think we'd want to reuse it anyways.

@tecgirl I've added some basic animations for now to move between the tray/browser state. The toolbar will animate down when moving away from the tray and animate up when entering the tray. I've also moved the settings button to the center instead of the menu until we land the menu work. There are a couple of UI issues I've run into though: 

1. Now that we no longer have the bar at the top, the tabs scroll under the status bar text. Any ideas on how we can make this better?

2. For iOS 8 devices, private mode isn't supported so the toolbar looks lopsided.

![simulator screen shot mar 28 2016 4 36 37 pm](https://cloud.githubusercontent.com/assets/434322/14089864/317d9bd8-f505-11e5-8bb8-348f70fa8968.png)

![simulator screen shot mar 28 2016 4 36 25 pm](https://cloud.githubusercontent.com/assets/434322/14089884/43b0c6ae-f505-11e5-9b0d-0fea7578efd4.png)
