### PR TITLE
Bug 1261851 - Added passcode/touch ID validation for logins when backgrounded along with sensitive blur

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -605,6 +605,7 @@
 		E6B6DCA21CD3D370009CF713 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6B6DC941CD3D35A009CF713 /* CrashReporter.framework */; };
 		E6B6DCA71CD3EC53009CF713 /* CrashSimulator.h in Headers */ = {isa = PBXBuildFile; fileRef = E6B6DCA51CD3EC53009CF713 /* CrashSimulator.h */; };
 		E6B6DCA81CD3EC53009CF713 /* CrashSimulator.m in Sources */ = {isa = PBXBuildFile; fileRef = E6B6DCA61CD3EC53009CF713 /* CrashSimulator.m */; };
+		E6CF28E71CB43B7900151AB3 /* SensitiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF28E61CB43B7900151AB3 /* SensitiveViewController.swift */; };
 		E6D749011C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */; };
 		E6D8D5E71B569D70009E5A58 /* BrowserTrayAnimators.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */; };
 		E6E4A9631BF0FA85008162D5 /* NSFileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E4A9621BF0FA85008162D5 /* NSFileManagerExtensions.swift */; };
@@ -1626,6 +1627,7 @@
 		E6B6DC941CD3D35A009CF713 /* CrashReporter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CrashReporter.framework; sourceTree = "<group>"; };
 		E6B6DCA51CD3EC53009CF713 /* CrashSimulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CrashSimulator.h; sourceTree = "<group>"; };
 		E6B6DCA61CD3EC53009CF713 /* CrashSimulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CrashSimulator.m; sourceTree = "<group>"; };
+		E6CF28E61CB43B7900151AB3 /* SensitiveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensitiveViewController.swift; sourceTree = "<group>"; };
 		E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLProtectionSpaceExtensions.swift; sourceTree = "<group>"; };
 		E6D8D5E61B569D70009E5A58 /* BrowserTrayAnimators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserTrayAnimators.swift; sourceTree = "<group>"; };
 		E6E4A9621BF0FA85008162D5 /* NSFileManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSFileManagerExtensions.swift; sourceTree = "<group>"; };
@@ -2885,6 +2887,7 @@
 				E69E06C81C76198000D0F926 /* AuthenticationManagerConstants.swift */,
 				E65D89171C8647420006EA35 /* AppAuthenticator.swift */,
 				E692E3281C46E62D009D1240 /* AuthenticationSettingsViewController.swift */,
+				E6CF28E61CB43B7900151AB3 /* SensitiveViewController.swift */,
 			);
 			path = AuthenticationManager;
 			sourceTree = "<group>";
@@ -4667,6 +4670,7 @@
 				E69E06D01C765BB900D0F926 /* NSAttributedStringExtensions.swift in Sources */,
 				7BEDD2B21CB7CC0B004B51F3 /* Animatable.swift in Sources */,
 				D30B0F301AA7D66300C01CA3 /* ThumbnailCell.swift in Sources */,
+				E6CF28E71CB43B7900151AB3 /* SensitiveViewController.swift in Sources */,
 				E68E7ADA1CAC207400FDCA76 /* ChangePasscodeViewController.swift in Sources */,
 				E640E85E1C73A45A00C5F072 /* PasscodeEntryViewController.swift in Sources */,
 				7BC68CCE1CC152B70043562A /* MenuViewController.swift in Sources */,

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -45,7 +45,7 @@ class AppAuthenticator {
         }
     }
 
