### PR TITLE
Bug #1266086 - Add support for hidden search engines in list.txt

### DIFF
--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -216,6 +216,10 @@ class SearchEngines {
         var engines = [OpenSearchEngine]()
         let parser = OpenSearchParser(pluginMode: true)
         for engineName in engineNames {
+            // Ignore hidden engines in list.txt
+            if (engineName.endsWith(":hidden")) {
+                continue;
+            }
             // Search the current localized search plugins directory for the search engine.
             // If it doesn't exist, fall back to English.
             var fullPath = (searchDirectory as NSString).stringByAppendingPathComponent("\(engineName).xml")


### PR DESCRIPTION
Android Firefox is going to start using :hidden in list.txt
We need to make sure this works on iOS (right now it crashes).