### PR TITLE
Bug 1268871 - Use PrivilegedRequest to open menu URLs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -957,7 +957,7 @@ class BrowserViewController: UIViewController {
     func openURLInNewTab(url: NSURL?, isPrivate: Bool = false) {
         let request: NSURLRequest?
         if let url = url {
-            request = NSURLRequest(URL: url)
+            request = PrivilegedRequest(URL: url)
         } else {
             request = nil
         }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1053,19 +1053,19 @@ extension TabTrayController: MenuActionDelegate {
                 }
             case .OpenTopSites:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(NSURLRequest(URL: HomePanelViewController.urlForHomePanelOfType(.TopSites)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.TopSites)!))
                 }
             case .OpenBookmarks:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(NSURLRequest(URL: HomePanelViewController.urlForHomePanelOfType(.Bookmarks)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.Bookmarks)!))
                 }
             case .OpenHistory:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(NSURLRequest(URL: HomePanelViewController.urlForHomePanelOfType(.History)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.History)!))
                 }
             case .OpenReadingList:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(NSURLRequest(URL: HomePanelViewController.urlForHomePanelOfType(.ReadingList)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.ReadingList)!))
                 }
             default: break
             }


### PR DESCRIPTION
I think this is from a combination of [bug 1263627](https://bugzilla.mozilla.org/show_bug.cgi?id=1263627) and [bug 1263974](https://bugzilla.mozilla.org/show_bug.cgi?id=1263974). The former prevents `localhost` pages from being loaded, and the latter prevents the web view URL from changing if the page doesn't load. Changing menu requests to use `PrivilegedRequest` will allow us to again load `localhost` URLs.