-    static func presentPasscodeAuthentication(presentingNavController: UINavigationController?, delegate: PasscodeEntryDelegate) {
+    static func presentPasscodeAuthentication(presentingNavController: UINavigationController?, delegate: PasscodeEntryDelegate?) {
         let passcodeVC = PasscodeEntryViewController()
         passcodeVC.delegate = delegate
         let navController = UINavigationController(rootViewController: passcodeVC)

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -93,6 +93,7 @@ class RequirePasscodeSetting: Setting {
             success: {
                 self.navigateToRequireInterval()
             },
+            cancel: nil,
             fallback: {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self)
             })
@@ -170,6 +171,7 @@ class TouchIDSetting: Setting {
                 authInfo,
                 touchIDReason: AuthenticationStrings.disableTouchReason,
                 success: self.touchIDSuccess,
+                cancel: nil,
                 fallback: self.touchIDFallback
             )
         } else {

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -10,6 +10,7 @@ import SwiftKeychainWrapper
 /// Delegate available for PasscodeEntryViewController consumers to be notified of the validation of a passcode.
 @objc protocol PasscodeEntryDelegate: class {
     func passcodeValidationDidSucceed()
+    optional func userDidCancelValidation()
 }
 
 /// Presented to the to user when asking for their passcode to validate entry into a part of the app.
@@ -43,6 +44,11 @@ class PasscodeEntryViewController: BasePasscodeViewController {
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
         self.view.endEditing(true)
+    }
+
+    override func dismiss() {
+        delegate?.userDidCancelValidation?()
+        super.dismiss()
     }
 }
 

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SnapKit
+import SwiftKeychainWrapper
+
+class SensitiveViewController: UIViewController {
+    var promptingForTouchID: Bool = false
+    var backgroundedBlur: UIImageView?
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        let notificationCenter = NSNotificationCenter.defaultCenter()
+        notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.checkIfUserRequiresValidation), name: UIApplicationDidBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(SensitiveViewController.blurContents), name: UIApplicationWillResignActiveNotification, object: nil)
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        let notificationCenter = NSNotificationCenter.defaultCenter()
+        notificationCenter.removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
+    }
+
+    func checkIfUserRequiresValidation() {
+        guard let authInfo = KeychainWrapper.authenticationInfo() where authInfo.requiresValidation() else {
+            removeBackgroundedBlur()
+            return
+        }
+
+        promptingForTouchID = true
+        AppAuthenticator.presentAuthenticationUsingInfo(authInfo,
+            touchIDReason: AuthenticationStrings.loginsTouchReason,
+            success: {
+                self.promptingForTouchID = false
+                self.removeBackgroundedBlur()
+            },
+            cancel: {
+                self.promptingForTouchID = false
+                self.navigationController?.popToRootViewControllerAnimated(true)
+            },
+            fallback: {
+                self.promptingForTouchID = false
+                AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self)
+            }
+        )
+    }
+
+    func blurContents() {
+        if backgroundedBlur == nil {
+            backgroundedBlur = addBlurredContent()
+        }
+    }
+
+    func removeBackgroundedBlur() {
+        if !promptingForTouchID {
+            backgroundedBlur?.removeFromSuperview()
+            backgroundedBlur = nil
+        }
+    }
+
+    private func addBlurredContent() -> UIImageView? {
+        guard let snapshot = view.screenshot() else {
+            return nil
+        }
+
+        let blurredSnapshot = snapshot.applyBlurWithRadius(10, blurType: BOXFILTER, tintColor: UIColor.init(white: 1, alpha: 0.3), saturationDeltaFactor: 1.8, maskImage: nil)
+        let blurView = UIImageView(image: blurredSnapshot)
+        view.addSubview(blurView)
+        blurView.snp_makeConstraints { $0.edges.equalTo(self.view) }
+        view.layoutIfNeeded()
+
+        return blurView
+    }
+}
+
+// MARK: - PasscodeEntryDelegate
+extension SensitiveViewController: PasscodeEntryDelegate {
+    func passcodeValidationDidSucceed() {
+        removeBackgroundedBlur()
+        self.navigationController?.dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    func userDidCancelValidation() {
+        self.navigationController?.popToRootViewControllerAnimated(false)
+    }
+}
+

--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 import SnapKit
 import Storage
 import Shared
+import SwiftKeychainWrapper
 
 private struct LoginListUX {
     static let RowHeight: CGFloat = 58
@@ -28,7 +29,7 @@ private extension UITableView {
 
 private let LoginCellIdentifier = "LoginCell"
 
-class LoginListViewController: UIViewController {
+class LoginListViewController: SensitiveViewController {
 
     private lazy var loginSelectionController: ListSelectionController = {
         return ListSelectionController(tableView: self.tableView)

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -466,6 +466,7 @@ class LoginsSetting: Setting {
     let profile: Profile
     var tabManager: TabManager!
     weak var navigationController: UINavigationController?
+    weak var settings: AppSettingsTableViewController?
 
     override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
 
@@ -475,6 +476,7 @@ class LoginsSetting: Setting {
         self.profile = settings.profile
         self.tabManager = settings.tabManager
         self.navigationController = settings.navigationController
+        self.settings = settings as? AppSettingsTableViewController
 
         let loginsTitle = NSLocalizedString("Logins", comment: "Label used as an item in Settings. When touched, the user will be navigated to the Logins/Password manager.")
         super.init(title: NSAttributedString(string: loginsTitle, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]),
@@ -483,7 +485,7 @@ class LoginsSetting: Setting {
 
     override func onClick(_: UINavigationController?) {
         guard let authInfo = KeychainWrapper.authenticationInfo() else {
-            navigateToLoginsList()
+            settings?.navigateToLoginsList()
             return
         }
 
@@ -491,28 +493,14 @@ class LoginsSetting: Setting {
             AppAuthenticator.presentAuthenticationUsingInfo(authInfo,
             touchIDReason: AuthenticationStrings.loginsTouchReason,
             success: {
-                self.navigateToLoginsList()
+                self.settings?.navigateToLoginsList()
             },
             cancel: nil,
             fallback: {
-                AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self)
+                AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self.settings)
             })
         } else {
-            self.navigateToLoginsList()
-        }
-    }
-
-    private func navigateToLoginsList() {
-        let viewController = LoginListViewController(profile: profile)
-        viewController.settingsDelegate = delegate
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
-
-extension LoginsSetting: PasscodeEntryDelegate {
-    @objc func passcodeValidationDidSucceed() {
-        navigationController?.dismissViewControllerAnimated(true) {
-            self.navigateToLoginsList()
+            settings?.navigateToLoginsList()
         }
     }
 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -493,6 +493,7 @@ class LoginsSetting: Setting {
             success: {
                 self.navigateToLoginsList()
             },
+            cancel: nil,
             fallback: {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self)
             })

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -167,3 +167,19 @@ class AppSettingsTableViewController: SettingsTableViewController {
         return super.tableView(tableView, viewForHeaderInSection: section)
     }
 }
+
+extension AppSettingsTableViewController {
+    func navigateToLoginsList() {
+        let viewController = LoginListViewController(profile: profile)
+        viewController.settingsDelegate = settingsDelegate
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+extension AppSettingsTableViewController: PasscodeEntryDelegate {
+    @objc func passcodeValidationDidSucceed() {
+        navigationController?.dismissViewControllerAnimated(true) {
+            self.navigateToLoginsList()
+        }
+    }
+}

--- a/Client/Frontend/Settings/LoginDetailViewController.swift
+++ b/Client/Frontend/Settings/LoginDetailViewController.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Storage
 import Shared
+import SwiftKeychainWrapper
 
 private enum InfoItem: Int {
     case TitleItem = 0
@@ -25,7 +26,7 @@ private struct LoginDetailUX {
     static let SeparatorHeight: CGFloat = 44
 }
 
-class LoginDetailViewController: UIViewController {
+class LoginDetailViewController: SensitiveViewController {
 
     private let profile: Profile
 

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -127,6 +127,10 @@ class AuthenticationManagerTests: KIFTestCase {
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Require Passcode, Immediately")
 
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForAnimationsToFinish()
+
         let tableView = tester().waitForViewWithAccessibilityIdentifier("AuthenticationManager.passcodeIntervalTableView") as! UITableView
         var immediatelyCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0))!
         var oneHourCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 5, inSection: 0))!
@@ -328,6 +332,7 @@ class AuthenticationManagerTests: KIFTestCase {
 
         // Navigate to logins and input our passcode
         tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Logins")
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
@@ -337,7 +342,12 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Touch ID & Passcode")
 
         // Change the require interval of the passcode
-        tester().tapViewWithAccessibilityLabel("Require Passcode")
+        tester().tapViewWithAccessibilityLabel("Require Passcode, Immediately")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForAnimationsToFinish()
+
         tester().tapRowAtIndexPath(NSIndexPath(forRow: 5, inSection: 0), inTableViewWithAccessibilityIdentifier: "AuthenticationManager.passcodeIntervalTableView")
 
         // Go back to logins and make sure it asks us for the passcode again
@@ -347,6 +357,5 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
         tester().tapViewWithAccessibilityLabel("Cancel")
         tester().tapViewWithAccessibilityLabel("Done")
-        tester().tapViewWithAccessibilityLabel("home")
     }
 }

--- a/UITests/AuthenticationManagerTests.swift
+++ b/UITests/AuthenticationManagerTests.swift
@@ -12,7 +12,7 @@ class AuthenticationManagerTests: KIFTestCase {
 
     override func tearDown() {
         super.tearDown()
-        resetPasscode()
+        PasscodeUtils.resetPasscode()
     }
 
     private func openAuthenticationManager() {
@@ -32,42 +32,16 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Done")
     }
 
-    private func resetPasscode() {
-        KeychainWrapper.setAuthenticationInfo(nil)
-    }
-
-    private func setPasscode(code: String, interval: PasscodeInterval) {
-        let info = AuthenticationKeychainInfo(passcode: code)
-        info.updateRequiredPasscodeInterval(interval)
-        KeychainWrapper.setAuthenticationInfo(info)
-    }
-
-    private func enterPasscodeWithDigits(digits: String) {
-        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex]))
-        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(1)]))
-        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(2)]))
-        tester().tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(3)]))
-    }
-
-    private func waitForPasscodeLabel() {
-        do {
-            try tester().tryFindingViewWithAccessibilityLabel("Passcode")
-            tester().waitForViewWithAccessibilityLabel("Passcode")
-        } catch {
-            tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
-        }
-    }
-
     func testTurnOnPasscodeSetsPasscodeAndInterval() {
-        resetPasscode()
+        PasscodeUtils.resetPasscode()
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Turn Passcode On")
         tester().waitForViewWithAccessibilityLabel("Enter a passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
-        enterPasscodeWithDigits("1337")
-        waitForPasscodeLabel()
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
 
         let info = KeychainWrapper.authenticationInfo()!
         XCTAssertEqual(info.passcode!, "1337")
@@ -77,30 +51,30 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testTurnOffPasscode() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-        enterPasscodeWithDigits("1337")
-        waitForPasscodeLabel()
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
         XCTAssertNil(KeychainWrapper.authenticationInfo())
 
         closeAuthenticationManager()
     }
 
     func testChangePasscode() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Change Passcode")
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
-        enterPasscodeWithDigits("2337")
-        waitForPasscodeLabel()
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
+        tester().waitForViewWithAccessibilityLabel("Touch ID & Passcode")
 
         let info = KeychainWrapper.authenticationInfo()!
         XCTAssertEqual(info.passcode!, "2337")
@@ -109,37 +83,37 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testChangePasscodeShowsErrorStates() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Change Passcode")
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
 
         // Enter wrong passcode
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
 
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 1))
 
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
 
         // Enter same passcode
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityLabel("New passcode must be different than existing code.")
 
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
 
         // Enter mismatched passcode
