### PR TITLE
Bug 1265345 – Homepage Settings

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
 		39A359E41BFCCE94006B9E87 /* SpotlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */; };
 		39A35AED1C0662A3006B9E87 /* SpotlightHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */; };
+		39AC591A1CC574AB0042C2F5 /* HomePageSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */; };
 		39D9E6851C89E9690071FADA /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B604FA11C495268006EEEC3 /* SnapKit.framework */; };
 		39E65D191CA455A900C63CE3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 391AEFD11C8F11ED00691F84 /* Images.xcassets */; };
 		39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */; };
@@ -1282,6 +1283,7 @@
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
 		39A359E31BFCCE94006B9E87 /* SpotlightHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotlightHelper.swift; path = Helpers/SpotlightHelper.swift; sourceTree = "<group>"; };
 		39A35AEC1C0662A3006B9E87 /* SpotlightHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SpotlightHelper.js; sourceTree = "<group>"; };
+		39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsViewController.swift; sourceTree = "<group>"; };
 		39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducerTests.swift; sourceTree = "<group>"; };
 		39E65D351CA5CAF200C63CE3 /* AsyncReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducer.swift; sourceTree = "<group>"; };
 		4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHistory.swift; sourceTree = "<group>"; };
@@ -2132,14 +2134,15 @@
 			isa = PBXGroup;
 			children = (
 				E692E3361C46E86A009D1240 /* AppSettingsOptions.swift */,
+				E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */,
+				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
+				D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */,
+				39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */,
+				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
+				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
+				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
 				2F44FC711A9E840300FD20CC /* SettingsNavigationController.swift */,
 				2F44FCC41A9E85E900FD20CC /* SettingsTableViewController.swift */,
-				E68E39BD1C46F42000B85F42 /* AppSettingsTableViewController.swift */,
-				2F44FCC61A9E8CF500FD20CC /* SearchSettingsTableViewController.swift */,
-				2F44FCCA1A9E972E00FD20CC /* SearchEnginePicker.swift */,
-				0B62EFD11AD63CD100ACB9CD /* Clearables.swift */,
-				74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */,
-				D3E8EEE71B97A87A001900FB /* ClearPrivateDataTableViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -4648,6 +4651,7 @@
 				D3A9949D1A3686BD008AD1AC /* Tab.swift in Sources */,
 				D3C744CD1A687D6C004CE85D /* URIFixup.swift in Sources */,
 				7BC68D091CC153020043562A /* RoundedToolbar.swift in Sources */,
+				39AC591A1CC574AB0042C2F5 /* HomePageSettingsViewController.swift in Sources */,
 				7B59FC3E1C68E9B600F58EF5 /* SWCellScrollView.m in Sources */,
 				E4A961181AC041C40069AD6F /* ReadabilityService.swift in Sources */,
 				D3BE7B261B054D4400641031 /* main.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		39E65D191CA455A900C63CE3 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 391AEFD11C8F11ED00691F84 /* Images.xcassets */; };
 		39E65D271CA5B92000C63CE3 /* AsyncReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */; };
 		39E65D371CA5CB0E00C63CE3 /* AsyncReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E65D351CA5CAF200C63CE3 /* AsyncReducer.swift */; };
+		39F6D0701CD3B0770055D949 /* HomePageSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */; };
 		4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */; };
 		4F514FD41ACD8F2C0022D7EA /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */; };
 		4F97573B1AFA6F37006ECC24 /* readerContent.html in Resources */ = {isa = PBXBuildFile; fileRef = 4F9757391AFA6F37006ECC24 /* readerContent.html */; };
