### PR TITLE
Bug 1266136 – Fixup Today widget margins

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -145,7 +145,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     override func viewDidLayoutSubviews() {
-        let preferredWidth: CGFloat = view.frame.size.width / CGFloat(2 * buttonContainer.subviews.count + 1)
+        let preferredWidth: CGFloat = view.frame.size.width / CGFloat(buttonContainer.subviews.count + 1)
         newPrivateTabButton.label.preferredMaxLayoutWidth = preferredWidth
         newTabButton.label.preferredMaxLayoutWidth = preferredWidth
     }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -9,8 +9,6 @@ import SnapKit
 
 private let log = Logger.browserLogger
 
-
-
 struct TodayUX {
     static let privateBrowsingColor = UIColor(colorString: "CE6EFC")
     static let backgroundHightlightColor = UIColor(white: 216.0/255.0, alpha: 44.0/255.0)

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -132,10 +132,10 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         view.addSubview(openCopiedLinkButton)
 
         openCopiedLinkButton.snp_makeConstraints { make in
-            make.bottom.equalTo(view.snp_bottom)
+            make.top.equalTo(buttonContainer.snp_bottom).offset(TodayUX.verticalWidgetMargin)
             make.width.equalTo(view.snp_width)
             make.centerX.equalTo(view.snp_centerX)
-            make.height.equalTo(buttonContainer.snp_height).multipliedBy(TodayUX.copiedLinkHeightOfButtonMultple)
+            make.height.equalTo(TodayUX.copyLinkButtonHeight)
         }
 
         view.snp_makeConstraints { make in
@@ -267,7 +267,6 @@ class ImageButtonWithLabel: UIView {
         label.snp_makeConstraints { make in
             make.centerX.equalTo(button.snp_centerX)
             make.top.equalTo(button.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2)
-            make.height.lessThanOrEqualTo(button.snp_height)
         }
     }
 
@@ -310,19 +309,19 @@ class ButtonWithSublabel: UIButton {
         self.addSubview(subtitleLabel)
 
         imageView.snp_remakeConstraints { make in
-            make.centerY.equalTo(titleLabel.snp_centerY)
+            make.centerY.equalTo(self.snp_centerY)
             make.left.equalTo(self.snp_left).offset(TodayUX.copyLinkImageHorizontalPadding)
         }
 
         titleLabel.snp_remakeConstraints { make in
-            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin)
+            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2)
             make.left.equalTo(imageView.snp_right).offset(TodayUX.horizontalWidgetMargin).priorityLow()
         }
 
         subtitleLabel.lineBreakMode = .ByTruncatingTail
         subtitleLabel.snp_makeConstraints { make in
             make.left.equalTo(titleLabel.snp_left)
-            make.top.equalTo(titleLabel.snp_bottom)
+            make.top.equalTo(titleLabel.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2)
             make.leading.equalTo(imageView.snp_trailing).offset(TodayUX.horizontalWidgetMargin)
             make.right.lessThanOrEqualTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
         }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -139,8 +139,12 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         }
 
         view.snp_makeConstraints { make in
-            let multiple = !hasCopiedURL ? 1.0 : (1.0 + TodayUX.copiedLinkHeightOfButtonMultple)
-            make.height.equalTo(self.buttonContainer.snp_height).multipliedBy(multiple)
+            if hasCopiedURL {
+                let extraHeight = TodayUX.copyLinkButtonHeight + 2 * TodayUX.verticalWidgetMargin
+                make.height.equalTo(buttonContainer.snp_height).offset(extraHeight)
+            } else {
+                make.height.equalTo(buttonContainer.snp_height)
+            }
         }
     }
 

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -34,13 +34,13 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     private lazy var newTabButton: ImageButtonWithLabel = {
         let imageButton = ImageButtonWithLabel()
         imageButton.addTarget(self, action: #selector(onPressNewTab), forControlEvents: .TouchUpInside)
+        imageButton.labelText = NSLocalizedString("TodayWidget.NewTabButtonLabel", value: "New Tab", tableName: "Today", comment: "New Tab button label")
 
         let button = imageButton.button
         button.setImage(UIImage(named: "new_tab_button_normal"), forState: .Normal)
         button.setImage(UIImage(named: "new_tab_button_highlight"), forState: .Highlighted)
 
         let label = imageButton.label
-        label.text = NSLocalizedString("TodayWidget.NewTabButtonLabel", value: "New Tab", tableName: "Today", comment: "New Tab button label")
         label.textColor = UIColor.whiteColor()
         label.font = UIFont.systemFontOfSize(TodayUX.imageButtonTextSize)
 
@@ -51,13 +51,13 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     private lazy var newPrivateTabButton: ImageButtonWithLabel = {
         let imageButton = ImageButtonWithLabel()
         imageButton.addTarget(self, action: #selector(onPressNewPrivateTab), forControlEvents: .TouchUpInside)
+        imageButton.labelText = NSLocalizedString("TodayWidget.NewPrivateTabButtonLabel", value: "New Private Tab", tableName: "Today", comment: "New Private Tab button label")
 
         let button = imageButton.button
         button.setImage(UIImage(named: "new_private_tab_button_normal"), forState: .Normal)
         button.setImage(UIImage(named: "new_private_tab_button_highlight"), forState: .Highlighted)
 
         let label = imageButton.label
-        label.text = NSLocalizedString("TodayWidget.NewPrivateTabButtonLabel", value: "New Private Tab", tableName: "Today", comment: "New Private Tab button label")
         label.textColor = TodayUX.privateBrowsingColor
         label.font = UIFont.systemFontOfSize(TodayUX.imageButtonTextSize)
 
@@ -113,6 +113,15 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             make.right.equalTo(buttonContainer.snp_right)
         }
 
+        newTabButton.label.snp_makeConstraints { make in
+            make.leading.greaterThanOrEqualTo(view)
+        }
+
+        newPrivateTabButton.label.snp_makeConstraints { make in
+            make.trailing.lessThanOrEqualTo(view)
+            make.left.greaterThanOrEqualTo(newTabButton.snp_right).priorityHigh()
+        }
+
         buttonContainer.snp_makeConstraints { make in
             make.width.equalTo(view.snp_width).multipliedBy(TodayUX.buttonContainerMultipleOfScreen)
             make.centerX.equalTo(view.snp_centerX)
@@ -133,6 +142,12 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             let multiple = !hasCopiedURL ? 1.0 : (1.0 + TodayUX.copiedLinkHeightOfButtonMultple)
             make.height.equalTo(self.buttonContainer.snp_height).multipliedBy(multiple)
         }
+    }
+
+    override func viewDidLayoutSubviews() {
+        let preferredWidth: CGFloat = view.frame.size.width / CGFloat(2 * buttonContainer.subviews.count + 1)
+        newPrivateTabButton.label.preferredMaxLayoutWidth = preferredWidth
+        newTabButton.label.preferredMaxLayoutWidth = preferredWidth
     }
 
     func updateCopiedLink() {
@@ -226,6 +241,16 @@ class ImageButtonWithLabel: UIView {
 
     lazy var label = UILabel()
 
+    var labelText: String? {
+        set {
+            label.text = newValue
+            label.sizeToFit()
+        }
+        get {
+            return label.text
+        }
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -250,6 +275,10 @@ class ImageButtonWithLabel: UIView {
             make.width.equalTo(button)
             make.height.equalTo(button)
         }
+
+        label.numberOfLines = 0
+        label.lineBreakMode = .ByWordWrapping
+        label.textAlignment = .Center
 
         label.snp_makeConstraints { make in
             make.centerX.equalTo(button.snp_centerX)

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -136,12 +136,11 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         }
 
         view.snp_makeConstraints { make in
+            var extraHeight = TodayUX.verticalWidgetMargin
             if hasCopiedURL {
-                let extraHeight = TodayUX.copyLinkButtonHeight + 2 * TodayUX.verticalWidgetMargin
-                make.height.equalTo(buttonContainer.snp_height).offset(extraHeight)
-            } else {
-                make.height.equalTo(buttonContainer.snp_height)
+                extraHeight += TodayUX.copyLinkButtonHeight + TodayUX.verticalWidgetMargin
             }
+            make.height.equalTo(buttonContainer.snp_height).offset(extraHeight)
         }
     }
 

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -23,6 +23,7 @@ struct TodayUX {
 
     static let verticalWidgetMargin: CGFloat = 10
     static let horizontalWidgetMargin: CGFloat = 10
+    static let copyLinkImageHorizontalPadding: CGFloat = 22
 
     static let buttonContainerMultipleOfScreen = 0.6
     static let copiedLinkHeightOfButtonMultple = 0.5
@@ -70,10 +71,9 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         button.setTitle(NSLocalizedString("TodayWidget.GoToCopiedLinkLabel", value: "Go to copied link", tableName: "Today", comment: "Go to link on clipboard"), forState: .Normal)
         button.addTarget(self, action: #selector(onPressOpenClibpoard), forControlEvents: .TouchUpInside)
         button.setBackgroundColor(TodayUX.backgroundHightlightColor, forState: .Highlighted)
-
-        button.label.font = UIFont.systemFontOfSize(TodayUX.labelTextSize)
         button.setImage(UIImage(named: "copy_link_icon"), forState: .Normal)
 
+        button.label.font = UIFont.systemFontOfSize(TodayUX.labelTextSize)
         button.subtitleLabel.font = UIFont.systemFontOfSize(TodayUX.linkTextSize)
 
         return button
@@ -125,7 +125,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         buttonContainer.snp_makeConstraints { make in
             make.width.equalTo(view.snp_width).multipliedBy(TodayUX.buttonContainerMultipleOfScreen)
             make.centerX.equalTo(view.snp_centerX)
-            make.top.equalTo(view.snp_top).offset(10)
+            make.top.equalTo(view.snp_top).offset(TodayUX.verticalWidgetMargin)
             make.height.equalTo(TodayUX.buttonContainerHeight).priorityLow()
         }
 
@@ -283,7 +283,8 @@ class ImageButtonWithLabel: UIView {
 
         label.snp_makeConstraints { make in
             make.centerX.equalTo(button.snp_centerX)
-            make.centerY.equalTo(button.snp_centerY).offset(39)
+            make.top.equalTo(button.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2)
+            make.height.lessThanOrEqualTo(button.snp_height)
         }
     }
 
@@ -327,11 +328,11 @@ class ButtonWithSublabel: UIButton {
 
         imageView.snp_remakeConstraints { make in
             make.centerY.equalTo(titleLabel.snp_centerY)
-            make.left.equalTo(self.snp_left).offset(22)
+            make.left.equalTo(self.snp_left).offset(TodayUX.copyLinkImageHorizontalPadding)
         }
 
         titleLabel.snp_remakeConstraints { make in
-            make.top.equalTo(self.snp_top).offset(10)
+            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin)
             make.left.equalTo(imageView.snp_right).offset(TodayUX.horizontalWidgetMargin).priorityLow()
         }
 
@@ -340,7 +341,7 @@ class ButtonWithSublabel: UIButton {
             make.left.equalTo(titleLabel.snp_left)
             make.top.equalTo(titleLabel.snp_bottom)
             make.leading.equalTo(imageView.snp_trailing).offset(TodayUX.horizontalWidgetMargin)
-            make.right.equalTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
+            make.right.lessThanOrEqualTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
         }
     }
 

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -25,8 +25,8 @@ struct TodayUX {
     static let horizontalWidgetMargin: CGFloat = 10
     static let copyLinkImageHorizontalPadding: CGFloat = 22
 
-    static let buttonContainerMultipleOfScreen = 0.6
     static let copiedLinkHeightOfButtonMultple = 0.5
+    static let buttonContainerMultipleOfScreen = 0.4
 }
 
 @objc (TodayViewController)
@@ -103,14 +103,14 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         buttonContainer.addSubview(newTabButton)
         newTabButton.snp_makeConstraints { make in
             make.top.equalTo(buttonContainer)
-            make.left.equalTo(buttonContainer)
+            make.centerX.equalTo(buttonContainer.snp_left)
         }
 
         // New private tab button and label.
         buttonContainer.addSubview(newPrivateTabButton)
         newPrivateTabButton.snp_makeConstraints { make in
             make.centerY.equalTo(newTabButton.snp_centerY)
-            make.right.equalTo(buttonContainer.snp_right)
+            make.centerX.equalTo(buttonContainer.snp_right)
         }
 
         newTabButton.label.snp_makeConstraints { make in

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -19,6 +19,7 @@ struct TodayUX {
     static let labelTextSize: CGFloat = 14.0
     static let imageButtonTextSize: CGFloat = 14.0
 
+    static let copyLinkButtonHeight: CGFloat = 44
 
     static let verticalWidgetMargin: CGFloat = 10
     static let horizontalWidgetMargin: CGFloat = 10

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -302,12 +302,15 @@ class ButtonWithSublabel: UIButton {
 
         titleLabel.snp_remakeConstraints { make in
             make.top.equalTo(self.snp_top).offset(10)
-            make.left.equalTo(imageView.snp_right).offset(10).priorityLow()
+            make.left.equalTo(imageView.snp_right).offset(TodayUX.horizontalWidgetMargin).priorityLow()
         }
 
+        subtitleLabel.lineBreakMode = .ByTruncatingTail
         subtitleLabel.snp_makeConstraints { make in
             make.left.equalTo(titleLabel.snp_left)
             make.top.equalTo(titleLabel.snp_bottom)
+            make.leading.equalTo(imageView.snp_trailing).offset(TodayUX.horizontalWidgetMargin)
+            make.right.equalTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
         }
     }
 

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -148,7 +148,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     func widgetMarginInsetsForProposedMarginInsets(defaultMarginInsets: UIEdgeInsets) -> UIEdgeInsets {
-        return UIEdgeInsetsMake(0, 0, TodayUX.verticalWidgetMargin, TodayUX.horizontalWidgetMargin)
+        return UIEdgeInsetsMake(0, 0, TodayUX.verticalWidgetMargin, 0)
     }
 
     private func alignButton(leftButton: ImageButtonWithLabel, rightButton: ImageButtonWithLabel) {

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -166,13 +166,6 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         return UIEdgeInsetsMake(0, 0, TodayUX.verticalWidgetMargin, 0)
     }
 
-    private func alignButton(leftButton: ImageButtonWithLabel, rightButton: ImageButtonWithLabel) {
-        rightButton.label.snp_makeConstraints { make in
-            make.centerY.equalTo(leftButton.label.snp_centerY)
-            make.left.equalTo(leftButton.label.snp_right).offset(44).priorityLow()
-        }
-    }
-
     func widgetPerformUpdateWithCompletionHandler(completionHandler: ((NCUpdateResult) -> Void)) {
         // Perform any setup necessary in order to update the view.
         dispatch_async(dispatch_get_main_queue()) {
@@ -182,16 +175,6 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             completionHandler(NCUpdateResult.NewData)
         }
         completionHandler(NCUpdateResult.NewData)
-    }
-
-    // MARK: Button and label creation
-
-    private func createButtonLabel(text: String, color: UIColor = UIColor.whiteColor()) -> UILabel {
-        let label = UILabel()
-        label.text = text
-        label.textColor = color
-        label.font = UIFont.systemFontOfSize(14.0)
-        return label
     }
 
     // MARK: Button behaviour

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -181,6 +181,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             // and we need to call the completion handler in every branch.
             completionHandler(NCUpdateResult.NewData)
         }
+        completionHandler(NCUpdateResult.NewData)
     }
 
     // MARK: Button and label creation

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -19,13 +19,11 @@ struct TodayUX {
     static let labelTextSize: CGFloat = 14.0
     static let imageButtonTextSize: CGFloat = 14.0
 
-    static let buttonContainerHeight = 88
 
     static let verticalWidgetMargin: CGFloat = 10
     static let horizontalWidgetMargin: CGFloat = 10
     static let copyLinkImageHorizontalPadding: CGFloat = 22
 
-    static let copiedLinkHeightOfButtonMultple = 0.5
     static let buttonContainerMultipleOfScreen = 0.4
 }
 
@@ -126,7 +124,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             make.width.equalTo(view.snp_width).multipliedBy(TodayUX.buttonContainerMultipleOfScreen)
             make.centerX.equalTo(view.snp_centerX)
             make.top.equalTo(view.snp_top).offset(TodayUX.verticalWidgetMargin)
-            make.height.equalTo(TodayUX.buttonContainerHeight).priorityLow()
+            make.bottom.equalTo(newPrivateTabButton.label.snp_bottom).priorityLow()
         }
 
         view.addSubview(openCopiedLinkButton)

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -247,7 +247,7 @@ class ImageButtonWithLabel: UIView {
         }
 
         snp_makeConstraints { make in
-            make.width.equalTo(label)
+            make.width.equalTo(button)
             make.height.equalTo(button)
         }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1266136

This PR includes a bunch fit & finish bugs detected after first TestFlight build.

These are: 
 * Adding ellipsis to the end of the URL.
 * Realigning the new tab buttons.
 * Adding multiline labels for the new tab buttons.
 * Moving the button highlight to touch the right hand side of the widget. This is covered in [another PR][1].

 [1]: https://github.com/mozilla/firefox-ios/pull/1726
