### PR TITLE
Bug 1263627 - Create PrivilegedRequest to guard requests against local web server

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		D3BE7B481B05596800641031 /* AuroraAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B471B05596800641031 /* AuroraAppDelegate.swift */; };
 		D3BF8CBB1B7425570007AFE6 /* DiskImageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */; };
 		D3C03E471C3C7C1500A07D5C /* MenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C03E461C3C7C1500A07D5C /* MenuHelper.swift */; };
+		D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */; };
 		D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */; };
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
@@ -1396,6 +1397,7 @@
 		D3BF8CBA1B7425570007AFE6 /* DiskImageStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskImageStore.swift; sourceTree = "<group>"; };
 		D3BF8CBC1B7472FA0007AFE6 /* DiskImageStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskImageStoreTests.swift; sourceTree = "<group>"; };
 		D3C03E461C3C7C1500A07D5C /* MenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuHelper.swift; sourceTree = "<group>"; };
+		D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalRequestHelper.swift; sourceTree = "<group>"; };
 		D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreTests.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
@@ -2497,6 +2499,7 @@
 				0BF42D361A7C0B8E00889E28 /* FaviconManager.swift */,
 				D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */,
 				D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */,
+				D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */,
 				0BB5B30A1AC0AD1F0052877D /* LoginsHelper.swift */,
 				7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
@@ -4433,6 +4436,7 @@
 				7B59FC441C68E9B600F58EF5 /* SWTableViewCell.m in Sources */,
 				E4A960061ABB9C450069AD6F /* ReaderModeUtils.swift in Sources */,
 				D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */,
+				D3C3696E1CC6B78800348A61 /* LocalRequestHelper.swift in Sources */,
 				E4B423DD1ABA0318007E66C8 /* ReaderModeHandlers.swift in Sources */,
 				7B0B1B9D1C1B6A3F00DF4AB5 /* InstructionsViewController.swift in Sources */,
 				D308E4E41A5306F500842685 /* SearchEngines.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */; };
 		D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314E7F51A37B98700426A76 /* BrowserToolbar.swift */; };
 		D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
+		D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */; };
 		D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */; };
 		D32109941B8CFD62006D5B74 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		D328175B1BD07BA900185845 /* NSCharacterSetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32817591BD07B6F00185845 /* NSCharacterSetExtensions.swift */; };
@@ -1342,6 +1343,7 @@
 		D313BE971B2F5096009EF241 /* DomainAutocompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTests.swift; sourceTree = "<group>"; };
 		D314E7F51A37B98700426A76 /* BrowserToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
 		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
+		D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivilegedRequest.swift; sourceTree = "<group>"; };
 		D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotHelper.swift; sourceTree = "<group>"; };
 		D32817591BD07B6F00185845 /* NSCharacterSetExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCharacterSetExtensions.swift; sourceTree = "<group>"; };
 		D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSwiftData.swift; sourceTree = "<group>"; };
@@ -1907,12 +1909,12 @@
 				288501FA1AC0F63800E7F670 /* NSScannerExtensions.swift */,
 				E6F9659D1B2F63A20034B023 /* NSStringExtensions.swift */,
 				2891CEC31ADC7F2900427D3C /* NSURLExtensions.swift */,
+				E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */,
 				28532D0B1C4837F1000072D9 /* SetExtensions.swift */,
 				2F13E77E1AC0BFF200D75081 /* StringExtensions.swift */,
 				D35275151AA8D13B00E9C906 /* UIColorExtensions.swift */,
 				0BB5B2BB1AC0AB9F0052877D /* UIImageExtensions.swift */,
 				0B5142CB1AE1BAF50014D0B3 /* UIViewExtensions.swift */,
-				E6D749001C4688D800C66ABA /* NSURLProtectionSpaceExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2499,6 +2501,7 @@
 				7BA8D1C61BA037F500C8AE9E /* OpenPdfHelper.swift */,
 				D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */,
 				E47536EC1C85412C0022CC69 /* PrintHelper.swift */,
+				D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */,
 				E47616C61AB74CA600E7DD25 /* ReaderModeBarView.swift */,
 				D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */,
 				D308E4E31A5306F500842685 /* SearchEngines.swift */,
