### PR TITLE
Bug 1273155 - Fixed cut off menu while showing in-call/hotspot status bar

### DIFF
--- a/Client/Frontend/Menu/MenuPresentationAnimator.swift
+++ b/Client/Frontend/Menu/MenuPresentationAnimator.swift
@@ -78,6 +78,7 @@ extension MenuPresentationAnimator {
         guard let container = transitionContext.containerView() else { return }
 
         let menuView = menuController.view
+        menuView.frame = container.bounds
         let bottomView = baseController.view
 
         // Insert tab tray below the browser and force a layout so the collection view can get it's frame right


### PR DESCRIPTION
Force presented menu frame to match container bounds to properly resize for in-call status bars. Really annoying that by default presented view controllers from a custom VC don't respect the status bar.