### PR TITLE
Bug 1261854 - Crash: Client: specialized ReaderMode.userContentController()

### DIFF
--- a/Client/Frontend/Reader/ReaderMode.swift
+++ b/Client/Frontend/Reader/ReaderMode.swift
@@ -249,7 +249,9 @@ class ReaderMode: BrowserHelper {
     private func handleReaderPageEvent(readerPageEvent: ReaderPageEvent) {
         switch readerPageEvent {
             case .PageShow:
-                delegate?.readerMode(self, didDisplayReaderizedContentForBrowser: browser!)
+                if let browser = browser {
+                    delegate?.readerMode(self, didDisplayReaderizedContentForBrowser: browser)
+                }
         }
     }
 


### PR DESCRIPTION
This makes the code a bit more robust to prevent a crash in `ReaderMode.userContentController()`.