@@ -2510,8 +2513,8 @@
 				E65AB12B1B7CDADF00C2B47A /* SessionRestoreHelper.swift */,
 				E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */,
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
-				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				7BA0601A1C0F4DE200DFADB6 /* TabPeekViewController.swift */,
+				D301AAED1A3A55B70078DD1D /* TabTrayController.swift */,
 				D3C744CC1A687D6C004CE85D /* URIFixup.swift */,
 				0BF0DB931A8545800039F300 /* URLBarView.swift */,
 				E4ECD0871B70FD4F00B90D22 /* WindowCloseHelper.swift */,
@@ -4456,6 +4459,7 @@
 				0BB5B2881AC0A2B90052877D /* SnackBar.swift in Sources */,
 				7BEFC6801BFF68C30059C952 /* QuickActions.swift in Sources */,
 				0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */,
+				D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,
 				2F44FC721A9E840300FD20CC /* SettingsNavigationController.swift in Sources */,
 				E69E06BA1C76173D00D0F926 /* RequirePasscodeIntervalViewController.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		D314E7F71A37B98700426A76 /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D314E7F51A37B98700426A76 /* BrowserToolbar.swift */; };
 		D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */; };
 		D31CF65C1CC1959A001D0BD0 /* PrivilegedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */; };
+		D31EC05F1CC57ED80096F4AB /* localhostLoad.html in Resources */ = {isa = PBXBuildFile; fileRef = D31EC05E1CC57ED80096F4AB /* localhostLoad.html */; };
 		D31F95E91AC226CB005C9F3B /* ScreenshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */; };
 		D32109941B8CFD62006D5B74 /* Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCAE21A1ABB51F800877008 /* Storage.framework */; };
 		D328175B1BD07BA900185845 /* NSCharacterSetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32817591BD07B6F00185845 /* NSCharacterSetExtensions.swift */; };
@@ -400,6 +401,7 @@
 		D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
 		D3C744D01A687D6C004CE85D /* URIFixup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C744CC1A687D6C004CE85D /* URIFixup.swift */; };
+		D3CFD3641CC5605B0064AB4A /* SecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CFD3631CC5605B0064AB4A /* SecurityTests.swift */; };
 		D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */; };
 		D3E171C21A841EAD00AB44CD /* KIFHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = D3E171C11A841EAD00AB44CD /* KIFHelper.js */; };
 		D3E1B0B91C3D90440069945A /* MenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C03E461C3C7C1500A07D5C /* MenuHelper.swift */; };
@@ -1345,6 +1347,7 @@
 		D314E7F51A37B98700426A76 /* BrowserToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
 		D31A0FC61A65D6D000DC8C7E /* SearchSuggestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSuggestClient.swift; sourceTree = "<group>"; };
 		D31CF65B1CC1959A001D0BD0 /* PrivilegedRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivilegedRequest.swift; sourceTree = "<group>"; };
+		D31EC05E1CC57ED80096F4AB /* localhostLoad.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = localhostLoad.html; sourceTree = "<group>"; };
 		D31F95E81AC226CB005C9F3B /* ScreenshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotHelper.swift; sourceTree = "<group>"; };
 		D32817591BD07B6F00185845 /* NSCharacterSetExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCharacterSetExtensions.swift; sourceTree = "<group>"; };
 		D32CACEC1AE04DA1000658EB /* TestSwiftData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSwiftData.swift; sourceTree = "<group>"; };
@@ -1400,6 +1403,7 @@
 		D3C3696D1CC6B78800348A61 /* LocalRequestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalRequestHelper.swift; sourceTree = "<group>"; };
 		D3C3EB641B6FF44000388E9A /* SessionRestoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionRestoreTests.swift; sourceTree = "<group>"; };
 		D3C744CC1A687D6C004CE85D /* URIFixup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URIFixup.swift; sourceTree = "<group>"; };
+		D3CFD3631CC5605B0064AB4A /* SecurityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecurityTests.swift; sourceTree = "<group>"; };
 		D3D488581ABB54CD00A93597 /* FileAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAccessorTests.swift; sourceTree = "<group>"; };
 		D3E171C11A841EAD00AB44CD /* KIFHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = KIFHelper.js; sourceTree = "<group>"; };
 		D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearPrivateDataTableViewController.swift; sourceTree = "<group>"; };
@@ -2437,6 +2441,7 @@
 				D39FA16F1A83E62600EE869C /* UITests-Bridging-Header.h */,
 				D343DCFD1C446BDB00D7EEE8 /* findPage.html */,
 				E6B4C3D71C68F55C001F97E8 /* JSPrompt.html */,
