### PR TITLE
Bug 1266709 - ensure that we always dismiss the tab tray when opening…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -968,9 +968,8 @@ class BrowserViewController: UIViewController {
     }
 
     func switchToTabForURLOrOpen(url: NSURL, isPrivate: Bool = false) {
-        let tab = tabManager.getTabForURL(url)
-        popToTab(tab)
-        if let tab = tab {
+        popToTab()
+        if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
             openURLInNewTab(url, isPrivate: isPrivate)
@@ -998,16 +997,14 @@ class BrowserViewController: UIViewController {
         urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 
-    private func popToTab(forTab: Tab? = nil) {
+    private func popToBVC() {
         guard let currentViewController = navigationController?.topViewController else {
                 return
         }
         if let presentedViewController = currentViewController.presentedViewController {
             presentedViewController.dismissViewControllerAnimated(false, completion: nil)
         }
-        // if a tab already exists and the top VC is not the BVC then pop the top VC, otherwise don't.
-        if currentViewController != self,
-            let _ = forTab {
+        if currentViewController != self {
             self.navigationController?.popViewControllerAnimated(true)
         } else if urlBar.inOverlayMode {
             urlBar.SELdidClickCancel()


### PR DESCRIPTION
… a tab from 3DT, Today and spotlight

(when opening a blank tab, the test for forTab to be present would fail causing the tab tray not to be dismissed when settings are displayed).

The way to test this I think it to run through every single scenario whereby we open a new tab and ensure the correct thing happens (either blank or an existing tab) through Spotlight, 3D Touch & the today widget (settings displayed above tab tray, settings above tab, tab tray open, tab selected etc).