### PR TITLE
Bug 1271674 - Xcode 7.3.1 Swift compiler crash on optimized build

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -5260,6 +5260,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = FirefoxNightly;
 		};
@@ -5751,6 +5752,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Firefox;
 		};
@@ -6419,6 +6421,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = FennecAurora;
 		};
@@ -6929,6 +6932,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = FirefoxBeta;
 		};


### PR DESCRIPTION
This patch changes the Swift Optimization Level from `-O -whole-module-optimization` to just `-O` for the *Storage* framework.

This is a temporary solution until we have a better idea how to deal with https://bugs.swift.org/browse/SR-1455 or until Apple provides an Xcode update that fixes this issue.

This fix now at least means we can continue to do builds. And the change is limited to *Storage*. The rest of the app compiles without issues with the original optimization settings.