### PR TITLE
Bug 1272157 – Add homepage to the AppState for consumption by the Menu.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var openInFirefoxParams: LaunchParams? = nil
 
+    var appStateStore: AppStateStore!
+
     func application(application: UIApplication, willFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Hold references to willFinishLaunching parameters for delayed app launch
         self.application = application
@@ -77,6 +79,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         log.debug("Getting profile…")
         let profile = getProfile(application)
+        appStateStore = AppStateStore()
 
         if !DebugSettingsBundleOptions.disableLocalWebServer {
             log.debug("Starting web server…")

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -79,7 +79,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         log.debug("Getting profile…")
         let profile = getProfile(application)
-        appStateStore = AppStateStore()
+        appStateStore = AppStateStore(prefs: profile.prefs)
 
         if !DebugSettingsBundleOptions.disableLocalWebServer {
             log.debug("Starting web server…")

--- a/Client/Application/AppState.swift
+++ b/Client/Application/AppState.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Shared
 
 protocol AppStateDelegate: class {
     func appDidUpdateState(appState: AppState)
@@ -10,6 +11,7 @@ protocol AppStateDelegate: class {
 
 struct AppState {
     let ui: UIState
+    let prefs: Prefs
 }
 
 enum UIState {
@@ -33,8 +35,13 @@ enum UIState {
 }
 
 class AppStateStore {
+    let prefs: Prefs
+
+    init(prefs: Prefs) {
+        self.prefs = prefs
+    }
     func updateState(state: UIState) -> AppState {
-        return AppState(ui: state)
+        return AppState(ui: state, prefs: prefs)
     }
 }
 
@@ -44,4 +51,10 @@ class AppStateStore {
 var mainStore: AppStateStore {
     let appDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
     return appDelegate.appStateStore
+}
+
+class Accessors {
+    static func getPrefs(state: AppState) -> Prefs {
+        return state.prefs
+    }
 }

--- a/Client/Application/AppState.swift
+++ b/Client/Application/AppState.swift
@@ -8,7 +8,11 @@ protocol AppStateDelegate: class {
     func appDidUpdateState(appState: AppState)
 }
 
-enum AppState {
+struct AppState {
+    let ui: UIState
+}
+
+enum UIState {
     case Tab(tabState: TabState)
     case HomePanels(homePanelState: HomePanelState)
     case TabTray(tabTrayState: TabTrayState)

--- a/Client/Application/AppState.swift
+++ b/Client/Application/AppState.swift
@@ -42,9 +42,6 @@ class AppStateStore {
 // It's on the global namespace because it's really just accessing the app delegate, 
 // not a shared static instance on the AppStateStore class.  
 var mainStore: AppStateStore {
-    guard let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate else {
-        // something bad happened here.
-        return AppStateStore()
-    }
+    let appDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
     return appDelegate.appStateStore
 }

--- a/Client/Application/AppState.swift
+++ b/Client/Application/AppState.swift
@@ -31,3 +31,20 @@ enum UIState {
         }
     }
 }
+
+class AppStateStore {
+    func updateState(state: UIState) -> AppState {
+        return AppState(ui: state)
+    }
+}
+
+// The mainStore should be a singleton.
+// It's on the global namespace because it's really just accessing the app delegate, 
+// not a shared static instance on the AppStateStore class.  
+var mainStore: AppStateStore {
+    guard let appDelegate = UIApplication.sharedApplication().delegate as? AppDelegate else {
+        // something bad happened here.
+        return AppStateStore()
+    }
+    return appDelegate.appStateStore
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1113,7 +1113,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func getCurrentAppState() -> AppState {
-        return AppState(ui: getCurrentUIState())
+        return mainStore.updateState(getCurrentUIState())
     }
 
     private func getCurrentUIState() -> UIState {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -167,8 +167,9 @@ class BrowserViewController: UIViewController {
         toolbar = nil
 
         if showToolbar {
+            let state = getCurrentAppState()
             toolbar = TabToolbar()
-            toolbar?.applyTheme(getCurrentAppState().isPrivate() ? Theme.PrivateMode : Theme.NormalMode)
+            toolbar?.applyTheme(state.ui.isPrivate() ? Theme.PrivateMode : Theme.NormalMode)
             toolbar?.tabToolbarDelegate = self
             footerBackground = BlurWrapper(view: toolbar!)
             footerBackground?.translatesAutoresizingMaskIntoConstraints = false
@@ -1112,6 +1113,10 @@ class BrowserViewController: UIViewController {
     }
 
     private func getCurrentAppState() -> AppState {
+        return AppState(ui: getCurrentUIState())
+    }
+
+    private func getCurrentUIState() -> UIState {
         guard let tab = tabManager.selectedTab,
         let displayURL = tab.displayURL where displayURL.absoluteString.characters.count > 0 else {
             if let homePanelController = homePanelController {
@@ -1167,7 +1172,7 @@ extension BrowserViewController: MenuActionDelegate {
                     tab.toggleDesktopSite()
                 }
             case .ToggleBookmarkStatus:
-                switch appState {
+                switch appState.ui {
                 case .Tab(let tabState):
                     self.toggleBookmarkForTabState(tabState)
                 default: break
@@ -1194,9 +1199,9 @@ extension BrowserViewController: MenuActionDelegate {
     }
 
     private func openHomePanel(panel: HomePanelType, forAppState appState: AppState) {
-        switch appState {
+        switch appState.ui {
         case .Tab(_):
-            self.openURLInNewTab(HomePanelViewController.urlForHomePanelOfType(panel)!, isPrivate: appState.isPrivate())
+            self.openURLInNewTab(HomePanelViewController.urlForHomePanelOfType(panel)!, isPrivate: appState.ui.isPrivate())
         case .HomePanels(_):
             self.homePanelController?.selectedPanel = panel
         default: break

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -20,11 +20,7 @@ class HomePageHelper {
 
     var currentURL: NSURL? {
         get {
-            let string = prefs.stringForKey(HomePageConstants.HomePageURLPrefKey) ?? defaultURLString
-            guard let urlString = string else {
-                return nil
-            }
-            return NSURL(string: urlString)
+            return HomePageAccessors.getHomePage(prefs)
         }
         set {
             if let url = newValue {
@@ -36,7 +32,7 @@ class HomePageHelper {
     }
 
     var defaultURLString: String? {
-        return prefs.stringForKey(HomePageConstants.DefaultHomePageURLPrefKey)
+        return HomePageAccessors.getDefaultHomePageString(prefs)
     }
 
     var isHomePageAvailable: Bool { return currentURL != nil }

--- a/Client/Frontend/Browser/HomePageHelper.swift
+++ b/Client/Frontend/Browser/HomePageHelper.swift
@@ -74,3 +74,40 @@ class HomePageHelper {
         navigationController?.presentViewController(alertController, animated: true, completion: nil)
     }
 }
+
+/// Accessors for homepage details from the app state.
+/// These are pure functions, so it's quite ok to have them 
+/// as static.
+class HomePageAccessors {
+    private static let getPrefs = Accessors.getPrefs
+
+    static func getHomePage(state: AppState) -> NSURL? {
+        return getHomePage(getPrefs(state))
+    }
+
+    static func hasHomePage(state: AppState) -> Bool {
+        return getHomePage(state) != nil
+    }
+
+    static func isButtonInMenu(state: AppState) -> Bool {
+        return isButtonInMenu(getPrefs(state))
+    }
+}
+
+private extension HomePageAccessors {
+    static func isButtonInMenu(prefs: Prefs) -> Bool {
+        return prefs.boolForKey(HomePageConstants.HomePageButtonIsInMenuPrefKey) ?? true
+    }
+
+    static func getHomePage(prefs: Prefs) -> NSURL? {
+        let string = prefs.stringForKey(HomePageConstants.HomePageURLPrefKey) ?? getDefaultHomePageString(prefs)
+        guard let urlString = string else {
+            return nil
+        }
+        return NSURL(string: urlString)
+    }
+
+    static func getDefaultHomePageString(prefs: Prefs) -> String? {
+        return prefs.stringForKey(HomePageConstants.DefaultHomePageURLPrefKey)
+    }
+}

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -134,7 +134,7 @@ class Tab: NSObject {
     }
 
     private func updateAppState() {
-        self.appStateDelegate?.appDidUpdateState(.Tab(tabState: self.tabState))
+        self.appStateDelegate?.appDidUpdateState(AppState(ui:.Tab(tabState: self.tabState)))
     }
 
     weak var navigationDelegate: WKNavigationDelegate? {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -134,7 +134,8 @@ class Tab: NSObject {
     }
 
     private func updateAppState() {
-        self.appStateDelegate?.appDidUpdateState(AppState(ui:.Tab(tabState: self.tabState)))
+        let state = mainStore.updateState(.Tab(tabState: self.tabState))
+        self.appStateDelegate?.appDidUpdateState(state)
     }
 
     weak var navigationDelegate: WKNavigationDelegate? {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -450,7 +450,7 @@ class TabTrayController: UIViewController {
 
     @objc
     private func didTapMenu() {
-        let state = AppState(ui: .TabTray(tabTrayState: self.tabTrayState))
+        let state = mainStore.updateState(.TabTray(tabTrayState: self.tabTrayState))
         let mvc = MenuViewController(withAppState: state, presentationStyle: .Modal)
         mvc.delegate = self
         mvc.actionDelegate = self
@@ -554,7 +554,7 @@ class TabTrayController: UIViewController {
     }
 
     private func updateAppState() {
-        let state = AppState(ui: .TabTray(tabTrayState: self.tabTrayState))
+        let state = mainStore.updateState(.TabTray(tabTrayState: self.tabTrayState))
         self.appStateDelegate?.appDidUpdateState(state)
     }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -450,7 +450,8 @@ class TabTrayController: UIViewController {
 
     @objc
     private func didTapMenu() {
-        let mvc = MenuViewController(withAppState: .TabTray(tabTrayState: self.tabTrayState), presentationStyle: .Modal)
+        let state = AppState(ui: .TabTray(tabTrayState: self.tabTrayState))
+        let mvc = MenuViewController(withAppState: state, presentationStyle: .Modal)
         mvc.delegate = self
         mvc.actionDelegate = self
         mvc.menuTransitionDelegate = MenuPresentationAnimator()
@@ -553,7 +554,8 @@ class TabTrayController: UIViewController {
     }
 
     private func updateAppState() {
-        self.appStateDelegate?.appDidUpdateState(.TabTray(tabTrayState: self.tabTrayState))
+        let state = AppState(ui: .TabTray(tabTrayState: self.tabTrayState))
+        self.appStateDelegate?.appDidUpdateState(state)
     }
 
     private func closeTabsForCurrentTray() {

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -134,7 +134,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     }
 
     private func updateAppState() {
-        let state = AppState(ui: .HomePanels(homePanelState: homePanelState))
+        let state = mainStore.updateState(.HomePanels(homePanelState: homePanelState))
         self.appStateDelegate?.appDidUpdateState(state)
     }
 

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -134,7 +134,8 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
     }
 
     private func updateAppState() {
-        self.appStateDelegate?.appDidUpdateState(.HomePanels(homePanelState: homePanelState))
+        let state = AppState(ui: .HomePanels(homePanelState: homePanelState))
+        self.appStateDelegate?.appDidUpdateState(state)
     }
 
     func SELhandleDismissKeyboardGestureRecognizer(gestureRecognizer: UITapGestureRecognizer) {

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -94,7 +94,11 @@ struct AppMenuConfiguration: MenuConfiguration {
             if #available(iOS 9, *) {
                 menuItems.append(tabState.desktopSite ? AppMenuConfiguration.RequestMobileMenuItem : AppMenuConfiguration.RequestDesktopMenuItem)
             }
-            menuItems.append(AppMenuConfiguration.OpenHomePageMenuItem)
+            if HomePageAccessors.hasHomePage(appState) {
+                menuItems.append(AppMenuConfiguration.OpenHomePageMenuItem)
+            } else {
+                menuItems.append(AppMenuConfiguration.SetHomePageMenuItem)
+            }
             menuItems.append(AppMenuConfiguration.NewTabMenuItem)
             if #available(iOS 9, *) {
                 menuItems.append(AppMenuConfiguration.NewPrivateTabMenuItem)

--- a/Client/Frontend/Menu/AppMenuConfiguration.swift
+++ b/Client/Frontend/Menu/AppMenuConfiguration.swift
@@ -32,7 +32,7 @@ struct AppMenuConfiguration: MenuConfiguration {
         menuItems = menuItemsForAppState(appState)
         menuToolbarItems = menuToolbarItemsForAppState(appState)
         numberOfItemsInRow = numberOfMenuItemsPerRowForAppState(appState)
-        isPrivateMode = appState.isPrivate()
+        isPrivateMode = appState.ui.isPrivate()
     }
 
     func menuForState(appState: AppState) -> MenuConfiguration {
@@ -77,7 +77,7 @@ struct AppMenuConfiguration: MenuConfiguration {
     }
 
     private func numberOfMenuItemsPerRowForAppState(appState: AppState) -> Int {
-        switch appState {
+        switch appState.ui {
         case .TabTray:
             return 4
         default:
@@ -88,7 +88,7 @@ struct AppMenuConfiguration: MenuConfiguration {
     // the items should be added to the array according to desired display order
     private func menuItemsForAppState(appState: AppState) -> [MenuItem] {
         var menuItems = [MenuItem]()
-        switch appState {
+        switch appState.ui {
         case .Tab(let tabState):
             menuItems.append(AppMenuConfiguration.FindInPageMenuItem)
             if #available(iOS 9, *) {
@@ -121,7 +121,7 @@ struct AppMenuConfiguration: MenuConfiguration {
     // the items should be added to the array according to desired display order
     private func menuToolbarItemsForAppState(appState: AppState) -> [MenuToolbarItem]? {
         let menuToolbarItems: [MenuToolbarItem]?
-        switch appState {
+        switch appState.ui {
         case .Tab, .TabTray:
             menuToolbarItems = [AppMenuConfiguration.TopSitesMenuToolbarItem,
                                 AppMenuConfiguration.BookmarksMenuToolbarItem,

--- a/Client/Frontend/Menu/AppMenuItem.swift
+++ b/Client/Frontend/Menu/AppMenuItem.swift
@@ -29,7 +29,7 @@ struct AppMenuItem: MenuItem {
     }
 
     func iconForState(appState: AppState) -> UIImage?  {
-        return appState.isPrivate() ? privateModeIcon : icon
+        return appState.ui.isPrivate() ? privateModeIcon : icon
     }
 
     func selectedIconForState(appState: AppState) -> UIImage? {

--- a/ClientTests/MenuTests.swift
+++ b/ClientTests/MenuTests.swift
@@ -17,9 +17,13 @@ class MenuTests: XCTestCase {
         super.tearDown()
     }
 
+    func appState(ui: UIState) -> AppState {
+        return AppState(ui: ui)
+    }
+
     func testMenuConfigurationForBrowser() {
         var tabState = TabState(isPrivate: false, desktopSite: false, isBookmarked: false, url: NSURL(string: "http://mozilla.com")!, title: "Mozilla", favicon: nil)
-        var browserConfiguration = AppMenuConfiguration(appState: .Tab(tabState: tabState))
+        var browserConfiguration = AppMenuConfiguration(appState: appState(.Tab(tabState: tabState)))
         XCTAssertEqual(browserConfiguration.menuItems.count, 7)
         XCTAssertEqual(browserConfiguration.menuItems[0].title, AppMenuConfiguration.FindInPageTitleString)
         XCTAssertEqual(browserConfiguration.menuItems[1].title, AppMenuConfiguration.ViewDesktopSiteTitleString)
@@ -38,7 +42,7 @@ class MenuTests: XCTestCase {
 
 
         tabState = TabState(isPrivate: true, desktopSite: true, isBookmarked: true, url: NSURL(string: "http://mozilla.com")!, title: "Mozilla", favicon: nil)
-        browserConfiguration = AppMenuConfiguration(appState: .Tab(tabState: tabState))
+        browserConfiguration = AppMenuConfiguration(appState: appState(.Tab(tabState: tabState)))
         XCTAssertEqual(browserConfiguration.menuItems.count, 7)
         XCTAssertEqual(browserConfiguration.menuItems[0].title, AppMenuConfiguration.FindInPageTitleString)
         XCTAssertEqual(browserConfiguration.menuItems[1].title, AppMenuConfiguration.ViewMobileSiteTitleString)
@@ -59,7 +63,7 @@ class MenuTests: XCTestCase {
 
     func testMenuConfigurationForHomePanels() {
         let homePanelState = HomePanelState(isPrivate: false, selectedIndex: 0)
-        let homePanelConfiguration = AppMenuConfiguration(appState: .HomePanels(homePanelState: homePanelState))
+        let homePanelConfiguration = AppMenuConfiguration(appState: appState(.HomePanels(homePanelState: homePanelState)))
         XCTAssertEqual(homePanelConfiguration.menuItems.count, 3)
         XCTAssertEqual(homePanelConfiguration.menuItems[0].title, AppMenuConfiguration.NewTabTitleString)
         XCTAssertEqual(homePanelConfiguration.menuItems[1].title, AppMenuConfiguration.NewPrivateTabTitleString)
@@ -70,7 +74,7 @@ class MenuTests: XCTestCase {
 
     func testMenuConfigurationForTabTray() {
         let tabTrayState = TabTrayState(isPrivate: false)
-        let tabTrayConfiguration = AppMenuConfiguration(appState: .TabTray(tabTrayState: tabTrayState))
+        let tabTrayConfiguration = AppMenuConfiguration(appState: appState(.TabTray(tabTrayState: tabTrayState)))
         XCTAssertEqual(tabTrayConfiguration.menuItems.count, 4)
         XCTAssertEqual(tabTrayConfiguration.menuItems[0].title, AppMenuConfiguration.NewTabTitleString)
         XCTAssertEqual(tabTrayConfiguration.menuItems[1].title, AppMenuConfiguration.NewPrivateTabTitleString)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1272157

This moves the existing state to a `ui` property of an `AppState` struct.

`AppState` will begin to gain either a `prefs` property with some standalone selector/accessors functions (not methods) or a `HomePageHelper`.

Currently, it is not intended that `AppState` is immutable, but it is should be on the road to be.