### PR TITLE
Bug 1247906 & 1247908 - ensure reader mode controls displayed in popover on iPhone plus

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2133,7 +2133,7 @@ extension BrowserViewController: ReaderModeDelegate {
 
     // Returning None here makes sure that the Popover is actually presented as a Popover and
     // not as a full-screen modal, which is the default on compact device classes.
-    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return UIModalPresentationStyle.None
     }
 }


### PR DESCRIPTION
Caused by requiring an implementation of the more specific adaptivePresentationStyleForPresentationController delegate method that takes a UITraitCollection as an argument

https://bugzilla.mozilla.org/show_bug.cgi?id=1247908
https://bugzilla.mozilla.org/show_bug.cgi?id=1247906