-        enterPasscodeWithDigits("3337")
+        PasscodeUtils.enterPasscode(tester(), digits: "3337")
         tester().waitForViewWithAccessibilityLabel("Passcodes didn't match. Try again.")
 
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
 
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
 
         let info = KeychainWrapper.authenticationInfo()!
         XCTAssertEqual(info.passcode!, "2337")
@@ -148,13 +122,10 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testChangeRequirePasscodeInterval() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Require Passcode, Immediately")
-
-        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-        enterPasscodeWithDigits("1337")
 
         let tableView = tester().waitForViewWithAccessibilityIdentifier("AuthenticationManager.passcodeIntervalTableView") as! UITableView
         var immediatelyCell = tableView.cellForRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0))!
@@ -183,14 +154,14 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testEnteringLoginsUsingPasscode() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
 
         tester().tapViewWithAccessibilityLabel("Back")
@@ -198,14 +169,14 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testEnteringLoginsUsingPasscodeWithImmediateInterval() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
         tester().tapViewWithAccessibilityLabel("Back")
 
@@ -217,14 +188,14 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testEnteringLoginsUsingPasscodeWithFiveMinutesInterval() {
-        setPasscode("1337", interval: .FiveMinutes)
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
 
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Logins")
 
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
         tester().waitForViewWithAccessibilityIdentifier("Login List")
         tester().tapViewWithAccessibilityLabel("Back")
 
@@ -248,7 +219,7 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testWrongPasscodeDisplaysAttemptsAndMaxError() {
-        setPasscode("1337", interval: .FiveMinutes)
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
 
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
@@ -257,11 +228,11 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
 
         // Enter wrong passcode
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 1))
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
         tester().waitForViewWithAccessibilityLabel(AuthenticationStrings.maximumAttemptsReachedNoTime)
 
         tester().tapViewWithAccessibilityLabel("Cancel")
