### PR TITLE
Bug 1261457 - Rich text editor fails because requests to about:blank are blocked

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1823,6 +1823,12 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        // Fixes 1261457 - Rich text editor fails because requests to about:blank are blocked
+        if url.scheme == "about" && url.resourceSpecifier == "blank" {
+            decisionHandler(WKNavigationActionPolicy.Allow)
+            return
+        }
+
         // First special case are some schemes that are about Calling. We prompt the user to confirm this action. This
         // gives us the exact same behaviour as Safari. The only thing we do not do is nicely format the phone number,
         // instead we present it as it was put in the URL.


### PR DESCRIPTION
This patch adds a special case for `about:blank` to the 'should we load this url' decision handler.

It looks like `about:blank` is used to reset an iframe. We used to load these, but after https://github.com/mozilla/firefox-ios/pull/1576 (Bug 1251507 - Safari parity for url and scheme handling) we started to ignore them. That was a mistake :-/

This patch simply special cases `about:blank` and lets the `WKWebView` load them.

🎱 