### PR TITLE
Bug 1263624 - Prevent sharing non-HTTP(S) URLs

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -19,6 +19,9 @@ private func applicationBundle() -> NSBundle {
 // SendTo extension.
 extension Strings {
     public static let SendToCancelButton = NSLocalizedString("SendTo.Cancel.Button", value: "Cancel", bundle: applicationBundle(), comment: "Button title for cancelling SendTo screen")
+    public static let SendToErrorOKButton = NSLocalizedString("SendTo.Error.OK.Button", value: "OK", bundle: applicationBundle(), comment: "OK button to dismiss the error prompt.")
+    public static let SendToErrorTitle = NSLocalizedString("SendTo.Error.Title", value: "The link you are trying to share cannot be shared.", bundle: applicationBundle(), comment: "Title of error prompt displayed when an invalid URL is shared.")
+    public static let SendToErrorMessage = NSLocalizedString("SendTo.Error.Message", value: "Only HTTP and HTTPS links can be shared.", bundle: applicationBundle(), comment: "Message in error prompt explaining why the URL is invalid.")
 }
 
 // ShareTo extension.

--- a/Extensions/ViewLater/ActionRequestHandler.swift
+++ b/Extensions/ViewLater/ActionRequestHandler.swift
@@ -12,13 +12,12 @@ class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
     func beginRequestWithExtensionContext(context: NSExtensionContext) {
         ExtensionUtils.extractSharedItemFromExtensionContext(context, completionHandler: {
             (item, error) -> Void in
-            if error == nil && item != nil {
+            if let item = item where error == nil && item.isShareable {
                 let profile = BrowserProfile(localName: "profile", app: nil)
-                profile.queue.addToQueue(item!)
-                context.completeRequestReturningItems([], completionHandler: nil);
-            } else {
-                context.completeRequestReturningItems([], completionHandler: nil);
+                profile.queue.addToQueue(item)
             }
+
+            context.completeRequestReturningItems([], completionHandler: nil)
         })
     }
 }

--- a/Storage/Sharing.swift
+++ b/Storage/Sharing.swift
@@ -18,6 +18,11 @@ public struct ShareItem {
         self.title = title
         self.favicon = favicon
     }
+
+    // We only support sharing HTTP and HTTPS URLs.
+    public var isShareable: Bool {
+        return NSURL(string: url)?.isWebPage() ?? false
+    }
 }
 
 public protocol ShareToDestination {

--- a/Utils/ExtensionUtils.swift
+++ b/Utils/ExtensionUtils.swift
@@ -8,33 +8,40 @@ import MobileCoreServices
 public struct ExtensionUtils {
     /// Look through the extensionContext for a url and title. Walks over all inputItems and then over all the attachments.
     /// Has a completionHandler because ultimately an XPC call to the sharing application is done.
-    /// We can always extract a URL and sometimes a title. The favicon is currently just a placeholder, but future code can possibly interact with a web page to find a proper icon.
+    /// We can always extract a URL and sometimes a title. The favicon is currently just a placeholder, but
+    /// future code can possibly interact with a web page to find a proper icon.
     public static func extractSharedItemFromExtensionContext(extensionContext: NSExtensionContext?, completionHandler: (ShareItem?, NSError!) -> Void) {
-        if extensionContext != nil {
-            if let inputItems : [NSExtensionItem] = extensionContext!.inputItems as? [NSExtensionItem] {
-                for inputItem in inputItems {
-                    if let attachments = inputItem.attachments as? [NSItemProvider] {
-                        for attachment in attachments {
-                            if attachment.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
-                                attachment.loadItemForTypeIdentifier(kUTTypeURL as String, options: nil, completionHandler: { (obj, err) -> Void in
-                                    if err != nil {
-                                        completionHandler(nil, err)
-                                    } else {
-                                        let title = inputItem.attributedContentText?.string as String?
-                                        if let url = obj as? NSURL {
-                                            completionHandler(ShareItem(url: url.absoluteString, title: title, favicon: nil), nil)
-                                        } else {
-                                            completionHandler(nil, NSError(domain: "org.mozilla.fennec", code: 999, userInfo: ["Problem": "Non-URL result."]))
-                                        }
-                                    }
-                                })
-                                return
-                            }
+        guard let extensionContext = extensionContext,
+              let inputItems = extensionContext.inputItems as? [NSExtensionItem] else {
+            completionHandler(nil, nil)
+            return
+        }
+
+        for inputItem in inputItems {
+            guard let attachments = inputItem.attachments as? [NSItemProvider] else { continue }
+
+            for attachment in attachments {
+                if attachment.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
+                    attachment.loadItemForTypeIdentifier(kUTTypeURL as String, options: nil) { obj, err in
+                        guard err == nil else {
+                            completionHandler(nil, err)
+                            return
                         }
+
+                        guard let url = obj as? NSURL else {
+                            completionHandler(nil, NSError(domain: "org.mozilla.fennec", code: 999, userInfo: ["Problem": "Non-URL result."]))
+                            return
+                        }
+
+                        let title = inputItem.attributedContentText?.string
+                        completionHandler(ShareItem(url: url.absoluteString, title: title, favicon: nil), nil)
                     }
+
+                    return
                 }
             }
         }
+
         completionHandler(nil, nil)
     }
 }


### PR DESCRIPTION
Cleaned up and simplified @st3fan's WIP #1716.

Rather than creating custom error UI for each extension, I opted to stick with a simple `UIAlertViewController` instead to display the error. We don't show errors for `ViewLater`, but we don't have many options there since it's a non-VC extension.