### PR TITLE
Bug 1270693 - FindInPageBar Keyboard Improvements

### DIFF
--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -63,6 +63,11 @@ class FindInPageBar: UIView {
         searchText.font = FindInPageUX.SearchTextFont
         searchText.autocapitalizationType = UITextAutocapitalizationType.None
         searchText.autocorrectionType = UITextAutocorrectionType.No
+        if #available(iOS 9.0, *) {
+            searchText.inputAssistantItem.leadingBarButtonGroups = []
+            searchText.inputAssistantItem.trailingBarButtonGroups = []
+        }
+        //searchText.delegate = self
         addSubview(searchText)
 
         matchCountView.textColor = FindInPageUX.MatchCountColor

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -68,6 +68,7 @@ class FindInPageBar: UIView {
             searchText.inputAssistantItem.trailingBarButtonGroups = []
         }
         searchText.enablesReturnKeyAutomatically = true
+        searchText.returnKeyType = .Search
         addSubview(searchText)
 
         matchCountView.textColor = FindInPageUX.MatchCountColor

--- a/Client/Frontend/Browser/FindInPageBar.swift
+++ b/Client/Frontend/Browser/FindInPageBar.swift
@@ -67,7 +67,7 @@ class FindInPageBar: UIView {
             searchText.inputAssistantItem.leadingBarButtonGroups = []
             searchText.inputAssistantItem.trailingBarButtonGroups = []
         }
-        //searchText.delegate = self
+        searchText.enablesReturnKeyAutomatically = true
         addSubview(searchText)
 
         matchCountView.textColor = FindInPageUX.MatchCountColor


### PR DESCRIPTION
This patch does three things:

* Remove the shortcuts bar for less clutter and safari parity. See screenshots below. This only affects iPad and iOS9.
* Enable `enablesReturnKeyAutomatically` so that the return key stays disabled unless there is content in the field
* Change the *return* key to be *Search* instead

*Virtual Keyboard Before/After*

![screenshot 2016-05-06 08 22 44](https://cloud.githubusercontent.com/assets/28052/15072998/d4913442-1364-11e6-9c8a-77cf9c1cda53.png)
![screenshot 2016-05-06 08 29 47](https://cloud.githubusercontent.com/assets/28052/15073006/e15841c0-1364-11e6-8d2f-3b7a067d5c0a.png)

*Hardware Keyboard Before/After*

![screenshot 2016-05-06 08 22 50](https://cloud.githubusercontent.com/assets/28052/15073042/1f0686e4-1365-11e6-88f2-1c259c82f961.png)
![screenshot 2016-05-06 08 29 52](https://cloud.githubusercontent.com/assets/28052/15073047/26e8e5b4-1365-11e6-9314-fb91373b08e7.png)
