### PR TITLE
Bug 1227863 - Don't create corrupt DB logger until we need to write a…

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -73,9 +73,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Create a new sync log file on cold app launch. Note that this doesn't roll old logs.
         Logger.syncLogger.newLogWithDate(logDate)
 
-        log.debug("Creating corrupt DB logger…")
-        Logger.corruptLogger.newLogWithDate(logDate)
-
         log.debug("Creating Browser log file…")
         Logger.browserLogger.newLogWithDate(logDate)
 

--- a/Storage/ThirdParty/SwiftData.swift
+++ b/Storage/ThirdParty/SwiftData.swift
@@ -663,10 +663,13 @@ public class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         return FilledSQLiteCursor<T>(statement: statement!, factory: factory)
     }
 
-    func writeCorruptionInfoForDBNamed(dbFilename: String, toLogger logger: XCGLogger) {
+    func writeCorruptionInfoForDBNamed(dbFilename: String, toLogger logger: RollingFileLogger) {
         dispatch_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             guard !SwiftData.corruptionLogsWritten.contains(dbFilename) else { return }
 
+            let logDate = NSDate()
+            logger.newLogWithDate(logDate)
+            
             logger.error("Corrupt DB detected! DB filename: \(dbFilename)")
 
             let dbFileSize = ("file://\(dbFilename)".asURL)?.allocatedFileSize() ?? 0


### PR DESCRIPTION
@sleroux , I changed the type of the parameter "logger" in the function "writeCorruptionInfoForDBNamed". Otherwise, we'd have to force downcast within the function.

One question remains. What if someone creates another swift file somewhere else in the codebase and attempts to create a new log file for the corrupt DB logging? (without realizing that one has already been created in SwiftData.swift)