### PR TITLE
Bug 1271337 - remove SyncedTabs from HomePanelType enum so anything u…

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -51,8 +51,7 @@ enum HomePanelType: Int {
     case TopSites = 0
     case Bookmarks = 1
     case History = 2
-    case SyncedTabs = 3
-    case ReadingList = 4
+    case ReadingList = 3
 }
 
 class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelDelegate {


### PR DESCRIPTION
…sing it for navigation will hit the right panel when selecting reading list

https://bugzilla.mozilla.org/show_bug.cgi?id=1271337