### PR TITLE
Bug 1266628 - Fixes Duplicate characters being added when using origi…

### DIFF
--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -50,10 +50,6 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         }
     }
 
-    var normalizedEnteredText: String {
-        return enteredText.lowercaseString.stringByTrimmingLeadingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
-    }
-
     override var text: String? {
         didSet {
             // SELtextDidChange is not called when directly setting the text property, so fire it manually.
@@ -94,6 +90,10 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
         }
 
         selectedTextRange = textRangeFromPosition(beginningOfDocument, toPosition: beginningOfDocument)
+    }
+
+    private func normalizeString(string: String) -> String {
+        return string.lowercaseString.stringByTrimmingLeadingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
     }
 
     /// Commits the completion by setting the text and removing the highlight.
@@ -145,8 +145,9 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
 
     private func removeCompletionIfRequiredForEnteredString(string: String) {
         // If user-entered text does not start with previous suggestion then remove the completion.
+
         let actualEnteredString = enteredText + string
-        if !previousSuggestion.startsWith(normalizedEnteredText) {
+        if !previousSuggestion.startsWith(normalizeString(actualEnteredString)) {
             removeCompletion()
         }
         enteredText = actualEnteredString
@@ -160,8 +161,8 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
             // Check that the length of the entered text is shorter than the length of the suggestion.
             // This ensures that completionActive is true only if there are remaining characters to
             // suggest (which will suppress the caret).
-            if suggestion.startsWith(normalizedEnteredText) && normalizedEnteredText.characters.count < suggestion.characters.count {
-                let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(normalizedEnteredText.characters.count))
+            if suggestion.startsWith(normalizeString(enteredText)) && normalizeString(enteredText).characters.count < suggestion.characters.count {
+                let endingString = suggestion.substringFromIndex(suggestion.startIndex.advancedBy(normalizeString(enteredText).characters.count))
                 let completedAndMarkedString = NSMutableAttributedString(string: enteredText + endingString)
                 completedAndMarkedString.addAttribute(NSBackgroundColorAttributeName, value: highlightColor, range: NSMakeRange(enteredText.characters.count, endingString.characters.count))
                 attributedText = completedAndMarkedString
@@ -189,13 +190,6 @@ class AutocompleteTextField: UITextField, UITextFieldDelegate {
     func textFieldShouldClear(textField: UITextField) -> Bool {
         removeCompletion()
         return autocompleteDelegate?.autocompleteTextFieldShouldClear(self) ?? true
-    }
-
-    override func setMarkedText(markedText: String?, selectedRange: NSRange) {
-        // Clear the autocompletion if any provisionally inserted text has been
-        // entered (e.g., a partial composition from a Japanese keyboard).
-        removeCompletion()
-        super.setMarkedText(markedText, selectedRange: selectedRange)
     }
 
     func SELtextDidChange(textField: UITextField) {


### PR DESCRIPTION
…nal Simplified Chinese.

The issue with this bug was related to the system calling setMarkedText before we had a chance to clear the current markedText url. I fixed the issue by making sure that completionActive is false before setMarkedText is called. This ensures that we wont remove the highlight from a multiInput highlight."