### PR TITLE
Bug 1267602 - Fixes No limit in entering incorrect passcodes after th…

### DIFF
--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -111,6 +111,11 @@ public extension AuthenticationKeychainInfo {
     }
 
     func recordFailedAttempt() {
+        if (self.failedAttempts >= AllowedPasscodeFailedAttempts) {
+            //This is a failed attempt after a lockout period. Reset the lockout state
+            //This prevents failedAttemps from being higher than 3
+            self.resetLockoutState()
+        }
         self.failedAttempts += 1
     }
 


### PR DESCRIPTION
…e first passcode lock out expires.

The bug occurred because the lockout state was never reset after the lockout interval had finished. Allowing failedAttempts to be larger than the numberOfAllowedAttempts.