### PR TITLE
Bug 1266091 – Escape URLs that contains query params.

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -201,7 +201,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         if let urlString = UIPasteboard.generalPasteboard().string,
             _ = NSURL(string: urlString) {
             let encodedString =
-                urlString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet())!
+                urlString.escape()
             openContainingApp("firefox://?url=\(encodedString)")
         }
     }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1266091

Use `StringExtensions.escape()` so URLs with query params work.