### PR TITLE
Bug 1274070 - Add timestamp to core ping

### DIFF
--- a/Telemetry/CorePing.swift
+++ b/Telemetry/CorePing.swift
@@ -12,7 +12,7 @@ private let PrefKeyClientID = "PrefKeyClientID"
 private let PrefKeyModel = "PrefKeyModel"
 
 // See https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/core-ping.html
-private let PingVersion = 3
+private let PingVersion = 5
 
 class CorePing: TelemetryPing {
     let payload: JSON
@@ -57,6 +57,12 @@ class CorePing: TelemetryPing {
 
         let locale = NSBundle.mainBundle().preferredLocalizations.first!.stringByReplacingOccurrencesOfString("_", withString: "-")
 
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let date = formatter.stringFromDate(NSDate())
+
+        let timezoneOffset = NSTimeZone.localTimeZone().secondsFromGMT / 60
+
         let out: [String: AnyObject] = [
             "v": PingVersion,
             "clientId": clientID,
@@ -67,7 +73,9 @@ class CorePing: TelemetryPing {
             "device": "Apple-" + model,
             "arch": "arm",
             "profileDate": profileDate,
-            "defaultSearch": profile.searchEngines.defaultEngine.id
+            "defaultSearch": profile.searchEngines.defaultEngine.id,
+            "created": date,
+            "tz": timezoneOffset
         ]
 
         payload = JSON(out)

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -4,6 +4,7 @@
 
 import Alamofire
 import Foundation
+import GCDWebServers
 import XCGLogger
 
 private let log = Logger.browserLogger
@@ -47,6 +48,7 @@ public class Telemetry {
 
         request.HTTPMethod = "POST"
         request.HTTPBody = body
+        request.addValue(GCDWebServerFormatRFC822(NSDate()), forHTTPHeaderField: "Date")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         Alamofire.Manager.sharedInstance.request(request).response { (request, response, data, error) in


### PR DESCRIPTION
Sample ping:

```
{
   "locale":"en",
   "osversion":"9.3.0",
   "defaultSearch":"yahoo",
   "seq":41,
   "os":"iOS",
   "tz":-420,
   "device":"Apple-x86_64",
   "clientId":"B65CE123-EF0B-4023-9D6C-8FF3A65556E7",
   "v":5,
   "created":"2016-05-18",
   "profileDate":16934,
   "arch":"arm"
}
```