### PR TITLE
Bug 1271018 - set default text alignment for settings to be Natural r…

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -37,7 +37,7 @@ class Setting {
 
     var accessoryType: UITableViewCellAccessoryType { return .None }
 
-    var textAlignment: NSTextAlignment { return .Left }
+    var textAlignment: NSTextAlignment { return .Natural }
     
     private(set) var enabled: Bool = true
 


### PR DESCRIPTION
…ather than Left

This is so that Right To Left language text alignment works as expected

https://bugzilla.mozilla.org/show_bug.cgi?id=1271018