### PR TITLE
Bug 1271572 - Don't update app state while menu is dismissing

### DIFF
--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -33,8 +33,10 @@ class MenuViewController: UIViewController {
 
     var appState: AppState {
         didSet {
-            menuConfig = menuConfig.menuForState(appState)
-            self.reloadView()
+            if !self.isBeingDismissed() {
+                menuConfig = menuConfig.menuForState(appState)
+                self.reloadView()
+            }
         }
     }
 


### PR DESCRIPTION
The popover dismissal takes long enough that the action has been performed and the app state has been updated and the menu updated to reflect the new state before the menu is dismissed. In this case, when appState is updated while the menu is dismissing, ignore the new app state.

https://bugzilla.mozilla.org/show_bug.cgi?id=1271572