### PR TITLE
Bug 1266476 - Implement core telemetry ping

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		D34510881ACF415700EC27F0 /* SearchLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34510871ACF415700EC27F0 /* SearchLoader.swift */; };
 		D34DC8531A16C40C00D49B7B /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		D34E33031BA793C2006135F0 /* loginForm.html in Resources */ = {isa = PBXBuildFile; fileRef = D34E33021BA793C2006135F0 /* loginForm.html */; };
+		D35F558A1CC5A4E000DC0D22 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35F55891CC5A4E000DC0D22 /* Telemetry.swift */; };
 		D36998891AD70A0A00650C6C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36998881AD70A0A00650C6C /* IOKit.framework */; };
 		D37016031BF282450063D032 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB5B2BB1AC0AB9F0052877D /* UIImageExtensions.swift */; };
 		D37524871C6E8B5A00A5F6C2 /* topdomains.txt in Resources */ = {isa = PBXBuildFile; fileRef = D37524861C6E8B5A00A5F6C2 /* topdomains.txt */; };
@@ -398,6 +399,7 @@
 		D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */; };
 		D39949F51C22461A00E2A03C /* RequestDesktopSiteActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39949F41C22461A00E2A03C /* RequestDesktopSiteActivity.swift */; };
 		D3994A4A1C22813200E2A03C /* FindInPageActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3994A491C22813200E2A03C /* FindInPageActivity.swift */; };
+		D39ABDFE1CC6F35F003A319E /* CorePing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35F55871CC5A3E400DC0D22 /* CorePing.swift */; };
 		D39FA16C1A83E17800EE869C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39FA16B1A83E17800EE869C /* CoreGraphics.framework */; };
 		D39FA1811A83E84900EE869C /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1801A83E84900EE869C /* Global.swift */; };
 		D39FA1831A83E87900EE869C /* NavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39FA1821A83E87900EE869C /* NavigationTests.swift */; };
@@ -1401,6 +1403,8 @@
 		D34E33021BA793C2006135F0 /* loginForm.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = loginForm.html; sourceTree = "<group>"; };
 		D35210E01CB2F16600FC5DCB /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Strings.swift; path = ../Client/Frontend/Strings.swift; sourceTree = "<group>"; };
 		D35275151AA8D13B00E9C906 /* UIColorExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
+		D35F55871CC5A3E400DC0D22 /* CorePing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CorePing.swift; path = Telemetry/CorePing.swift; sourceTree = "<group>"; };
+		D35F55891CC5A4E000DC0D22 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Telemetry.swift; path = Telemetry/Telemetry.swift; sourceTree = "<group>"; };
 		D36998881AD70A0A00650C6C /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
 		D37524861C6E8B5A00A5F6C2 /* topdomains.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = topdomains.txt; sourceTree = "<group>"; };
 		D375A91F1AE71675001B30D5 /* ViewMemoryLeakTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewMemoryLeakTests.swift; sourceTree = "<group>"; };
@@ -2029,6 +2033,8 @@
 		28BFA7101C8E5C1A0017C2BD /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				D35F55871CC5A3E400DC0D22 /* CorePing.swift */,
+				D35F55891CC5A4E000DC0D22 /* Telemetry.swift */,
 				28BFA7241C8E5C3F0017C2BD /* TelemetryPing.swift */,
 			);
 			name = Telemetry;
@@ -4242,6 +4248,7 @@
 				288501FB1AC0F63800E7F670 /* NSScannerExtensions.swift in Sources */,
 				E6F9659E1B2F63A20034B023 /* NSStringExtensions.swift in Sources */,
 				E65D89811C8778940006EA35 /* AuthenticationKeychainInfo.swift in Sources */,
+				D35F558A1CC5A4E000DC0D22 /* Telemetry.swift in Sources */,
 				6BE4ACF91B0657180092AEBE /* Accessibility.swift in Sources */,
 				28BFA7251C8E5C3F0017C2BD /* TelemetryPing.swift in Sources */,
 				288A2DAA1AB8B3700023ABC3 /* Box.swift in Sources */,
