### PR TITLE
Bug 1268554 - Send the core ping whenever the app is foregrounded

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -147,14 +147,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.updateAuthenticationInfo()
         SystemUtils.onFirstRun()
 
-        // Send a telemetry ping if the user hasn't disabled reporting.
-        // We still create and log the ping for non-release channels, but we don't submit it.
-        if profile.prefs.boolForKey("settings.sendUsageData") ?? true {
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
-                let ping = CorePing(profile: profile)
-                Telemetry.sendPing(ping)
-            }
-        }
+        sendCorePing()
 
         log.debug("Done with setting up the application.")
         return true
@@ -347,6 +340,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // is that this method is only invoked whenever the application is entering the foreground where as 
         // `applicationDidBecomeActive` will get called whenever the Touch ID authentication overlay disappears.
         self.updateAuthenticationInfo()
+
+        sendCorePing()
+    }
+
+    /// Send a telemetry ping if the user hasn't disabled reporting.
+    /// We still create and log the ping for non-release channels, but we don't submit it.
+    private func sendCorePing() {
+        if let profile = profile where (profile.prefs.boolForKey("settings.sendUsageData") ?? true) {
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
+                let ping = CorePing(profile: profile)
+                Telemetry.sendPing(ping)
+            }
+        }
     }
 
     private func updateAuthenticationInfo() {


### PR DESCRIPTION
Was originally going to put this in `applicationDidBecomeActive`, but I found that there are several places where this is called when we probably wouldn't want to send the ping. Examples: sliding down the notification bar, or double-tapping the home button and choosing Firefox when it's already active.

`applicationWillEnterForeground` seems to be called only after the user has explicitly put the app in the background, which is what we want (and pretty much equivalent to Android's `onStart`).