@@ -1286,6 +1287,7 @@
 		39AC59191CC574AA0042C2F5 /* HomePageSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsViewController.swift; sourceTree = "<group>"; };
 		39E65D261CA5B92000C63CE3 /* AsyncReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducerTests.swift; sourceTree = "<group>"; };
 		39E65D351CA5CAF200C63CE3 /* AsyncReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncReducer.swift; sourceTree = "<group>"; };
+		39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITests.swift; sourceTree = "<group>"; };
 		4A59BF410BBD9B3BE71F4C7C /* TestHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHistory.swift; sourceTree = "<group>"; };
 		4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryTests.swift; sourceTree = "<group>"; };
 		4F9757391AFA6F37006ECC24 /* readerContent.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = readerContent.html; sourceTree = "<group>"; };
@@ -2558,6 +2560,7 @@
 				D343DCD81C445EE600D7EEE8 /* FindInPageTests.swift */,
 				D39FA1801A83E84900EE869C /* Global.swift */,
 				4F514FD31ACD8F2C0022D7EA /* HistoryTests.swift */,
+				39F6D06F1CD3B0770055D949 /* HomePageSettingsUITests.swift */,
 				E6A92ADA1C52A8DA00743291 /* LoginInputTests.swift */,
 				E633E3791C2204BE001FFF6C /* LoginManagerTests.swift */,
 				D39FA1821A83E87900EE869C /* NavigationTests.swift */,
@@ -4439,6 +4442,7 @@
 				2F642CED1AA8FFAF004F8BE8 /* SearchSettingsUITests.swift in Sources */,
 				E640E8701C73BCF500C5F072 /* AuthenticationManagerTests.swift in Sources */,
 				7B59FC491C68E9B600F58EF5 /* SWUtilityButtonTapGestureRecognizer.m in Sources */,
+				39F6D0701CD3B0770055D949 /* HomePageSettingsUITests.swift in Sources */,
 				E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -611,3 +611,26 @@ class ChinaSyncServiceSetting: WithoutAccountSetting {
     }
 }
 
