### PR TITLE
(v4.x only) No Bug - Updated Today extension widget with proper version

### DIFF
--- a/Extensions/Today/Info.plist
+++ b/Extensions/Today/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Looks like the version for the Today widget wasn't updated to 4.0.0 on the v4.x branch. This fixes that.