### PR TITLE
Bug 1223162 - Created base notifications view controller and notification in status bar area when syncing

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		E663D5781BB341C4001EF30E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D5771BB341C4001EF30E /* ToggleButton.swift */; };
 		E66464911C10CA9C00AF05CE /* SearchInputViewRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66464901C10CA9C00AF05CE /* SearchInputViewRefTests.swift */; };
 		E66464EE1C10D98000AF05CE /* AssertionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66464ED1C10D98000AF05CE /* AssertionUtils.swift */; };
+		E664B45A1CD7ECDB0045A6A4 /* NotificationRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */; };
 		E66C5B481BDA81050051AA93 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */; };
 		E679FDBB1B99CF10008C220A /* PrivateBrowsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */; };
 		E68AEDB01B18F81A00133D99 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68AEDAF1B18F81A00133D99 /* SwipeAnimator.swift */; };
@@ -1592,6 +1593,7 @@
 		E663D5771BB341C4001EF30E /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
 		E66464901C10CA9C00AF05CE /* SearchInputViewRefTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchInputViewRefTests.swift; sourceTree = "<group>"; };
 		E66464ED1C10D98000AF05CE /* AssertionUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionUtils.swift; sourceTree = "<group>"; };
+		E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotificationRootViewController.swift; path = Notifications/NotificationRootViewController.swift; sourceTree = "<group>"; };
 		E66C5B461BDA81050051AA93 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ImageEffects.h"; sourceTree = "<group>"; };
 		E66C5B471BDA81050051AA93 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ImageEffects.m"; sourceTree = "<group>"; };
 		E679FDBA1B99CF10008C220A /* PrivateBrowsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTests.swift; sourceTree = "<group>"; };
@@ -2853,6 +2855,14 @@
 			path = Other;
 			sourceTree = "<group>";
 		};
+		E664B4581CD7ECBB0045A6A4 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				E664B4591CD7ECDB0045A6A4 /* NotificationRootViewController.swift */,
+			);
+			name = Notifications;
+			sourceTree = "<group>";
+		};
 		E66C5B451BDA81050051AA93 /* Apple */ = {
 			isa = PBXGroup;
 			children = (
@@ -3100,6 +3110,7 @@
 				E49943F31AE6879C00BF9DE4 /* Intro */,
 				E63ED8DF1BFD254E0097D08E /* Login Management */,
 				7BC7B4571C903A6A0046E9D2 /* Menu */,
+				E664B4581CD7ECBB0045A6A4 /* Notifications */,
 				F84B21F51A0910F600AAB793 /* Reader */,
 				2F44FC551A9E83E200FD20CC /* Settings */,
 				D3972BF01C22412B00035B87 /* Share */,
@@ -4617,6 +4628,7 @@
 				7BC68CCB1CC152B70043562A /* MenuDataSource.swift in Sources */,
 				E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
+				E664B45A1CD7ECDB0045A6A4 /* NotificationRootViewController.swift in Sources */,
 				2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */,
 				E4A961341AC051360069AD6F /* ReadabilityTabHelper.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -19,7 +19,7 @@ let AllowThirdPartyKeyboardsKey = "settings.allowThirdPartyKeyboards"
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var browserViewController: BrowserViewController!
-    var rootViewController: UINavigationController!
+    var rootViewController: NotificationRootViewController!
     weak var profile: BrowserProfile?
     var tabManager: TabManager!
     var adjustIntegration: AdjustIntegration?
@@ -111,10 +111,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         browserViewController.restorationClass = AppDelegate.self
         browserViewController.automaticallyAdjustsScrollViewInsets = false
 
-        rootViewController = UINavigationController(rootViewController: browserViewController)
-        rootViewController.automaticallyAdjustsScrollViewInsets = false
-        rootViewController.delegate = self
-        rootViewController.navigationBarHidden = true
+        let navigationController = UINavigationController(rootViewController: browserViewController)
+        navigationController.automaticallyAdjustsScrollViewInsets = false
+        navigationController.delegate = self
+        navigationController.navigationBarHidden = true
+        rootViewController = NotificationRootViewController(rootViewController: navigationController)
+
         self.window!.rootViewController = rootViewController
 
         do {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -109,10 +109,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         browserViewController = BrowserViewController(profile: self.profile!, tabManager: self.tabManager)
         browserViewController.restorationIdentifier = NSStringFromClass(BrowserViewController.self)
         browserViewController.restorationClass = AppDelegate.self
-        browserViewController.automaticallyAdjustsScrollViewInsets = false
 
         let navigationController = UINavigationController(rootViewController: browserViewController)
-        navigationController.automaticallyAdjustsScrollViewInsets = false
         navigationController.delegate = self
         navigationController.navigationBarHidden = true
         rootViewController = NotificationRootViewController(rootViewController: navigationController)

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -23,17 +23,6 @@ private extension TrayToBrowserAnimator {
         guard let container = transitionContext.containerView() else { return }
         guard let selectedTab = bvc.tabManager.selectedTab else { return }
 
-        // Bug 1205464 - Top Sites tiles blow up or shrink after rotating
-        // Force the BVC's frame to match the tab trays since for some reason on iOS 9 the UILayoutContainer in
-        // the UINavigationController doesn't rotate the presenting view controller
-        let os = NSProcessInfo().operatingSystemVersion
-        switch (os.majorVersion, os.minorVersion, os.patchVersion) {
-        case (9, _, _):
-            bvc.view.frame = UIWindow().frame
-        default:
-            break
-        }
-
         let tabManager = bvc.tabManager
         let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let expandFromIndex = displayedTabs.indexOf(selectedTab) else { return }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -27,6 +27,8 @@ private extension TrayToBrowserAnimator {
         let displayedTabs = selectedTab.isPrivate ? tabManager.privateTabs : tabManager.normalTabs
         guard let expandFromIndex = displayedTabs.indexOf(selectedTab) else { return }
 
+        bvc.view.frame = transitionContext.finalFrameForViewController(bvc)
+
         // Hide browser components
         bvc.toggleSnackBarVisibility(show: false)
         toggleWebViewVisibility(show: false, usingTabManager: bvc.tabManager)

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -56,7 +56,7 @@ extension NotificationRootViewController {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         showingNotification ? remakeConstraintsForVisibleNotification() : remakeConstraintsForHiddenNotification()
-        view.setNeedsUpdateConstraints()
+        view.setNeedsLayout()
     }
 
     override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
@@ -128,7 +128,8 @@ private extension NotificationRootViewController {
         }
 
         self.rootViewController.view.snp_remakeConstraints { make in
-            make.bottom.left.right.equalTo(self.view)
+            make.left.right.equalTo(self.view)
+            make.bottom.equalTo(self.snp_bottomLayoutGuideTop)
             make.top.equalTo(self.notificationView.snp_bottom)
         }
     }
@@ -141,7 +142,8 @@ private extension NotificationRootViewController {
         }
 
         self.rootViewController.view.snp_remakeConstraints { make in
-            make.bottom.left.right.equalTo(self.view)
+            make.left.right.equalTo(self.view)
+            make.bottom.equalTo(self.snp_bottomLayoutGuideTop)
             make.top.equalTo(self.snp_topLayoutGuideBottom)
         }
     }
@@ -202,8 +204,10 @@ private class NotificationStatusView: UIView {
     }
 
     func startAnimation() {
-        animationTimer = NSTimer.scheduledTimerWithTimeInterval(0.2, target: self, selector: #selector(NotificationStatusView.updateEllipsis), userInfo: nil, repeats: true)
-        NSRunLoop.mainRunLoop().addTimer(animationTimer!, forMode: NSRunLoopCommonModes)
+        if animationTimer == nil {
+            animationTimer = NSTimer.scheduledTimerWithTimeInterval(0.2, target: self, selector: #selector(NotificationStatusView.updateEllipsis), userInfo: nil, repeats: true)
+            NSRunLoop.mainRunLoop().addTimer(animationTimer!, forMode: NSRunLoopCommonModes)
+        }
     }
 
     func endAnimation() {

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import SnapKit
+import Shared
+
+/// This view controller wraps around the main UINavigationController of our app that holds the Browser/Tab Tray.
+/// It allows us to display notifications/toasts in the top area of the screen while pushing away the status
+/// bar to indicate sync status globally.
+class NotificationRootViewController: UIViewController {
+    private var rootViewController: UIViewController
+
+    private let notificationCenter = NSNotificationCenter.defaultCenter()
+    private var statusBarHidden = false
+    private var showingNotification = false
+
+    private lazy var notificationView: NotificationStatusView = {
+        let view = NotificationStatusView()
+        view.hidden = true
+        return view
+    }()
+
+    init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+        super.init(nibName: nil, bundle: nil)
+
+        notificationCenter.addObserver(self, selector: #selector(NotificationRootViewController.didStartSyncing), name: NotificationProfileDidStartSyncing, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(NotificationRootViewController.didFinishSyncing), name: NotificationProfileDidFinishSyncing, object: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self, name: NotificationProfileDidStartSyncing, object: nil)
+        notificationCenter.removeObserver(self, name: NotificationProfileDidFinishSyncing, object: nil)
+    }
+}
+
+// MARK: - View Controller Overrides
+extension NotificationRootViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addChildViewController(rootViewController)
+        view.addSubview(rootViewController.view)
+        rootViewController.didMoveToParentViewController(self)
+
+        view.addSubview(notificationView)
+
+        remakeConstraintsForHiddenNotification()
+    }
+
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        showingNotification ? remakeConstraintsForVisibleNotification() : remakeConstraintsForHiddenNotification()
+        view.setNeedsUpdateConstraints()
+    }
+
+    override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
+        coordinator.animateAlongsideTransition({ _ in
+            self.setNeedsStatusBarAppearanceUpdate()
+        }, completion: nil)
+    }
+
+    override func prefersStatusBarHidden() -> Bool {
+        // Always hide status bar when in landscape iPhone
+        if traitCollection.horizontalSizeClass == .Compact && traitCollection.verticalSizeClass == .Compact {
+            return true
+        }
+        return statusBarHidden
+    }
+
+    override func preferredStatusBarUpdateAnimation() -> UIStatusBarAnimation {
+        return .Slide
+    }
+
+    override func preferredStatusBarStyle() -> UIStatusBarStyle {
+        return .LightContent
+    }
+}
+
+// MARK: - Notification API
+extension NotificationRootViewController {
+    func showStatusNotification() {
+        assert(NSThread.isMainThread(), "Showing notifications must occur on the UI Thread.")
+        self.statusBarHidden = true
+        self.notificationView.hidden = false
+        self.notificationView.alpha = 0
+        self.view.layoutIfNeeded()
+        UIView.animateWithDuration(0.33) {
+            self.remakeConstraintsForVisibleNotification()
+            self.notificationView.alpha = 1
+            self.setNeedsStatusBarAppearanceUpdate()
+            self.view.setNeedsUpdateConstraints()
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    func hideStatusNotification() {
+        assert(NSThread.isMainThread(), "Hiding notifications must occur on the UI Thread.")
+        self.statusBarHidden = false
+        self.view.layoutIfNeeded()
+        UIView.animateWithDuration(0.33, animations: {
+            self.remakeConstraintsForHiddenNotification()
+            self.notificationView.alpha = 0
+            self.setNeedsStatusBarAppearanceUpdate()
+            self.view.setNeedsUpdateConstraints()
+            self.view.layoutIfNeeded()
+        }, completion: { _ in
+            self.notificationView.hidden = true
+        })
+    }
+}
+
+// MARK: - Layout Constraints
+private extension NotificationRootViewController {
+    func remakeConstraintsForVisibleNotification() {
+        self.notificationView.snp_remakeConstraints { make in
+            make.height.equalTo(20)
+            make.left.right.equalTo(self.view)
+            make.top.equalTo(self.snp_topLayoutGuideBottom)
+        }
+
+        self.rootViewController.view.snp_remakeConstraints { make in
+            make.bottom.left.right.equalTo(self.view)
+            make.top.equalTo(self.notificationView.snp_bottom)
+        }
+    }
+
+    func remakeConstraintsForHiddenNotification() {
+        self.notificationView.snp_remakeConstraints { make in
+            make.height.equalTo(20)
+            make.left.right.equalTo(self.view)
+            make.bottom.equalTo(self.snp_topLayoutGuideTop)
+        }
+
+        self.rootViewController.view.snp_remakeConstraints { make in
+            make.bottom.left.right.equalTo(self.view)
+            make.top.equalTo(self.snp_topLayoutGuideBottom)
+        }
+    }
+}
+
+// MARK: - Notification Selectors
+private extension NotificationRootViewController {
+    @objc func didStartSyncing() {
+        showingNotification = true
+        notificationView.titleLabel.text = Strings.SyncingMessage
+        dispatch_async(dispatch_get_main_queue()) {
+            self.showStatusNotification()
+        }
+    }
+
+    @objc func didFinishSyncing() {
+        showingNotification = false
+        dispatch_async(dispatch_get_main_queue()) {
+            self.hideStatusNotification()
+        }
+    }
+}
+
+// MARK: Notification Status View
+private class NotificationStatusView: UIView {
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .whiteColor()
+        label.font = UIConstants.DefaultChromeSmallFontBold
+        return label
+    }()
+
+    init() {
+        super.init(frame: CGRect.zero)
+        backgroundColor = UIConstants.AppBackgroundColor
+        addSubview(titleLabel)
+        titleLabel.snp_makeConstraints { make in
+            make.center.equalTo(self)
+            make.width.lessThanOrEqualTo(self.snp_width)
+        }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -84,7 +84,7 @@ class SyncNowSetting: WithAccountSetting {
 
     private let syncNowTitle = NSAttributedString(string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.blackColor(), NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
 
-    private let syncingTitle = NSAttributedString(string: Strings.SyncingMessage, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+    private let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
 
     override var accessoryType: UITableViewCellAccessoryType { return .None }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -84,7 +84,7 @@ class SyncNowSetting: WithAccountSetting {
 
     private let syncNowTitle = NSAttributedString(string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.blackColor(), NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
 
-    private let syncingTitle = NSAttributedString(string: NSLocalizedString("Syncing…", comment: "Syncing Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+    private let syncingTitle = NSAttributedString(string: Strings.SyncingMessage, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
 
     override var accessoryType: UITableViewCellAccessoryType { return .None }
 

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -68,3 +68,8 @@ extension Strings {
     public static let SyncedTabsTableViewCellDescription = NSLocalizedString("HistoryPanel.SyncedTabsCell.Description", value: "devices connected", comment: "Description that corresponds with a number of devices connected for the Synced Tabs Cell in the History Panel")
     public static let HistoryPanelEmptyStateTitle = NSLocalizedString("HistoryPanel.EmptyState.Title", value: "Websites you've visited recently will show up here.", comment: "Title for the History Panel empty state.")
 }
+
+// Syncing
+extension Strings {
+    public static let SyncingMessage = NSLocalizedString("Sync.Syncing.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing")
+}

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -71,5 +71,6 @@ extension Strings {
 
 // Syncing
 extension Strings {
-    public static let SyncingMessage = NSLocalizedString("Sync.Syncing.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing")
+    public static let SyncingMessageWithEllipsis = NSLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end")
+    public static let SyncingMessageWithoutEllipsis = NSLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis")
 }


### PR DESCRIPTION
Originally I started down the path of using an overlaying UIWindow object to display the notification over the status bar like most of the third-party libraries out there do but that fell apart pretty quickly because of how we show/hide the status bar at various areas of the app (settings, landscape browser). It was also a pain to manage orientation changes since you needed to manually set the transforms yourself since windows are not part of the layout cycle.

This approach embeds the root UINavigationController of the app into another view controller. This has a few benefits:

1. Takes part in the UIViewController lifecycle and view transform changes.
2. Can handle changes like in-call status bars without additional work.
3. Gives us better control over how we animate in not only the notification but also the contents below.

The downside to the embedding approach is that we don't show the notification view when we're in settings since that view controller is presented on top of the root UINavigationController one. I don't think this is a problem since we already see the syncing status in the settings anyways. I also think it works in our benefit for when we want to implement the 'Go to Copied Link' banner since it will keep the banner visible in the context of the browser/tab tray only. We can easily extend this controller to include a notification observer for copied links.

As always thoughts and concerns most appreciated!