+class HomePageSetting: Setting {
+    let profile: Profile
+    var tabManager: TabManager!
+
+    override var accessoryType: UITableViewCellAccessoryType { return .DisclosureIndicator }
+
+    override var accessibilityIdentifier: String? { return "HomePageSetting" }
+
+    init(settings: SettingsTableViewController) {
+        self.profile = settings.profile
+        self.tabManager = settings.tabManager
+
+        super.init(title: NSAttributedString(string: Strings.SettingsHomePageSectionName, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor]))
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        let viewController = HomePageSettingsViewController()
+        viewController.profile = profile
+        viewController.tabManager = tabManager
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+}

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -43,6 +43,7 @@ class AppSettingsTableViewController: SettingsTableViewController {
         let prefs = profile.prefs
         var generalSettings = [
             SearchSetting(settings: self),
+            HomePageSetting(settings: self),
             BoolSetting(prefs: prefs, prefKey: "blockPopups", defaultValue: true,
                 titleText: NSLocalizedString("Block Pop-up Windows", comment: "Block pop-up windows setting")),
             BoolSetting(prefs: prefs, prefKey: "saveLogins", defaultValue: true,

--- a/Client/Frontend/Settings/HomePageSettingsViewController.swift
+++ b/Client/Frontend/Settings/HomePageSettingsViewController.swift
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Shared
+import SnapKit
+
+private let log = Logger.browserLogger
+
+struct HomePageConstants {
+    static let HomePageURLPrefKey = "homepage.url"
+    static let HomePageButtonIsInMenuPrefKey = "homepage.button.isInMenu"
+    static let DefaultHomePageURLPrefKey = "homepage.url.default"
+}
+
+class HomePageSettingsViewController: SettingsTableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = Strings.SettingsHomePageTitle
+    }
+
+    override func generateSettings() -> [SettingSection] {
+        let prefs = profile.prefs
+
+        func setHomePage(url: NSURL?) -> (UINavigationController? -> ()) {
+            weak var tableView: UITableView? = self.tableView
+            return { nav in
+                if let url = url {
+                    prefs.setString(url.absoluteString, forKey: HomePageConstants.HomePageURLPrefKey)
+                } else {
+                    prefs.removeObjectForKey(HomePageConstants.HomePageURLPrefKey)
+                }
+                tableView?.reloadData()
+            }
+        }
+
+        func isHomePage(url: NSURL?) -> (() -> Bool) {
+            return {
+                return url?.isWebPage() ?? false
+            }
+        }
+
+        func URLFromString(string: String?) -> NSURL? {
+            guard let string = string else {
+                return nil
+            }
+            return NSURL(string: string)
+        }
+
+        let currentTabURL = self.tabManager.selectedTab?.displayURL
+        let clipboardURL = URLFromString(UIPasteboard.generalPasteboard().string)
+        let defaultURL = URLFromString(prefs.stringForKey(HomePageConstants.DefaultHomePageURLPrefKey))
+
+        var basicSettings: [Setting] = [
+            WebPageSetting(prefs: prefs,
+                prefKey: HomePageConstants.HomePageURLPrefKey,
+                placeholder: Strings.SettingsHomePagePlaceholder,
+                accessibilityIdentifier: "HomePageSetting"),
+            ButtonSetting(title: NSAttributedString(string: Strings.SettingsHomePageUseCurrentPage),
+                accessibilityIdentifier: "UseCurrentTab",
+                isEnabled: isHomePage(currentTabURL),
+                onClick: setHomePage(currentTabURL)),
+            ButtonSetting(title: NSAttributedString(string: Strings.SettingsHomePageUseCopiedLink),
+                accessibilityIdentifier: "UseCopiedLink",
+                isEnabled: isHomePage(clipboardURL),
+                onClick: setHomePage(clipboardURL)),
+            ]
+
+        if let _ = defaultURL {
+            basicSettings += [
+                ButtonSetting(title: NSAttributedString(string: Strings.SettingsHomePageUseDefault),
+                    accessibilityIdentifier: "UseDefault",
+                    onClick: setHomePage(defaultURL)),
+                ]
+        }
+
+        basicSettings += [
+            ButtonSetting(title: NSAttributedString(string: Strings.SettingsHomePageClear),
+                destructive: true,
+                accessibilityIdentifier: "ClearHomePage",
+                onClick: setHomePage(nil)),
+            ]
+
+        var settings: [SettingSection] = [
+            SettingSection(title: NSAttributedString(string: Strings.SettingsHomePageURLSectionTitle), children: basicSettings),
+            ]
+
+        if AppConstants.MOZ_MENU {
+            settings += [
+                SettingSection(children: [
+                    BoolSetting(prefs: prefs,
+                        prefKey: HomePageConstants.HomePageButtonIsInMenuPrefKey,
+                        defaultValue: true,
+                        titleText: Strings.SettingsHomePageUIPositionTitle,
+                        statusText: Strings.SettingsHomePageUIPositionSubtitle),
+                    ]),
+                ]
+        }
+
+        return settings
+    }
+}
+
+class WebPageSetting: StringSetting {
+    init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingDidChange: (String? -> Void)? = nil) {
+        super.init(prefs: prefs,
+                   prefKey: prefKey,
+                   defaultValue: defaultValue,
+                   placeholder: placeholder,
+                   accessibilityIdentifier: accessibilityIdentifier,
+                   settingIsValid: WebPageSetting.isURL,
+                   settingDidChange: settingDidChange)
+        textField.keyboardType = .URL
+        textField.autocapitalizationType = .None
+        textField.autocorrectionType = .No
+    }
+
+    static func isURL(string: String?) -> Bool {
+        guard let string = string else {
+            return false
+        }
+        return NSURL(string: string)?.isWebPage() ?? false
+    }
+}

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -15,7 +15,7 @@ private let Bug1204635_S3 = NSLocalizedString("Clear", tableName: "ClearPrivateD
 private let Bug1204635_S4 = NSLocalizedString("Cancel", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to cancel clear private data dialog")
 
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
-class Setting {
+class Setting: NSObject {
     private var _title: NSAttributedString?
 
     weak var delegate: SettingsDelegate?
@@ -25,7 +25,7 @@ class Setting {
 
     // The title shown on the pref.
     var title: NSAttributedString? { return _title }
-    var accessibilityIdentifier: String? { return nil }
+    private(set) var accessibilityIdentifier: String?
 
     // An optional second line of text shown on the pref.
     var status: NSAttributedString? { return nil }
@@ -191,6 +191,132 @@ class BoolSetting: Setting {
     @objc func switchValueChanged(control: UISwitch) {
         prefs.setBool(control.on, forKey: prefKey)
         settingDidChange?(control.on)
+    }
+}
+
+/// A helper class for a setting backed by a UITextField.
+/// This takes an optional settingIsValid and settingDidChange callback
+/// If settingIsValid returns false, the Setting will not change and the text remains red.
+class StringSetting: Setting, UITextFieldDelegate {
+
+    let prefKey: String
+
+    private let prefs: Prefs
+    private let defaultValue: String?
+    private let placeholder: String
+    private let settingDidChange: (String? -> Void)?
+    private let settingIsValid: (String? -> Bool)?
+
+    let textField = UITextField()
+
+    init(prefs: Prefs, prefKey: String, defaultValue: String? = nil, placeholder: String, accessibilityIdentifier: String, settingIsValid isValueValid: (String? -> Bool)? = nil, settingDidChange: (String? -> Void)? = nil) {
+        self.prefs = prefs
+        self.prefKey = prefKey
+        self.defaultValue = defaultValue
+        self.settingDidChange = settingDidChange
+        self.settingIsValid = isValueValid
+        self.placeholder = placeholder
+
+        super.init()
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        if let id = accessibilityIdentifier {
+            textField.accessibilityIdentifier = id + "TextField"
+        }
+        textField.placeholder = placeholder
+        textField.delegate = self
+        textField.addTarget(self, action: #selector(textFieldDidChange), forControlEvents: .EditingChanged)
+
+        cell.accessibilityTraits = UIAccessibilityTraitLink
+        cell.contentView.addSubview(textField)
+
+        let container = UIView()
+        container.addSubview(textField)
+        cell.contentView.addSubview(container)
+
+        cell.contentView.snp_makeConstraints { make in
+            make.height.equalTo(44)
+            make.width.equalTo(cell.snp_width)
+        }
+
+        textField.snp_makeConstraints { make in
+            make.height.equalTo(cell.contentView)
+            make.width.equalTo(cell.contentView).offset(-2 * SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+            make.leading.equalTo(cell.contentView).offset(SettingsTableSectionHeaderFooterViewUX.titleHorizontalPadding)
+        }
+        textField.text = prefs.stringForKey(prefKey) ?? defaultValue
+        textFieldDidChange(textField)
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        textField.becomeFirstResponder()
+    }
+
+    private func isValid(value: String?) -> Bool {
+        return settingIsValid?(value) ?? true
+    }
+
+    @objc func textFieldDidChange(textField: UITextField) {
+        let color = isValid(textField.text) ? UIConstants.TableViewRowTextColor : UIConstants.DestructiveRed
+        textField.textColor = color
+    }
+
+    @objc func textFieldShouldReturn(textField: UITextField) -> Bool {
+        return isValid(textField.text)
+    }
+
+    @objc func textFieldDidEndEditing(textField: UITextField) {
+        let text = textField.text
+        if !isValid(text) {
+            return
+        }
+        if let text = text {
+            prefs.setString(text, forKey: prefKey)
+        } else {
+            prefs.removeObjectForKey(prefKey)
+        }
+        // Call settingDidChange with text or nil.
+        settingDidChange?(text)
+    }
+}
+
+/// A helper class for a setting backed by a UITextField.
+/// This takes an optional isEnabled and mandatory onClick callback
+/// isEnabled is called on each tableview.reloadData. If it returns
+/// false then the 'button' appears disabled.
+class ButtonSetting: Setting {
+    let onButtonClick: (UINavigationController?) -> ()
+    let destructive: Bool
+    let isEnabled: (() -> Bool)?
+
+    init(title: NSAttributedString?, destructive: Bool = false, accessibilityIdentifier: String, isEnabled: (() -> Bool)? = nil, onClick: UINavigationController? -> ()) {
+        self.onButtonClick = onClick
+        self.destructive = destructive
+        self.isEnabled = isEnabled
+        super.init(title: title)
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    override func onConfigureCell(cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+
+        if isEnabled?() ?? true {
+            cell.textLabel?.textColor = destructive ? UIConstants.DestructiveRed : UIConstants.HighlightBlue
+        } else {
+            cell.textLabel?.textColor = UIConstants.TableViewDisabledRowTextColor
+        }
+        cell.textLabel?.textAlignment = NSTextAlignment.Center
+        cell.accessibilityTraits = UIAccessibilityTraitButton
+        cell.selectionStyle = .None
+    }
+
+    override func onClick(navigationController: UINavigationController?) {
+        if isEnabled?() ?? true {
+            onButtonClick(navigationController)
+        }
     }
 }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -57,3 +57,17 @@ extension Strings {
     public static let LoginsHelperDontSaveButtonTitle = NSLocalizedString("LoginsHelper.DontSave.Button", value: "Don’t Save", comment: "Button to not save the user's password")
     public static let LoginsHelperUpdateButtonTitle = NSLocalizedString("LoginsHelper.Update.Button", value: "Update", comment: "Button to update the user's password")
 }
+
+// Home page.
+extension Strings {
+    public static let SettingsHomePageSectionName = NSLocalizedString("Settings.HomePage.SectionName", value: "Homepage", comment: "Label used as an item in Settings. When touched it will open a dialog to configure the home page and its uses.")
+    public static let SettingsHomePageTitle = NSLocalizedString("Settings.HomePage.Title", value: "Homepage Settings", comment: "Title displayed in header of the setting panel.")
+    public static let SettingsHomePageUIPositionTitle = NSLocalizedString("Settings.HomePage.UI.Toggle.Title", value: "Show Homepage icon in menu", comment: "Toggle setting to show home page button in menu, or on toolbar.")
+    public static let SettingsHomePageUIPositionSubtitle = NSLocalizedString("Settings.HomePage.UI.Toggle.Subtitle", value: "Requires a restart to take effect", comment: "Toggle setting to show home page button in menu, or on toolbar.")
+    public static let SettingsHomePageURLSectionTitle = NSLocalizedString("Settings.HomePage.URL.Title", value: "Current Homepage", comment: "Title of the setting section containing the URL of the current home page.")
+    public static let SettingsHomePageUseCurrentPage = NSLocalizedString("Settings.HomePage.UseCurrent.Button", value: "Use Current Page", comment: "Button in settings to use the current page as home page.")
+    public static let SettingsHomePagePlaceholder = NSLocalizedString("Settings.HomePage.URL.Placeholder", value: "Enter a webpage", comment: "Placeholder text in the homepage setting when no homepage has been set.")
+    public static let SettingsHomePageUseCopiedLink = NSLocalizedString("Settings.HomePage.UseCopiedLink.Button", value: "Use Copied Link", comment: "Button in settings to use the current link on the clipboard as home page.")
+    public static let SettingsHomePageUseDefault = NSLocalizedString("Settings.HomePage.UseDefault.Button", value: "Use Default", comment: "Button in settings to use the default home page. If no default is set, then this button isn't shown.")
+    public static let SettingsHomePageClear = NSLocalizedString("Settings.HomePage.Clear.Button", value: "Clear", comment: "Button in settings to clear the home page.")
+}

--- a/UITests/Global.swift
+++ b/UITests/Global.swift
@@ -451,3 +451,26 @@ class DynamicFontUtils {
         tester.waitForTimeInterval(0.3)
     }
 }
+
+class HomePageUtils {
+    static func navigateToHomePageSettings(tester: KIFUITestActor) {
+        tester.waitForAnimationsToFinish()
+        tester.tapViewWithAccessibilityLabel("Menu")
+        tester.tapViewWithAccessibilityLabel("Settings")
+        tester.tapViewWithAccessibilityIdentifier("HomePageSetting")
+    }
+
+    static func homePageSetting(tester: KIFUITestActor) -> String? {
+        let view = tester.waitForViewWithAccessibilityIdentifier("HomePageSettingTextField")
+        guard let textField = view as? UITextField else {
+            XCTFail("View is not a textField: view is \(view)")
+            return nil
+        }
+        return textField.text
+    }
+
+    static func navigateFromHomePageSettings(tester: KIFUITestActor) {
+        tester.tapViewWithAccessibilityLabel("Settings")
+        tester.tapViewWithAccessibilityLabel("Done")
+    }
+}

--- a/UITests/HomePageSettingsUITests.swift
+++ b/UITests/HomePageSettingsUITests.swift
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+class HomePageSettingsUITests: KIFTestCase {
+
+    private var webRoot: String!
+
+    override func setUp() {
+        webRoot = SimplePageServer.start()
+        UIPasteboard.generalPasteboard().string = " "
+    }
+
+    func testNavigation() {
+        HomePageUtils.navigateToHomePageSettings(tester())
+        // if we can't find the home paget text view, then this will time out.
+        tester().tapViewWithAccessibilityIdentifier("HomePageSetting")
+        HomePageUtils.navigateFromHomePageSettings(tester())
+    }
+
+    func testTyping() {
+        HomePageUtils.navigateToHomePageSettings(tester())
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        XCTAssertEqual("", HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("HomePageSetting")
+
+        let webPageString = "http://www.mozilla.com/typing"
+        tester().enterTextIntoCurrentFirstResponder(webPageString)
+        XCTAssertEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        // check if it's saved
+        HomePageUtils.navigateFromHomePageSettings(tester())
+        HomePageUtils.navigateToHomePageSettings(tester())
+        XCTAssertEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        // teardown.
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        HomePageUtils.navigateFromHomePageSettings(tester())
+    }
+
+    func testTypingBadURL() {
+        HomePageUtils.navigateToHomePageSettings(tester())
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        XCTAssertEqual("", HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("HomePageSetting")
+
+        let webPageString = "not a webpage"
+        tester().enterTextIntoCurrentFirstResponder(webPageString)
+        XCTAssertEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        // check if it's saved
+        HomePageUtils.navigateFromHomePageSettings(tester())
+        HomePageUtils.navigateToHomePageSettings(tester())
+        XCTAssertNotEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        // teardown.
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        HomePageUtils.navigateFromHomePageSettings(tester())
+    }
+
+    func testCurrentPage() {
+        let webPageString = "\(webRoot)/numberedPage.html?page=1"
+        tester().tapViewWithAccessibilityIdentifier("url")
+
+        tester().clearTextFromAndThenEnterTextIntoCurrentFirstResponder("\(webPageString)\n")
+        tester().waitForWebViewElementWithAccessibilityLabel("Page 1")
+
+        // now go to settings.
+        HomePageUtils.navigateToHomePageSettings(tester())
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        XCTAssertEqual("", HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("UseCurrentTab")
+        XCTAssertEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        HomePageUtils.navigateFromHomePageSettings(tester())
+        BrowserUtils.resetToAboutHome(tester())
+    }
+
+    func testClipboard() {
+        let webPageString = "https://www.mozilla.org/clipboard"
+        UIPasteboard.generalPasteboard().string = webPageString
+        HomePageUtils.navigateToHomePageSettings(tester())
+
+        tester().tapViewWithAccessibilityIdentifier("UseCopiedLink")
+        XCTAssertEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        XCTAssertEqual("", HomePageUtils.homePageSetting(tester()))
+        HomePageUtils.navigateFromHomePageSettings(tester())
+    }
+
+
+    func testDisabledClipboard() {
+        let webPageString = "not a url"
+        UIPasteboard.generalPasteboard().string = webPageString
+        HomePageUtils.navigateToHomePageSettings(tester())
+
+        tester().tapViewWithAccessibilityIdentifier("UseCopiedLink")
+        XCTAssertNotEqual(webPageString, HomePageUtils.homePageSetting(tester()))
+
+        tester().tapViewWithAccessibilityIdentifier("ClearHomePage")
+        XCTAssertEqual("", HomePageUtils.homePageSetting(tester()))
+        HomePageUtils.navigateFromHomePageSettings(tester())
+    }
+
+
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1265345

This adds a minimally functional settings page to make the rest of the feature work. This is a simple text field, with buttons to fill it with a link on the clipboard, the current page, to clear and to replace with a default.

It uses existing settings pages, and adds additional Settings widgets: `ButtonSetting` and `StringSetting`.

Support is added for setting a default homepage (e.g. a locale specific homepage) within the settings page.