### PR TITLE
Bug 1257538 - Prevents empty states in History/Bookmark panel from having their tex…

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -118,7 +118,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         welcomeLabel.textAlignment = NSTextAlignment.Center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         welcomeLabel.textColor = BookmarksPanelUX.WelcomeScreenItemTextColor
-        welcomeLabel.numberOfLines = 2
+        welcomeLabel.numberOfLines = 0
         welcomeLabel.adjustsFontSizeToFitWidth = true
 
         welcomeLabel.snp_makeConstraints { make in

--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -208,7 +208,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         welcomeLabel.textAlignment = NSTextAlignment.Center
         welcomeLabel.font = DynamicFontHelper.defaultHelper.DeviceFontLight
         welcomeLabel.textColor = HistoryPanelUX.WelcomeScreenItemTextColor
-        welcomeLabel.numberOfLines = 2
+        welcomeLabel.numberOfLines = 0
         welcomeLabel.adjustsFontSizeToFitWidth = true
 
         welcomeLabel.snp_makeConstraints { make in


### PR DESCRIPTION
…t made too small.

Both panel's empty states were set to an explicit 2 lines. In certain locals more than 2 lines are required and in those cases even though there is enough room the text would be resized to fit.