+				D31EC05E1CC57ED80096F4AB /* localhostLoad.html */,
 				D34E33021BA793C2006135F0 /* loginForm.html */,
 				0BF8F8D91AEFF1C900E90BC2 /* noTitle.html */,
 				0B6FBAB11AC1F830007EC669 /* numberedPage.html */,
@@ -2454,6 +2459,7 @@
 				D343DCD81C445EE600D7EEE8 /* FindInPageTests.swift */,
 				D39FA1801A83E84900EE869C /* Global.swift */,
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
+				D3CFD3631CC5605B0064AB4A /* SecurityTests.swift */,
 				E6A92ADA1C52A8DA00743291 /* LoginInputTests.swift */,
 				E633E3791C2204BE001FFF6C /* LoginManagerTests.swift */,
 				D39FA1821A83E87900EE869C /* NavigationTests.swift */,
@@ -3891,6 +3897,7 @@
 				D343DCFE1C446BDB00D7EEE8 /* findPage.html in Resources */,
 				0BF8F8DA1AEFF1C900E90BC2 /* noTitle.html in Resources */,
 				D3E171C21A841EAD00AB44CD /* KIFHelper.js in Resources */,
+				D31EC05F1CC57ED80096F4AB /* localhostLoad.html in Resources */,
 				4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4320,6 +4327,7 @@
 				D313BE981B2F5096009EF241 /* DomainAutocompleteTests.swift in Sources */,
 				4F97573C1AFA6F37006ECC24 /* ReaderViewUITests.swift in Sources */,
 				7BB20B6D1B71160200F1657F /* TopSitesTests.swift in Sources */,