@@ -269,7 +240,7 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testWrongPasscodeAttemptsPersistAcrossEntryAndConfirmation() {
-        setPasscode("1337", interval: .FiveMinutes)
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
 
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
@@ -278,7 +249,7 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().waitForViewWithAccessibilityLabel("Enter Passcode")
 
         // Enter wrong passcode
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
 
         tester().tapViewWithAccessibilityLabel("Cancel")
@@ -292,22 +263,22 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
 
         // Enter wrong passcode, again
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 1))
         tester().tapViewWithAccessibilityLabel("Cancel")
         closeAuthenticationManager()
     }
 
     func testChangedPasswordMustBeNew() {
-        setPasscode("1337", interval: .FiveMinutes)
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Change Passcode")
 
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
 
         tester().waitForViewWithAccessibilityLabel("Enter a new passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
 
         // Should display error and take us back to first pane
         tester().waitForViewWithAccessibilityLabel("New passcode must be different than existing code.")
@@ -322,10 +293,10 @@ class AuthenticationManagerTests: KIFTestCase {
         tester().tapViewWithAccessibilityLabel("Turn Passcode On")
 
         tester().waitForViewWithAccessibilityLabel("Enter a passcode")
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
 
         tester().waitForViewWithAccessibilityLabel("Re-enter passcode")
-        enterPasscodeWithDigits("1234")
+        PasscodeUtils.enterPasscode(tester(), digits: "1234")
 
         // Should display error and take us back to first pane
         tester().waitForViewWithAccessibilityLabel("Passcodes didn't match. Try again.")
@@ -336,18 +307,46 @@ class AuthenticationManagerTests: KIFTestCase {
     }
 
     func testPasscodeMustBeCorrectWhenRemoving() {
-        setPasscode("1337", interval: .Immediately)
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
 
         openAuthenticationManager()
         tester().tapViewWithAccessibilityLabel("Turn Passcode Off")
 
         tester().waitForViewWithAccessibilityLabel("Enter passcode")
-        enterPasscodeWithDigits("2337")
+        PasscodeUtils.enterPasscode(tester(), digits: "2337")
 
         tester().waitForViewWithAccessibilityLabel(String(format: AuthenticationStrings.incorrectAttemptsRemaining, 2))
 
-        enterPasscodeWithDigits("1337")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().tapViewWithAccessibilityLabel("Touch ID & Passcode")
 
         closeAuthenticationManager()
+    }
+
+    func testChangingIntervalResetsValidationTimer() {
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
+
+        // Navigate to logins and input our passcode
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForViewWithAccessibilityLabel("Logins")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Touch ID & Passcode")
+
+        // Change the require interval of the passcode
+        tester().tapViewWithAccessibilityLabel("Require Passcode")
+        tester().tapRowAtIndexPath(NSIndexPath(forRow: 5, inSection: 0), inTableViewWithAccessibilityIdentifier: "AuthenticationManager.passcodeIntervalTableView")
+
+        // Go back to logins and make sure it asks us for the passcode again
+        tester().tapViewWithAccessibilityLabel("Back")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        tester().tapViewWithAccessibilityLabel("Cancel")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
     }
 }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -6,6 +6,8 @@ import Foundation
 import GCDWebServers
 import Storage
 import WebKit
+import SwiftKeychainWrapper
+import Shared
 
 let LabelAddressAndSearch = "Address and Search"
 
@@ -449,5 +451,24 @@ class DynamicFontUtils {
         let value = UIContentSizeCategoryMedium
         UIApplication.sharedApplication().setValue(value, forKey: "preferredContentSizeCategory")
         tester.waitForTimeInterval(0.3)
+    }
+}
+
+class PasscodeUtils {
+    static func resetPasscode() {
+        KeychainWrapper.setAuthenticationInfo(nil)
+    }
+
+    static func setPasscode(code: String, interval: PasscodeInterval) {
+        let info = AuthenticationKeychainInfo(passcode: code)
+        info.updateRequiredPasscodeInterval(interval)
+        KeychainWrapper.setAuthenticationInfo(info)
+    }
+
+    static func enterPasscode(tester: KIFUITestActor, digits: String) {
+        tester.tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex]))
+        tester.tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(1)]))
+        tester.tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(2)]))
+        tester.tapViewWithAccessibilityLabel(String(digits.characters[digits.startIndex.advancedBy(3)]))
     }
 }

