### PR TITLE
Bug 1265688 – Cancel editing of URL bar when opening link from without

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -999,6 +999,8 @@ class BrowserViewController: UIViewController {
         if currentViewController != self,
             let _ = forTab {
             self.navigationController?.popViewControllerAnimated(true)
+        } else if urlBar.inOverlayMode {
+            urlBar.SELdidClickCancel()
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1265688

This affects opening links from external apps and today widget. It also affects opening bookmarks from 3DT.

It does not affect opening new tabs.