+				D3CFD3641CC5605B0064AB4A /* SecurityTests.swift in Sources */,
 				7B59FC401C68E9B600F58EF5 /* SWCellScrollView.m in Sources */,
 				D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */,
 				D3C3EB651B6FF44000388E9A /* SessionRestoreTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -96,7 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             log.error("Failed to assign AVAudioSession category to allow playing with silent switch on for aural progress bar")
         }
 
-        let defaultRequest = NSURLRequest(URL: UIConstants.DefaultHomePage)
+        let defaultRequest = PrivilegedRequest(URL: UIConstants.DefaultHomePage)
         let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
 
         log.debug("Configuring tabManager…")

--- a/Client/Assets/CertError.html
+++ b/Client/Assets/CertError.html
@@ -15,7 +15,7 @@
         if (fresh)
           fresh = false;
         else
-          location.reload();
+          webkit.messageHandlers.localRequestHelper.postMessage({ type: "reload" });
       });
     </script>
   </head>

--- a/Client/Assets/NetError.html
+++ b/Client/Assets/NetError.html
@@ -15,7 +15,7 @@
         if (fresh)
           fresh = false;
         else
-          location.reload();
+          webkit.messageHandlers.localRequestHelper.postMessage({ type: "reload" });
       });
     </script>
   </head>

--- a/Client/Assets/SessionRestore.html
+++ b/Client/Assets/SessionRestore.html
@@ -27,7 +27,9 @@
           restoreIndex = urlList.length - 1;
       }
 
-      window.location = urlList[restoreIndex];
+      // Forward the URL to the local request helper so we can restore any local pages
+      // that were in the session.
+      webkit.messageHandlers.localRequestHelper.postMessage({ type: "load", url: urlList[restoreIndex] });
 
       // Fire the restore event so that future URL changes are reflected in the UI.
       webkit.messageHandlers.sessionRestoreHelper.postMessage({ name: "didRestoreSession" });

--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -158,7 +158,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
             jsonDict["currentPage"] = currentPage
             let escapedJSON = JSON.stringify(jsonDict, pretty: false).stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet())!
             let restoreURL = NSURL(string: "\(WebServer.sharedInstance.base)/about/sessionrestore?history=\(escapedJSON)")
-            lastRequest = NSURLRequest(URL: restoreURL!)
+            lastRequest = PrivilegedRequest(URL: restoreURL!)
             webView.loadRequest(lastRequest!)
         } else if let request = lastRequest {
             webView.loadRequest(request)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -764,7 +764,7 @@ class BrowserViewController: UIViewController {
             resetSpoofedUserAgentIfRequired(webView, newURL: url)
         }
 
-        if let nav = tab.loadRequest(NSURLRequest(URL: url)) {
+        if let nav = tab.loadRequest(PrivilegedRequest(URL: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }
@@ -1829,6 +1829,12 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
+        if !navigationAction.isAllowed {
+            log.warning("Denying unprivileged request: \(navigationAction.request)")
+            decisionHandler(WKNavigationActionPolicy.Cancel)
+            return
+        }
+
         // First special case are some schemes that are about Calling. We prompt the user to confirm this action. This
         // gives us the exact same behaviour as Safari.
 
@@ -1993,6 +1999,11 @@ private let SchemesAllowedToOpenPopups = ["http", "https", "javascript", "data"]
 extension BrowserViewController: WKUIDelegate {
     func webView(webView: WKWebView, createWebViewWithConfiguration configuration: WKWebViewConfiguration, forNavigationAction navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let currentTab = tabManager.selectedTab else { return nil }
+
+        if !navigationAction.isAllowed {
+            log.warning("Denying unprivileged request: \(navigationAction.request)")
+            return nil
+        }
 
         screenshotHelper.takeScreenshot(currentTab)
 
@@ -2231,7 +2242,7 @@ extension BrowserViewController {
                         try self.readerModeCache.put(currentURL, readabilityResult)
                     } catch _ {
                     }
-                    if let nav = webView.loadRequest(NSURLRequest(URL: readerModeURL)) {
+                    if let nav = webView.loadRequest(PrivilegedRequest(URL: readerModeURL)) {
                         self.ignoreNavigationInTab(tab, navigation: nav)
                     }
                 }
@@ -2730,5 +2741,12 @@ extension BrowserViewController: FindInPageBarDelegate, FindInPageHelperDelegate
 extension BrowserViewController: JSPromptAlertControllerDelegate {
     func promptAlertControllerDidDismiss(alertController: JSPromptAlertController) {
         showQueuedAlertIfAvailable()
+    }
+}
+
+private extension WKNavigationAction {
+    /// Allow local requests only if the request is privileged.
+    private var isAllowed: Bool {
+        return !(request.URL?.isLocal ?? false) || request.isPrivileged
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1456,6 +1456,8 @@ extension BrowserViewController: BrowserDelegate {
         }
         let spotlightHelper = SpotlightHelper(browser: browser, openURL: openURL)
         browser.addHelper(spotlightHelper, name: SpotlightHelper.name())
+
+        browser.addHelper(LocalRequestHelper(), name: LocalRequestHelper.name())
     }
 
     func browser(browser: Browser, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -251,7 +251,7 @@ class ErrorPageHelper {
         }
 
         components.queryItems = queryItems
-        webView.loadRequest(NSURLRequest(URL: components.URL!))
+        webView.loadRequest(PrivilegedRequest(URL: components.URL!))
     }
 
     class func isErrorPageURL(url: NSURL) -> Bool {

--- a/Client/Frontend/Browser/ErrorPageHelper.swift
+++ b/Client/Frontend/Browser/ErrorPageHelper.swift
@@ -160,7 +160,7 @@ class ErrorPageHelper {
             ]
 
             let tryAgain = NSLocalizedString("Try again", tableName: "ErrorPages", comment: "Shown in error pages on a button that will try to load the page again")
-            var actions = "<button onclick='window.location.reload()'>\(tryAgain)</button>"
+            var actions = "<button onclick='webkit.messageHandlers.localRequestHelper.postMessage({ type: \"reload\" })'>\(tryAgain)</button>"
 
             if errDomain == kCFErrorDomainCFNetwork as String {
                 if let code = CFNetworkErrors(rawValue: Int32(errCode)) {

--- a/Client/Frontend/Browser/LocalRequestHelper.swift
+++ b/Client/Frontend/Browser/LocalRequestHelper.swift
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+class LocalRequestHelper: BrowserHelper {
+    func scriptMessageHandlerName() -> String? {
+        return "localRequestHelper"
+    }
+
+    func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        guard message.frameInfo.request.URL?.isLocal ?? false else { return }
+
+        let params = message.body as! [String: String]
+
+        if params["type"] == "load",
+           let url = NSURL(string: params["url"]!) {
+            message.webView?.loadRequest(PrivilegedRequest(URL: url))
+        } else if params["type"] == "reload" {
+            message.webView?.reload()
+        } else {
+            assertionFailure("Invalid message: \(message.body)")
+        }
+    }
+
+    class func name() -> String {
+        return "LocalRequestHelper"
+    }
+}

--- a/Client/Frontend/Browser/PrivilegedRequest.swift
+++ b/Client/Frontend/Browser/PrivilegedRequest.swift
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+private let REQUEST_KEY_PRIVILEGED = "privileged"
+
+/**
+ Request that is allowed to load local resources.
+
+ Pages running on the local server have same origin access all resources
+ on the server, so we need to prevent arbitrary web pages from accessing
+ these resources. We do so by explicitly requiring "privileged" requests
+ in our navigation policy when loading local resources.
+
+ Be careful: creating a privileged request for an arbitrary URL provided
+ by the page will break this model. Only use a privileged request when
+ needed, and when you are sure the URL is from a trustworthy source!
+ **/
+class PrivilegedRequest: NSMutableURLRequest {
+    override init(URL: NSURL, cachePolicy: NSURLRequestCachePolicy, timeoutInterval: NSTimeInterval) {
+        super.init(URL: URL, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
+        setPrivileged()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setPrivileged()
+    }
+
+    private func setPrivileged() {
+        NSURLProtocol.setProperty(true, forKey: REQUEST_KEY_PRIVILEGED, inRequest: self)
+    }
+}
+
+extension NSURLRequest {
+    var isPrivileged: Bool {
+        return NSURLProtocol.propertyForKey(REQUEST_KEY_PRIVILEGED, inRequest: self) != nil
+    }
+}

--- a/Client/Frontend/Browser/SessionRestoreHelper.swift
+++ b/Client/Frontend/Browser/SessionRestoreHelper.swift
@@ -22,6 +22,8 @@ class SessionRestoreHelper: BrowserHelper {
     }
 
     func userContentController(userContentController: WKUserContentController, didReceiveScriptMessage message: WKScriptMessage) {
+        guard AboutUtils.getAboutComponent(message.frameInfo.request.URL) == "sessionrestore" else { return }
+
         if let browser = browser, params = message.body as? [String: AnyObject] {
             if params["name"] as! String == "didRestoreSession" {
                 dispatch_async(dispatch_get_main_queue()) {

--- a/Client/Frontend/Reader/ReaderViewLoading.html
+++ b/Client/Frontend/Reader/ReaderViewLoading.html
@@ -70,7 +70,7 @@
       request.open("GET", "/reader-mode/page-exists" + document.location.search, true);
       request.onload = function() {
         if (request.status == 200) {
-          location.reload(true);
+          webkit.messageHandlers.localRequestHelper.postMessage({ type: "reload" });
         } else {
           triggerCheck();
         }

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -369,6 +369,10 @@ class SimplePageServer {
             return GCDWebServerDataResponse(HTML: self.getPageData("loginForm"))
         }
 
+        webServer.addHandlerForMethod("GET", path: "/localhostLoad.html", requestClass: GCDWebServerRequest.self) { _ in
+            return GCDWebServerDataResponse(HTML: self.getPageData("localhostLoad"))
+        }
+
         webServer.addHandlerForMethod("GET", path: "/auth.html", requestClass: GCDWebServerRequest.self) { (request: GCDWebServerRequest!) in
             // "user:pass", Base64-encoded.
             let expectedAuth = "Basic dXNlcjpwYXNz"

--- a/UITests/SecurityTests.swift
+++ b/UITests/SecurityTests.swift
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import WebKit
+
+class SecurityTests: KIFTestCase {
+    private var webRoot: String!
+
+    override func setUp() {
+        webRoot = SimplePageServer.start()
+        super.setUp()
+    }
+
+    override func beforeEach() {
+        let testURL = "\(webRoot)/localhostLoad.html"
+        tester().tapViewWithAccessibilityIdentifier("url")
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(testURL)\n")
+        tester().waitForViewWithAccessibilityLabel("Web content") as! WKWebView
+        tester().waitForWebViewElementWithAccessibilityLabel("Session exploit")
+    }
+
+    /// Tap the Session exploit button, which tries to load the session restore page on localhost
+    /// in the current tab. Make sure nothing happens.
+    func testSessionExploit() {
+        tester().tapWebViewElementWithAccessibilityLabel("Session exploit")
+        tester().waitForTimeInterval(1)
+
+        // Make sure the URL doesn't change.
+        let webView = tester().waitForViewWithAccessibilityLabel("Web content") as! WKWebView
+        XCTAssertEqual(webView.URL!.path, "/localhostLoad.html")
+
+        // Also make sure the XSS alert doesn't appear.
+        XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))
+    }
+
+    /// Tap the Error exploit button, which tries to load the error page on localhost
+    /// in a new tab via window.open(). Make sure nothing happens.
+    func testErrorExploit() {
+        // We should only have one tab open.
+        tester().waitForTappableViewWithAccessibilityLabel("Show Tabs", value: "1", traits: UIAccessibilityTraitButton)
+
+        tester().tapWebViewElementWithAccessibilityLabel("Error exploit")
+
+        // Make sure a new tab wasn't opened.
+        tester().waitForTappableViewWithAccessibilityLabel("Show Tabs", value: "1", traits: UIAccessibilityTraitButton)
+    }
+
+    /// Tap the New tab exploit button, which tries to piggyback off of an error page
+    /// to load the session restore exploit. A new tab will load showing an error page,
+    /// but we shouldn't be able to load session restore.
+    func testWindowExploit() {
+        tester().tapWebViewElementWithAccessibilityLabel("New tab exploit")
+        tester().waitForTimeInterval(1)
+        let webView = tester().waitForViewWithAccessibilityLabel("Web content") as! WKWebView
+
+        // Make sure the URL doesn't change.
+        XCTAssertEqual(webView.URL!.path, "/errors/error.html")
+
+        // Also make sure the XSS alert doesn't appear.
+        XCTAssertFalse(tester().viewExistsWithLabel("Local page loaded"))
+    }
+
+    override func afterEach() {
+        BrowserUtils.resetToAboutHome(tester())
+    }
+}

--- a/UITests/localhostLoad.html
+++ b/UITests/localhostLoad.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+<script>
+  var json = '{"history":["javascript:alert(\'Local page loaded\')"],"currentPage":-1}';
+  var sessionURL = 'http://localhost:6571/about/sessionrestore?history=' + escape(json);
+  var errorURL = 'http://localhost:6571/errors/error.html?url=nttps://mozilla.com/';
+
+  function newTabExploit() {
+    var win = window.open("http://1.2.3.4.5");
+    setTimeout(function () {
+      win.location.href = sessionURL;
+    }, 500);
+  }
+</script>
+</head>
+<body>
+  <button onclick="document.location=sessionURL">Session exploit</button>
+  <button onclick="window.open(errorURL)">Error exploit</button>
+  <button onclick="newTabExploit()">New tab exploit</button>
+</body>
+</html>

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -223,6 +223,10 @@ extension NSURL {
 
         return false
     }
+
+    public var isLocal: Bool {
+        return host == "localhost" || host == "127.0.0.1"
+    }
 }
 
 //MARK: Private Helpers


### PR DESCRIPTION
This PR requires that requests be explicitly privileged to load `localhost` resources; otherwise, they're denied in `decidePolicyForNavigationAction`. At first I had trouble figuring out a good way to distinguish between `NSURLRequest`s initiated by the browser vs those initiated by a page. Thankfully, `NSURLRequest` is [designed to accept custom properties](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURLRequest_Class/):

> NSURLRequest is designed to be extended to support additional protocols by adding categories that provide accessor methods for your own protocol-specific properties. Those methods can get and set the actual values by calling the NSURLProtocol methods propertyForKey:inRequest: and setProperty:forKey:inRequest:.

With this change, any request to a `localhost` URL (reader mode, error pages, session restore, etc) must be privileged or else it will fail.