### PR TITLE
Bug 1271721 - Added duration, tap to Settings, and different messaging to the notification status bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -456,6 +456,11 @@ class BrowserViewController: UIViewController {
         let state = getCurrentAppState()
         self.appDidUpdateState(state)
         log.debug("BVC done.")
+
+        NSNotificationCenter.defaultCenter().addObserver(self,
+                                                         selector: #selector(BrowserViewController.openSettings),
+                                                         name: NotificationStatusNotificationTapped,
+                                                         object: nil)
     }
 
     private func showRestoreTabsAlert() {
@@ -527,8 +532,12 @@ class BrowserViewController: UIViewController {
 
     override func viewWillDisappear(animated: Bool) {
         screenshotHelper.viewIsVisible = false
-
         super.viewWillDisappear(animated)
+    }
+
+    override func viewDidDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationStatusNotificationTapped, object: nil)
     }
 
     func resetBrowserChrome() {
@@ -1226,7 +1235,9 @@ class BrowserViewController: UIViewController {
         return .Tab(tabState: tab.tabState)
     }
 
-    private func openSettings() {
+    @objc private func openSettings() {
+        assert(NSThread.isMainThread(), "Opening settings requires being invoked on the main thread")
+
         let settingsTableViewController = AppSettingsTableViewController()
         settingsTableViewController.profile = profile
         settingsTableViewController.tabManager = tabManager

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -387,6 +387,16 @@ class TabTrayController: UIViewController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(TabTrayController.SELDynamicFontChanged(_:)), name: NotificationDynamicFontChanged, object: nil)
     }
 
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(TabTrayController.SELdidClickSettingsItem), name: NotificationStatusNotificationTapped, object: nil)
+    }
+
+    override func viewDidDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: NotificationStatusNotificationTapped, object: nil)
+    }
+
     override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -424,6 +434,8 @@ class TabTrayController: UIViewController {
     }
 
     func SELdidClickSettingsItem() {
+        assert(NSThread.isMainThread(), "Opening settings requires being invoked on the main thread")
+
         let settingsTableViewController = AppSettingsTableViewController()
         settingsTableViewController.profile = profile
         settingsTableViewController.tabManager = tabManager

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -208,7 +208,11 @@ private extension NotificationRootViewController {
         }
     }
 
