### PR TITLE
Bug 1268263 – Fix double unescaping for firefox://?url URLs.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -248,7 +248,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let params: LaunchParams
 
-        if let url = url, newURL = NSURL(string: url.unescape()) {
+        if let url = url, newURL = NSURL(string: url) {
             params = LaunchParams(url: newURL, isPrivate: isPrivate)
         } else {
             params = LaunchParams(url: nil, isPrivate: isPrivate)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1268263