### PR TITLE
Bug 1271378 - Report session times in core ping

### DIFF
--- a/ClientTelemetry.swift
+++ b/ClientTelemetry.swift
@@ -6,6 +6,8 @@ import Foundation
 import Shared
 
 private let PrefKeySearches = "Telemetry.Searches"
+private let PrefKeyUsageTime = "Telemetry.UsageTime"
+private let PrefKeyUsageCount = "Telemetry.UsageCount"
 
 class SearchTelemetry {
     // For data consistency, the strings used here are identical to the ones reported in Android.
@@ -42,5 +44,43 @@ private class SearchTelemetryEvent: TelemetryEvent {
         var searches = SearchTelemetry.getData(prefs) ?? [:]
         searches[engineWithSource] = (searches[engineWithSource] ?? 0) + 1
         prefs.setObject(searches, forKey: PrefKeySearches)
+    }
+}
+
+
+class UsageTelemetry {
+    private init() {}
+
+    class func makeEvent(usageInterval: Int) -> TelemetryEvent {
+        return UsageTelemetryEvent(usageInterval: usageInterval)
+    }
+
+    class func getCount(prefs: Prefs) -> Int {
+        return Int(prefs.intForKey(PrefKeyUsageCount) ?? 0)
+    }
+
+    class func getTime(prefs: Prefs) -> Int {
+        return Int(prefs.intForKey(PrefKeyUsageTime) ?? 0)
+    }
+
+    class func reset(prefs: Prefs) {
+        prefs.setInt(0, forKey: PrefKeyUsageCount)
+        prefs.setInt(0, forKey: PrefKeyUsageTime)
+    }
+}
+
+private class UsageTelemetryEvent: TelemetryEvent {
+    private let usageInterval: Int
+
+    init(usageInterval: Int) {
+        self.usageInterval = usageInterval
+    }
+
+    func record(prefs: Prefs) {
+        let count = Int32(UsageTelemetry.getCount(prefs) + 1)
+        prefs.setInt(count, forKey: PrefKeyUsageCount)
+
+        let time = Int32(UsageTelemetry.getTime(prefs) + usageInterval)
+        prefs.setInt(time, forKey: PrefKeyUsageTime)
     }
 }


### PR DESCRIPTION
This sends an array of usage times with the core ping. A single usage time is defined as the time, in seconds, the application has been in the foreground.

One useful metric this can help capture is determining how long users are using the app before they uninstall. Since sending the ping on each application foreground isn't sufficient to measure a user who only uses the application once, this PR changes the core ping triggers. Rather than sending the core ping on each application foreground, we'll now send the core ping to be sent after 1) the first application startup, and 2) each application background.

Sending a ping on each background allows us to include the usage interval for that session. Sending a ping on the first run (or more specifically, first run with this patch applied) gives us a soon-as-possible data point that we can use to uniquely identify a user (so they'll at least be on the map after a crash-then-uninstall scenario). Other than the initial launch, I can't think of a reason we'd want to send pings on app startup/foreground, but happy to hear any arguments.

The `usage` array works by appending the current usage time to the stored array, then clearing the stored array after a successful ping. That means the very first ping will have an empty `usage` array on the first run, and all subsequent pings will contain at least one value in the array. Generally, the array will have just one item since pings will usually succeed.