-    @objc func fxaAccountDidChange() {
+    @objc func fxaAccountDidChange(notification: NSNotification) {
+        guard let userInfo = notification.userInfo where (userInfo[NotificationUserInfoKeyHasSyncableAccount] as? Bool ?? false) else {
+            return
+        }
+
         // Only show 'Syncing...' whenever the accounts have changed indicating a first time sync.
         showNotificationForSync = true
         syncTitle = Strings.FirstTimeSyncLongTime

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -160,7 +160,7 @@ private extension NotificationRootViewController {
         showNotificationForSync = false
 
         showingNotification = true
-        notificationView.titleLabel.text = Strings.SyncingMessageWithoutEllipsis
+        notificationView.titleLabel.text = Strings.FirstTimeSyncLongTime
         dispatch_async(dispatch_get_main_queue()) {
             self.showStatusNotification()
         }

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -6,6 +6,8 @@ import Foundation
 import SnapKit
 import Shared
 
+let NotificationStatusNotificationTapped = "NotificationStatusNotificationTapped"
+
 // Notification duration in seconds
 enum NotificationDuration: NSTimeInterval {
     case Short = 4
@@ -26,6 +28,7 @@ class NotificationRootViewController: UIViewController {
 
     lazy var notificationView: NotificationStatusView = {
         let view = NotificationStatusView()
+        view.addTarget(self, action: #selector(NotificationRootViewController.didTapNotification))
         view.hidden = true
         return view
     }()
@@ -216,8 +219,11 @@ private extension NotificationRootViewController {
         syncTitle = Strings.SyncingMessageWithoutEllipsis
     }
 
+    @objc func didTapNotification() {
+        notificationCenter.postNotificationName(NotificationStatusNotificationTapped, object: nil)
+    }
 
-    @objc private func dismissDurationedNotification() {
+    @objc func dismissDurationedNotification() {
         dispatch_async(dispatch_get_main_queue()) {
             self.hideStatusNotification()
         }
@@ -237,8 +243,12 @@ class NotificationStatusView: UIView {
         return label
     }
 
+    private let tapGesture = UITapGestureRecognizer()
+
     init() {
         super.init(frame: CGRect.zero)
+        userInteractionEnabled = true
+        addGestureRecognizer(tapGesture)
         backgroundColor = UIConstants.AppBackgroundColor
         addSubview(titleLabel)
         addSubview(ellipsisLabel)
@@ -269,6 +279,10 @@ class NotificationStatusView: UIView {
 
     func endAnimation() {
         animationTimer?.invalidate()
+    }
+
+    func addTarget(target: AnyObject, action: Selector) {
+        tapGesture.addTarget(target, action: action)
     }
 
     @objc func updateEllipsis() {

--- a/Client/Frontend/Notifications/NotificationRootViewController.swift
+++ b/Client/Frontend/Notifications/NotificationRootViewController.swift
@@ -73,9 +73,6 @@ extension NotificationRootViewController {
         super.viewWillAppear(animated)
         showingNotification ? remakeConstraintsForVisibleNotification() : remakeConstraintsForHiddenNotification()
         view.setNeedsLayout()
-
-        // Test
-//        NSTimer.scheduledTimerWithTimeInterval(4, target: self, selector: #selector(NotificationRootViewController.testSyncing), userInfo: nil, repeats: false)
     }
 
     override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
@@ -100,15 +97,6 @@ extension NotificationRootViewController {
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
         return .LightContent
     }
-
-//    func testSyncing() {
-//        NSNotificationCenter.defaultCenter().postNotificationName(NotificationFirefoxAccountChanged, object: nil, userInfo: [NotificationUserInfoKeyHasSyncableAccount: true])
-//        NSNotificationCenter.defaultCenter().postNotificationName(NotificationProfileDidStartSyncing, object: nil, userInfo: nil)
-//        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2 * Double(NSEC_PER_SEC)))
-//        dispatch_after(delayTime, dispatch_get_main_queue()) {
-//            self.syncFailed()
-//        }
-//    }
 }
 
 // MARK: - Notification API
@@ -229,18 +217,6 @@ private extension NotificationRootViewController {
                 self.showStatusNotification(animated: false, withEllipsis: true)
             } else {
                 self.showStatusNotification(withEllipsis: true)
-            }
-        }
-    }
-
-    @objc func syncFailed() {
-        dispatch_async(dispatch_get_main_queue()) {
-            self.notificationView.titleLabel.text = "Sync failed!"
-            if self.showingNotification {
-                self.hideStatusNotification(animated: false)
-                self.showStatusNotification(animated: false)
-            } else {
-                self.showStatusNotification()
             }
         }
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -76,6 +76,8 @@ class DisconnectSetting: WithAccountSetting {
 }
 
 class SyncNowSetting: WithAccountSetting {
+    static let NotificationUserInitiatedSyncManually = "NotificationUserInitiatedSyncManually"
+
     private lazy var timestampFormatter: NSDateFormatter = {
         let formatter = NSDateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
@@ -129,6 +131,7 @@ class SyncNowSetting: WithAccountSetting {
     }
 
     override func onClick(navigationController: UINavigationController?) {
+        NSNotificationCenter.defaultCenter().postNotificationName(SyncNowSetting.NotificationUserInitiatedSyncManually, object: nil)
         profile.syncManager.syncEverything()
     }
 }

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -73,6 +73,7 @@ extension Strings {
 extension Strings {
     public static let SyncingMessageWithEllipsis = NSLocalizedString("Sync.SyncingEllipsis.Label", value: "Syncing…", comment: "Message displayed when the user's account is syncing with ellipsis at the end")
     public static let SyncingMessageWithoutEllipsis = NSLocalizedString("Sync.Syncing.Label", value: "Syncing", comment: "Message displayed when the user's account is syncing with no ellipsis")
+    public static let FirstTimeSyncLongTime = NSLocalizedString("Sync.FirstTimeMessage.Label", value: "Your first sync may take a while", comment: "Message displayed when the user syncs for the first time")
 }
 
 //Hotkey Titles

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -519,7 +519,8 @@ public class BrowserProfile: Profile {
         registerForNotifications()
         
         // tell any observers that our account has changed
-        NSNotificationCenter.defaultCenter().postNotificationName(NotificationFirefoxAccountChanged, object: nil)
+        let userInfo = [NotificationUserInfoKeyHasSyncableAccount: hasSyncableAccount()]
+        NSNotificationCenter.defaultCenter().postNotificationName(NotificationFirefoxAccountChanged, object: nil, userInfo: userInfo)
 
         self.syncManager.onAddedAccount()
     }

--- a/Utils/NotificationConstants.swift
+++ b/Utils/NotificationConstants.swift
@@ -14,3 +14,6 @@ public let NotificationOnLocationChange = "OnLocationChange"
 
 // Fired when the login synchronizer has finished applying remote changes
 public let NotificationDataRemoteLoginChangesWereApplied = "NotificationDataRemoteLoginChangesWereApplied"
+
+// MARK: Notification UserInfo Keys
+public let NotificationUserInfoKeyHasSyncableAccount = "NotificationUserInfoKeyHasSyncableAccount"


### PR DESCRIPTION
Implements changes for:

1. Show only when syncing for the first time
2. Show when the user has manually initiated a sync
3. Only show for a duration of 4 seconds
4. Tap to navigate to settings page

The only thing thats missing is notifying on a failed sync result.