### PR TITLE
Bug 1264225 - Prevent syncing for unverified/unsyncable accounts along with proper visual feedback

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -132,7 +132,9 @@ class HistoryPanelSiteTableViewController: SiteTableViewController {
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
         case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory:
-            resyncHistory()
+            if self.profile.hasSyncableAccount() {
+                resyncHistory()
+            }
             break
         case NotificationDynamicFontChanged:
             if emptyStateOverlayView.superview != nil {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -83,7 +83,7 @@ class SyncNowSetting: WithAccountSetting {
     }()
 
     private var syncNowTitle: NSAttributedString {
-        return NSMutableAttributedString(
+        return NSAttributedString(
             string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
             attributes: [
                 NSForegroundColorAttributeName: self.enabled ? UIColor.blackColor() : UIColor.grayColor(),
@@ -92,7 +92,7 @@ class SyncNowSetting: WithAccountSetting {
         )
     }
 
-    private let syncingTitle = NSMutableAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+    private let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
 
     override var accessoryType: UITableViewCellAccessoryType { return .None }
 

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -82,9 +82,17 @@ class SyncNowSetting: WithAccountSetting {
         return formatter
     }()
 
-    private let syncNowTitle = NSAttributedString(string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"), attributes: [NSForegroundColorAttributeName: UIColor.blackColor(), NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
+    private var syncNowTitle: NSAttributedString {
+        return NSMutableAttributedString(
+            string: NSLocalizedString("Sync Now", comment: "Sync Firefox Account"),
+            attributes: [
+                NSForegroundColorAttributeName: self.enabled ? UIColor.blackColor() : UIColor.grayColor(),
+                NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont
+            ]
+        )
+    }
 
-    private let syncingTitle = NSAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
+    private let syncingTitle = NSMutableAttributedString(string: Strings.SyncingMessageWithEllipsis, attributes: [NSForegroundColorAttributeName: UIColor.grayColor(), NSFontAttributeName: UIFont.systemFontOfSize(DynamicFontHelper.defaultHelper.DefaultStandardFontSize, weight: UIFontWeightRegular)])
 
     override var accessoryType: UITableViewCellAccessoryType { return .None }
 
@@ -107,12 +115,17 @@ class SyncNowSetting: WithAccountSetting {
         return attributedString
     }
 
+    override var enabled: Bool {
+        return profile.hasSyncableAccount()
+    }
+
     override func onConfigureCell(cell: UITableViewCell) {
         cell.textLabel?.attributedText = title
         cell.detailTextLabel?.attributedText = status
         cell.accessoryType = accessoryType
         cell.accessoryView = nil
-        cell.userInteractionEnabled = !profile.syncManager.isSyncing
+        cell.userInteractionEnabled = !profile.syncManager.isSyncing && enabled
+        cell.selectionStyle = profile.syncManager.isSyncing ? .None : .Gray
     }
 
     override func onClick(navigationController: UINavigationController?) {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -565,7 +565,7 @@ public class BrowserProfile: Profile {
         func applicationDidBecomeActive() {
             self.backgrounded = false
 
-            guard self.profile.hasAccount() else {
+            guard self.profile.hasSyncableAccount() else {
                 return
             }
 
@@ -791,6 +791,9 @@ public class BrowserProfile: Profile {
         }
 
         func onAddedAccount() -> Success {
+            // Only sync if we're green lit. This makes sure that we don't sync unverified accounts.
+            guard self.profile.hasSyncableAccount() else { return succeed() }
+
             self.beginTimedSyncs();
             return self.syncEverything()
         }


### PR DESCRIPTION
Turns out the brief 'Syncing Now' message was being called by an observer on the history panel to resync the history. I've updated various places to include checks to hasSyncableAccount along with visual updates to the Sync Now button when the account is not syncable.