### PR TITLE
Bug 1264748 - TabManager thread safety

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -396,15 +396,17 @@ class TabManager : NSObject {
     }
 
     func prefsDidChange() {
-        let allowPopups = !(self.prefs.boolForKey("blockPopups") ?? true)
-        // Each tab may have its own configuration, so we should tell each of them in turn.
-        for tab in tabs {
-            tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
-        }
-        // The default tab configurations also need to change.
-        self.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
-        if #available(iOS 9, *) {
-            self.privateConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+        dispatch_async(dispatch_get_main_queue()) {
+            let allowPopups = !(self.prefs.boolForKey("blockPopups") ?? true)
+            // Each tab may have its own configuration, so we should tell each of them in turn.
+            for tab in self.tabs {
+                tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            }
+            // The default tab configurations also need to change.
+            self.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            if #available(iOS 9, *) {
+                self.privateConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+            }
         }
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -86,10 +86,14 @@ class TabManager : NSObject {
     var selectedIndex: Int { return _selectedIndex }
 
     var normalTabs: [Browser] {
+        assert(NSThread.isMainThread())
+
         return tabs.filter { !$0.isPrivate }
     }
 
     var privateTabs: [Browser] {
+        assert(NSThread.isMainThread())
+
         if #available(iOS 9, *) {
             return tabs.filter { $0.isPrivate }
         } else {
@@ -98,6 +102,8 @@ class TabManager : NSObject {
     }
 
     init(defaultNewTabRequest: NSURLRequest, prefs: Prefs, imageStore: DiskImageStore?) {
+        assert(NSThread.isMainThread())
+
         self.prefs = prefs
         self.defaultNewTabRequest = defaultNewTabRequest
         self.navDelegate = TabManagerNavDelegate()
@@ -114,14 +120,20 @@ class TabManager : NSObject {
     }
 
     func addNavigationDelegate(delegate: WKNavigationDelegate) {
+        assert(NSThread.isMainThread())
+
         self.navDelegate.insert(delegate)
     }
 
     var count: Int {
+        assert(NSThread.isMainThread())
+
         return tabs.count
     }
 
     var selectedTab: Browser? {
+        assert(NSThread.isMainThread())
+
         if !(0..<count ~= _selectedIndex) {
             return nil
         }
@@ -130,6 +142,8 @@ class TabManager : NSObject {
     }
 
     subscript(index: Int) -> Browser? {
+        assert(NSThread.isMainThread())
+
         if index >= tabs.count {
             return nil
         }
@@ -137,6 +151,8 @@ class TabManager : NSObject {
     }
 
     subscript(webView: WKWebView) -> Browser? {
+        assert(NSThread.isMainThread())
+
         for tab in tabs {
             if tab.webView === webView {
                 return tab
@@ -147,6 +163,8 @@ class TabManager : NSObject {
     }
 
     func getTabFor(url: NSURL) -> Browser? {
+        assert(NSThread.isMainThread())
+
         for tab in tabs {
             if (tab.webView?.URL == url) {
                 return tab
@@ -181,6 +199,8 @@ class TabManager : NSObject {
     }
 
     func expireSnackbars() {
+        assert(NSThread.isMainThread())
+
         for tab in tabs {
             tab.expireSnackbars()
         }
@@ -210,6 +230,8 @@ class TabManager : NSObject {
     }
 
     func addTabsForURLs(urls: [NSURL], zombie: Bool) {
+        assert(NSThread.isMainThread())
+
         if urls.isEmpty {
             return
         }
@@ -252,6 +274,8 @@ class TabManager : NSObject {
     }
 
     func configureTab(tab: Browser, request: NSURLRequest?, flushToDisk: Bool, zombie: Bool) {
+        assert(NSThread.isMainThread())
+
         for delegate in delegates {
             delegate.get()?.tabManager(self, didCreateTab: tab)
         }
@@ -346,6 +370,8 @@ class TabManager : NSObject {
     }
 
     func getIndex(tab: Browser) -> Int {
+        assert(NSThread.isMainThread())
+
         for i in 0..<count {
             if tabs[i] === tab {
                 return i
@@ -357,6 +383,8 @@ class TabManager : NSObject {
     }
 
     func getTabForURL(url: NSURL) -> Browser? {
+        assert(NSThread.isMainThread())
+
         return tabs.filter { $0.webView?.URL == url } .first
     }
 
@@ -381,6 +409,8 @@ class TabManager : NSObject {
     }
 
     func resetProcessPool() {
+        assert(NSThread.isMainThread())
+
         configuration.processPool = WKProcessPool()
     }
 }
@@ -413,6 +443,8 @@ extension TabManager {
         }
 
         init?(browser: Browser, isSelected: Bool) {
+            assert(NSThread.isMainThread())
+
             self.screenshotUUID = browser.screenshotUUID
             self.isSelected = isSelected
             self.title = browser.displayTitle
@@ -479,6 +511,8 @@ extension TabManager {
     }
 
     private func preserveTabsInternal() {
+        assert(NSThread.isMainThread())
+
         guard !isRestoring else { return }
 
         let path = TabManager.tabsStateArchivePath()
@@ -645,6 +679,8 @@ extension TabManager : WKNavigationDelegate {
 
 extension TabManager {
     class func tabRestorationDebugInfo() -> String {
+        assert(NSThread.isMainThread())
+
         let tabs = TabManager.tabsToRestore()?.map { $0.jsonDictionary } ?? []
         do {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(tabs, options: [.PrettyPrinted])


### PR DESCRIPTION
As mentioned in [bug 1250153](https://bugzilla.mozilla.org/show_bug.cgi?id=1250153), `TabManager` isn't thread-safe, so it'd be a good idea to enforce that its methods be used only on the main thread.

I was pretty aggressive in adding assertions to any method that touched shared state in `TabManager`. Since assertions aren't executed on non-debug builds, this shouldn't cost us anything.