### PR TITLE
Bug 1270971 - Top Sites tile order should follow RTL rules

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -505,7 +505,13 @@ class TopSitesLayout: UICollectionViewLayout {
 
         // Set the top thumbnail frames.
         let row = floor(Double(indexPath.item / thumbnailCols))
-        let col = indexPath.item % thumbnailCols
+        let col: Int
+        if UIApplication.sharedApplication().userInterfaceLayoutDirection == .RightToLeft {
+            // For RTL the rows are mirrored, item 0 starts at the right
+            col = thumbnailCols - (indexPath.item % thumbnailCols) - 1
+        } else {
+            col = indexPath.item % thumbnailCols
+        }
         let size = collectionView?.bounds.size ?? CGSizeZero
         let insets = ThumbnailCellUX.insetsForCollectionViewSize(size,
             traitCollection:  collectionView!.traitCollection)


### PR DESCRIPTION
This patch adds RTL support to Top Sites.

Left-To-Right:

<img width="432" alt="screenshot 2016-05-06 22 02 48" src="https://cloud.githubusercontent.com/assets/28052/15089659/4fac1a72-13d6-11e6-8cd4-6153f27649ec.png">

Right-To-Left:

<img width="432" alt="screenshot 2016-05-06 21 55 57" src="https://cloud.githubusercontent.com/assets/28052/15089660/5752a656-13d6-11e6-9ceb-11a41d3080c9.png">
