### PR TITLE
No bug - Add an issue template encouraging people to use bugzilla

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+Hey there! Thanks for using Firefox!
+
+We prefer to have bugs in Bugzilla. That way issues can be tracked and the rest of Mozilla can help us fix and verify issues as well.
+
+We would love if you have found a bug to report it in Bugzilla. [File a new bug](https://bugzilla.mozilla.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2F&bug_ignored=0&op_sys=iOS%20&product=Firefox%20for%20iOS&rep_platform=All)
+
+If you are having an issue building or running the project message us on IRC. There are lots of people who are around to help. We are on [#mobile](https://wiki.mozilla.org/IRC)


### PR DESCRIPTION
I thought it would be a good idea to add an issue template to encourage people to use bugzilla instead of github issues. Let me know what you guys think

You can read about issue templates here 
https://github.com/blog/2111-issue-and-pull-request-templates