### PR TITLE
Bug 1266699 - dynamically calculate the menu row height rather than f…

### DIFF
--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -62,6 +62,10 @@ struct AppMenuConfiguration: MenuConfiguration {
         return isPrivateMode ? UIImage(named:"bottomNav-menu-pbm") : UIImage(named:"bottomNav-menu")
     }
 
+    func minMenuRowHeight() -> CGFloat {
+        return 65.0
+    }
+
     func shadowColor() -> UIColor {
         return isPrivateMode ? UIColor.darkGrayColor() : UIColor.lightGrayColor()
     }

--- a/Client/Frontend/Widgets/Menu/MenuConfiguration.swift
+++ b/Client/Frontend/Widgets/Menu/MenuConfiguration.swift
@@ -19,6 +19,7 @@ protocol MenuConfiguration {
     func menuTintColor() -> UIColor
     func menuFont() -> UIFont
     func menuIcon() -> UIImage?
+    func minMenuRowHeight() -> CGFloat
     func shadowColor() -> UIColor
     func selectedItemTintColor() -> UIColor
 }

--- a/Client/Frontend/Widgets/Menu/MenuDelegate.swift
+++ b/Client/Frontend/Widgets/Menu/MenuDelegate.swift
@@ -11,4 +11,6 @@ protocol MenuToolbarItemDelegate {
 
 protocol MenuItemDelegate {
     func menuView(menuView: MenuView, didSelectItemAtIndexPath indexPath: NSIndexPath)
+
+    func heightForRowsInMenuView(menuView: MenuView) -> CGFloat
 }

--- a/Client/Frontend/Widgets/Menu/MenuView.swift
+++ b/Client/Frontend/Widgets/Menu/MenuView.swift
@@ -94,7 +94,7 @@ class MenuView: UIView {
         }
     }
 
-    var menuRowHeight: Float = 65.0 {
+    var menuRowHeight: Float = 0 {
         didSet {
             self.setNeedsLayout()
         }
@@ -321,7 +321,9 @@ class MenuView: UIView {
     private func layoutMenu() {
         let numberOfItemsInRow = CGFloat(menuItemDataSource?.numberOfItemsPerRowInMenuView(self) ?? 0)
         menuPagingLayout.maxNumberOfItemsPerPageRow = Int(numberOfItemsInRow)
-        menuPagingLayout.menuRowHeight = CGFloat(menuRowHeight)
+
+        menuPagingLayout.menuRowHeight = CGFloat(menuItemDelegate?.heightForRowsInMenuView(self) ?? 0)
+        menuRowHeight = Float(menuPagingLayout.menuRowHeight)
 
         menuPagingView.snp_updateConstraints { make in
             let maxNumberOfItemsForPage = CGFloat(self.menuItemDataSource?.menuView(self, numberOfItemsForPage: 0) ?? 0)
@@ -362,12 +364,6 @@ extension MenuView: UICollectionViewDataSource {
 }
 
 extension MenuView: UICollectionViewDelegateFlowLayout {
-
-    func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-        let numberOfItemsInRow = CGFloat(menuItemDataSource?.numberOfItemsPerRowInMenuView(self) ?? 0)
-        let width = ((self.bounds.size.width - itemPadding) - ((numberOfItemsInRow+1) * menuPagingLayout.interitemSpacing)) / numberOfItemsInRow
-        return CGSizeMake(width, CGFloat(menuRowHeight))
-    }
 
     func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
         menuItemDelegate?.menuView(self, didSelectItemAtIndexPath: indexPath)

--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -185,6 +185,30 @@ extension MenuViewController: MenuItemDelegate {
         }
         performMenuAction(menuItem.action, withAnimation: animation, onView: menuItemCell.menuImageView)
     }
+
+    func heightForRowsInMenuView(menuView: MenuView) -> CGFloat {
+        // loop through the labels for the menu items and calculate the largest
+        var largestLabel: CGFloat = 0
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: menuConfig.minMenuRowHeight(), height: 0))
+        label.font = menuConfig.menuFont()
+        for item in menuConfig.menuItems {
+            label.text = item.title
+            let labelHeight = getLabelHeight(label)
+            largestLabel = max(largestLabel, labelHeight + 13)
+        }
+        return max(menuConfig.minMenuRowHeight(), largestLabel)
+    }
+
+    func getLabelHeight(label: UILabel) -> CGFloat {
+
+        guard let labelText = label.text else {
+            return 0
+        }
+        let constraint = CGSizeMake(label.frame.width, CGFloat.max)
+        let context = NSStringDrawingContext()
+        let boundingBox = NSString(string: labelText).boundingRectWithSize(constraint, options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes: [NSFontAttributeName: label.font], context: context).size
+        return ceil(boundingBox.height)
+    }
 }
 
 extension MenuViewController: MenuItemDataSource {


### PR DESCRIPTION
…ixing it to a certain size

This is so that we can expand the row height as the menu text size grows.

There is a magic number adjustment to account for the image icon, but it's the only number that works and I can't see a way to calculate it. Any ideas gratefully received.

https://bugzilla.mozilla.org/show_bug.cgi?id=1266699