@@ -4535,6 +4542,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
+				D39ABDFE1CC6F35F003A319E /* CorePing.swift in Sources */,
 				E640E86A1C73A47C00C5F072 /* PasscodeViews.swift in Sources */,
 				E692E3371C46E86A009D1240 /* AppSettingsOptions.swift in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -146,7 +146,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         log.debug("Updating authentication keychain state to reflect system state")
         self.updateAuthenticationInfo()
         SystemUtils.onFirstRun()
-        
+
+        // Send a telemetry ping if the user hasn't disabled reporting.
+        // We still create and log the ping for non-release channels, but we don't submit it.
+        if profile.prefs.boolForKey("settings.sendUsageData") ?? true {
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+                let ping = CorePing(profile: profile)
+                Telemetry.sendPing(ping)
+            }
+        }
+
         log.debug("Done with setting up the application.")
         return true
     }

--- a/Telemetry/CorePing.swift
+++ b/Telemetry/CorePing.swift
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+import UIKit
+
+private let PrefKeyProfileDate = "PrefKeyProfileDate"
+private let PrefKeyPingCount = "PrefKeyPingCount"
+private let PrefKeyClientID = "PrefKeyClientID"
+private let PrefKeyModel = "PrefKeyModel"
+
+// See https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/core-ping.html
+private let PingVersion = 3
+
+class CorePing: TelemetryPing {
+    let payload: JSON
+
+    init(profile: Profile) {
+        let version = NSProcessInfo.processInfo().operatingSystemVersion
+        let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+
+        let pingCount = profile.prefs.intForKey(PrefKeyPingCount) ?? 0
+        profile.prefs.setInt(pingCount + 1, forKey: PrefKeyPingCount)
+
+        let profileDate: Int
+        if let date = profile.prefs.intForKey(PrefKeyProfileDate) {
+            profileDate = Int(date)
+        } else if let attributes = try? NSFileManager.defaultManager().attributesOfItemAtPath(profile.files.rootPath as String),
+                  let date = attributes[NSFileCreationDate] as? NSDate {
+            let seconds = date.timeIntervalSince1970
+            profileDate = Int(UInt64(seconds) * OneSecondInMilliseconds / OneDayInMilliseconds)
+            profile.prefs.setInt(Int32(profileDate), forKey: PrefKeyProfileDate)
+        } else {
+            profileDate = 0
+        }
+
+        let clientID: String
+        if let id = profile.prefs.stringForKey(PrefKeyClientID) {
+            clientID = id
+        } else {
+            clientID = NSUUID().UUIDString
+            profile.prefs.setString(clientID, forKey: PrefKeyClientID)
+        }
+
+        let model: String
+        if let modelString = profile.prefs.stringForKey(PrefKeyModel) {
+            model = modelString
+        } else {
+            var sysinfo = utsname()
+            uname(&sysinfo)
+            let rawModel = NSString(bytes: &sysinfo.machine, length: Int(_SYS_NAMELEN), encoding: NSASCIIStringEncoding)!
+            model = rawModel.stringByTrimmingCharactersInSet(NSCharacterSet.controlCharacterSet())
+            profile.prefs.setString(model, forKey: PrefKeyModel)
+        }
+
+        let locale = NSBundle.mainBundle().preferredLocalizations.first!.stringByReplacingOccurrencesOfString("_", withString: "-")
+
+        let out: [String: AnyObject] = [
+            "v": PingVersion,
+            "clientId": clientID,
+            "seq": Int(pingCount),
+            "locale": locale,
+            "os": "iOS",
+            "osversion": versionString,
+            "device": "Apple-" + model,
+            "arch": "arm",
+            "profileDate": profileDate,
+            "defaultSearch": profile.searchEngines.defaultEngine.shortName,
+        ]
+
+        payload = JSON(out)
+    }
+}

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Alamofire
+import Foundation
+import XCGLogger
+
+private let log = Logger.browserLogger
+private let ServerURL = "https://incoming.telemetry.mozilla.org".asURL!
+private let AppName = "Fennec"
+
+public class Telemetry {
+    public class func sendPing(ping: TelemetryPing) {
+        let payload = ping.payload.toString()
+
+        let docID = NSUUID().UUIDString
+        let docType = "core"
+        let appVersion = NSBundle.mainBundle().infoDictionary!["CFBundleShortVersionString"] as! String
+        let buildID = NSBundle.mainBundle().objectForInfoDictionaryKey(kCFBundleVersionKey as String) as! String
+
+        let channel: String
+        switch AppConstants.BuildChannel {
+        case .Fennec: fallthrough
+        case .Aurora: fallthrough
+        case .Developer: channel = "default"
+        case .Beta: channel = "beta"
+        case .Release: channel = "release"
+        }
+
+        let path = "/submit/telemetry/\(docID)/\(docType)/\(AppName)/\(appVersion)/\(channel)/\(buildID)"
+        let url = ServerURL.URLByAppendingPathComponent(path)
+        let request = NSMutableURLRequest(URL: url)
+
+        log.debug("Ping URL: \(url)")
+        log.debug("Ping payload: \(payload)")
+
+        guard let body = payload.dataUsingEncoding(NSUTF8StringEncoding) else {
+            log.error("Invalid data!")
+            assertionFailure()
+            return
+        }
+
+        guard channel != "default" else {
+            log.debug("Non-release build; not sending ping")
+            return
+        }
+
+        request.HTTPMethod = "POST"
+        request.HTTPBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        Alamofire.Manager.sharedInstance.request(request).response { (request, response, data, error) in
+            log.debug("Ping response: \(response?.statusCode ?? -1).")
+        }
+    }
+}
+
+public protocol TelemetryPing {
+    var payload: JSON { get }
+}


### PR DESCRIPTION
Sends a core ping based on the [spec](https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/core-ping.html).

Some notes:
* The ping is sent on each application startup after a 5 second delay.
* The profile date is determined by looking at the creation date of the profile directory.
* The model is determined using `uname` as described in [this StackOverflow answer](http://stackoverflow.com/a/11197770). As shown there, the model strings will include the model name followed by version/subversion numbers.
* We don't send the pings on developer builds, but we still build/log them to follow release as closely as possible.