### PR TITLE
Bug 1196949 - Replaced system provided Cancel button in extensions with our own

### DIFF
--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -48,7 +48,7 @@ class ClientPickerViewController: UITableViewController {
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(ClientPickerViewController.refresh), forControlEvents: UIControlEvents.ValueChanged)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: NSLocalizedString("Cancel", tableName: "SendTo", comment: "Button title for cancelling SendTo screen"),
+            title: NSLocalizedString("SendTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling SendTo screen"),
             style: .Plain,
             target: self,
             action:  #selector(ClientPickerViewController.cancel)

--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -47,7 +47,13 @@ class ClientPickerViewController: UITableViewController {
         title = NSLocalizedString("Send Tab", tableName: "SendTo", comment: "Title of the dialog that allows you to send a tab to a different device")
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(ClientPickerViewController.refresh), forControlEvents: UIControlEvents.ValueChanged)
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: #selector(ClientPickerViewController.cancel))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: NSLocalizedString("Cancel", tableName: "SendTo", comment: "Button title for cancelling SendTo screen"),
+            style: .Plain,
+            target: self,
+            action:  #selector(ClientPickerViewController.cancel)
+        )
+
         tableView.registerClass(ClientPickerTableViewHeaderCell.self, forCellReuseIdentifier: ClientPickerTableViewHeaderCell.CellIdentifier)
         tableView.registerClass(ClientPickerTableViewCell.self, forCellReuseIdentifier: ClientPickerTableViewCell.CellIdentifier)
         tableView.registerClass(ClientPickerNoClientsTableViewCell.self, forCellReuseIdentifier: ClientPickerNoClientsTableViewCell.CellIdentifier)

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -90,7 +90,7 @@ class ShareDialogController: UIViewController, UITableViewDataSource, UITableVie
 
         navItem = UINavigationItem()
         navItem.leftBarButtonItem = UIBarButtonItem(
-            title: NSLocalizedString("Cancel", tableName: "ShareTo", comment: "Button title for cancelling Share screen"),
+            title: NSLocalizedString("ShareTo.Cancel.Button", value: "Cancel", comment: "Button title for cancelling Share screen"),
             style: .Plain,
             target: self,
             action: #selector(ShareDialogController.cancel)

--- a/Extensions/ShareTo/ShareViewController.swift
+++ b/Extensions/ShareTo/ShareViewController.swift
@@ -89,7 +89,12 @@ class ShareDialogController: UIViewController, UITableViewDataSource, UITableVie
         // Setup the NavigationItem
 
         navItem = UINavigationItem()
-        navItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: #selector(ShareDialogController.cancel))
+        navItem.leftBarButtonItem = UIBarButtonItem(
+            title: NSLocalizedString("Cancel", tableName: "ShareTo", comment: "Button title for cancelling Share screen"),
+            style: .Plain,
+            target: self,
+            action: #selector(ShareDialogController.cancel)
+        )
         navItem.leftBarButtonItem?.setTitleTextAttributes([NSFontAttributeName: ShareDialogControllerUX.NavigationBarCancelButtonFont], forState: UIControlState.Normal)
         navItem.leftBarButtonItem?.accessibilityIdentifier = "ShareDialogController.navigationItem.leftBarButtonItem"
 


### PR DESCRIPTION
Probably assigns the tableName to the localization strings for Cancel in the ShareTo/SendTo extensions.