--- a/UITests/LoginManagerTests.swift
+++ b/UITests/LoginManagerTests.swift
@@ -11,6 +11,7 @@ class LoginManagerTests: KIFTestCase {
     private var webRoot: String!
 
     override func setUp() {
+        PasscodeUtils.resetPasscode()
         webRoot = SimplePageServer.start()
         generateLogins()
     }
@@ -18,9 +19,11 @@ class LoginManagerTests: KIFTestCase {
     override func tearDown() {
         super.tearDown()
         clearLogins()
+        PasscodeUtils.resetPasscode()
     }
 
     private func openLoginManager() {
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
         tester().tapViewWithAccessibilityLabel("Menu")
         tester().tapViewWithAccessibilityLabel("Settings")
         tester().tapViewWithAccessibilityLabel("Logins")
@@ -29,6 +32,7 @@ class LoginManagerTests: KIFTestCase {
     private func closeLoginManager() {
         tester().tapViewWithAccessibilityLabel("Back")
         tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
     }
 
     private func generateLogins() {
@@ -661,6 +665,95 @@ class LoginManagerTests: KIFTestCase {
         // Check that edit button has been disabled
         tester().waitForViewWithAccessibilityLabel("Edit", traits: UIAccessibilityTraitNotEnabled)
 
+        closeLoginManager()
+    }
+
+    func testLoginsListPromptsForPasscodeOnReentryFromBackground() {
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+
+        tester().waitForViewWithAccessibilityLabel("Logins")
+        tester().deactivateAppForDuration(3)
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForViewWithAccessibilityLabel("Logins")
+
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testLoginsListPromptsForPasscodeOnReentryFromBackgroundWithDelay() {
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+
+        tester().waitForViewWithAccessibilityLabel("Logins")
+        tester().deactivateAppForDuration(3)
+        tester().waitForViewWithAccessibilityLabel("Logins")
+
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Done")
+        tester().tapViewWithAccessibilityLabel("home")
+    }
+
+    func testLoginsDetailsPromptsForPasscodeOnReentryFromBackground() {
+        PasscodeUtils.setPasscode("1337", interval: .Immediately)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+
+        tester().waitForViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+        tester().tapViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+
+        tester().deactivateAppForDuration(3)
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+        tester().waitForViewWithAccessibilityLabel("a0@email.com")
+
+        tester().tapViewWithAccessibilityLabel("Back")
+        closeLoginManager()
+    }
+
+    func testLoginsDetailsPromptsForPasscodeOnReentryFromBackgroundWithDelay() {
+        PasscodeUtils.setPasscode("1337", interval: .FiveMinutes)
+
+        tester().tapViewWithAccessibilityLabel("Show Tabs")
+        tester().tapViewWithAccessibilityLabel("Menu")
+        tester().tapViewWithAccessibilityLabel("Settings")
+        tester().tapViewWithAccessibilityLabel("Logins")
+
+        tester().waitForViewWithAccessibilityLabel("Enter Passcode")
+        PasscodeUtils.enterPasscode(tester(), digits: "1337")
+
+        tester().waitForViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+        tester().tapViewWithAccessibilityLabel("a0@email.com, http://a0.com")
+
+        tester().deactivateAppForDuration(3)
+
+        tester().waitForViewWithAccessibilityLabel("a0@email.com")
+
+        tester().tapViewWithAccessibilityLabel("Back")
         closeLoginManager()
     }
 }


### PR DESCRIPTION
Whenever the logins list or login detail pages are backgrounded, a blur is applied to hide potentially sensitive information. If a user has Passcode or Touch ID enabled, the user will be prompted for authentication upon returning to the app if the user left from one of these screens. The user will only be prompted if the 'Require Passcode' time interval has expired. By default this interval is set to Immediately which means that if the user returns back to the app while being in a logins screen they will always be prompted for authentication. 

Couple of notes on the code changes:

1. Needed to add another callback to the `AppAuthenticator` authentication method to handle cancelling. Before we could ignore cancels but if a user is looking at a logins page and cancels we want to perform an action (in this case, roll back to the previous screen)

2. When prompting the user for Touch ID, the system fires UIApplicationDidBecomeActiveNotification/UIApplicationDidBecomeActiveNotification notifications when the modal disappears. To differentiate this from a regular background -> foreground, I retain state of when we're showing a prompt using a `promptingForTouchID` boolean. Not the nicest but oh well.

3. The default UIVisualEffect blur and `applyLightBlur` methods on UIImage didn't produce a 'good' blur. I opted for using a more fine-tuned blur so you can see the highlight/colors of the information to know that they are there but are still illegible.