### PR TITLE
Bug 1271380 - Report search counts in core ping

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 		D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA77831A43B2CE0010CD32 /* OpenSearch.swift */; };
 		D38F02D11C05127100175932 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F02D01C05127100175932 /* Authenticator.swift */; };
 		D38F03701C06387900175932 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38F036F1C06387900175932 /* AuthenticationTests.swift */; };
+		D3921DBE1CEFD33600679798 /* ClientTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3921DBD1CEFD33600679798 /* ClientTelemetry.swift */; };
 		D3968F251A38FE8500CEFD3B /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3968F241A38FE8500CEFD3B /* TabManager.swift */; };
 		D3972BF31C22412B00035B87 /* ShareExtensionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF11C22412B00035B87 /* ShareExtensionHelper.swift */; };
 		D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */; };
@@ -1435,6 +1436,7 @@
 		D38A1EDF1CB458EC0080C842 /* CertError.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = CertError.html; sourceTree = "<group>"; };
 		D38F02D01C05127100175932 /* Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
 		D38F036F1C06387900175932 /* AuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
+		D3921DBD1CEFD33600679798 /* ClientTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientTelemetry.swift; sourceTree = "<group>"; };
 		D3968F241A38FE8500CEFD3B /* TabManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 		D3972BF11C22412B00035B87 /* ShareExtensionHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareExtensionHelper.swift; sourceTree = "<group>"; };
 		D3972BF21C22412B00035B87 /* TitleActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TitleActivityItemProvider.swift; sourceTree = "<group>"; };
@@ -2056,6 +2058,7 @@
 				D35F55871CC5A3E400DC0D22 /* CorePing.swift */,
 				D35F55891CC5A4E000DC0D22 /* Telemetry.swift */,
 				28BFA7241C8E5C3F0017C2BD /* TelemetryPing.swift */,
+				D3921DBD1CEFD33600679798 /* ClientTelemetry.swift */,
 			);
 			name = Telemetry;
 			sourceTree = "<group>";
@@ -4671,6 +4674,7 @@
 				7BC68CCB1CC152B70043562A /* MenuDataSource.swift in Sources */,
 				E65072A31B2737DA001A0AC6 /* GeometryExtensions.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
+				D3921DBE1CEFD33600679798 /* ClientTelemetry.swift in Sources */,
 				E664B45A1CD7ECDB0045A6A4 /* NotificationRootViewController.swift in Sources */,
 				2FDE87FE1ABB3817005317B1 /* RemoteTabsPanel.swift in Sources */,
 				39DD030D1CD53E1900BC09B3 /* HomePageHelper.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -80,6 +80,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let profile = getProfile(application)
         appStateStore = AppStateStore(prefs: profile.prefs)
 
+        log.debug("Initializing telemetry…")
+        Telemetry.initWithPrefs(profile.prefs)
+
         if !DebugSettingsBundleOptions.disableLocalWebServer {
             log.debug("Starting web server…")
             // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1513,11 +1513,14 @@ extension BrowserViewController: URLBarDelegate {
     func urlBar(urlBar: URLBarView, didSubmitText text: String) {
         // If we can't make a valid URL, do a search query.
         // If we still don't have a valid URL, something is broken. Give up.
+        let engine = profile.searchEngines.defaultEngine
         guard let url = URIFixup.getURL(text) ??
-                        profile.searchEngines.defaultEngine.searchURLForQuery(text) else {
+                        engine.searchURLForQuery(text) else {
             log.error("Error handling URL entry: \"\(text)\".")
             return
         }
+
+        Telemetry.recordEvent(SearchTelemetry.makeEvent(engine: engine, source: .URLBar))
 
         finishEditingAndSubmit(url, visitType: VisitType.Typed)
     }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -376,10 +376,20 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     func SELdidSelectEngine(sender: UIButton) {
         // The UIButtons are the same cardinality and order as the array of quick search engines.
         // Subtract 1 from index to account for magnifying glass accessory.
-        if let index = searchEngineScrollViewContent.subviews.indexOf(sender),
-           let url = quickSearchEngines[index - 1].searchURLForQuery(searchQuery) {
-            searchDelegate?.searchViewController(self, didSelectURL: url)
+        guard let index = searchEngineScrollViewContent.subviews.indexOf(sender) else {
+            assertionFailure()
+            return
         }
+
+        let engine = quickSearchEngines[index - 1]
+
+        guard let url = engine.searchURLForQuery(searchQuery) else {
+            assertionFailure()
+            return
+        }
+
+        Telemetry.recordEvent(SearchTelemetry.makeEvent(engine: engine, source: .QuickSearch))
+        searchDelegate?.searchViewController(self, didSelectURL: url)
     }
 
     func SELdidClickSearchButton() {
@@ -545,11 +555,15 @@ extension SearchViewController {
 
 extension SearchViewController: SuggestionCellDelegate {
     private func suggestionCell(suggestionCell: SuggestionCell, didSelectSuggestion suggestion: String) {
+        // Assume that only the default search engine can provide search suggestions.
+        let engine = searchEngines.defaultEngine
+
         var url = URIFixup.getURL(suggestion)
         if url == nil {
-            // Assume that only the default search engine can provide search suggestions.
-            url = searchEngines?.defaultEngine.searchURLForQuery(suggestion)
+            url = engine.searchURLForQuery(suggestion)
         }
+
+        Telemetry.recordEvent(SearchTelemetry.makeEvent(engine: engine, source: .Suggestion))
 
         if let url = url {
             searchDelegate?.searchViewController(self, didSelectURL: url)

--- a/ClientTelemetry.swift
+++ b/ClientTelemetry.swift
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Shared
+
+private let PrefKeySearches = "Telemetry.Searches"
+
+class SearchTelemetry {
+    // For data consistency, the strings used here are identical to the ones reported in Android.
+    enum Source: String {
+        case URLBar = "actionbar"
+        case QuickSearch = "listitem"
+        case Suggestion = "suggestion"
+    }
+
+    private init() {}
+
+    class func makeEvent(engine engine: OpenSearchEngine, source: Source) -> TelemetryEvent {
+        let engineID = engine.engineID ?? "other"
+        return SearchTelemetryEvent(engineWithSource: "\(engineID).\(source.rawValue)")
+    }
+
+    class func getData(prefs: Prefs) -> [String: Int]? {
+        return prefs.dictionaryForKey(PrefKeySearches) as? [String: Int]
+    }
+
+    class func resetCount(prefs: Prefs) {
+        prefs.removeObjectForKey(PrefKeySearches)
+    }
+}
+
+private class SearchTelemetryEvent: TelemetryEvent {
+    private let engineWithSource: String
+
+    init(engineWithSource: String) {
+        self.engineWithSource = engineWithSource
+    }
+
+    func record(prefs: Prefs) {
+        var searches = SearchTelemetry.getData(prefs) ?? [:]
+        searches[engineWithSource] = (searches[engineWithSource] ?? 0) + 1
+        prefs.setObject(searches, forKey: PrefKeySearches)
+    }
+}

--- a/Telemetry/CorePing.swift
+++ b/Telemetry/CorePing.swift
@@ -12,7 +12,7 @@ private let PrefKeyClientID = "PrefKeyClientID"
 private let PrefKeyModel = "PrefKeyModel"
 
 // See https://gecko.readthedocs.org/en/latest/toolkit/components/telemetry/telemetry/core-ping.html
-private let PingVersion = 5
+private let PingVersion = 6
 
 class CorePing: TelemetryPing {
     let payload: JSON
@@ -64,7 +64,7 @@ class CorePing: TelemetryPing {
 
         let timezoneOffset = NSTimeZone.localTimeZone().secondsFromGMT / 60
 
-        let out: [String: AnyObject] = [
+        var out: [String: AnyObject] = [
             "v": PingVersion,
             "clientId": clientID,
             "seq": Int(pingCount),
@@ -78,6 +78,11 @@ class CorePing: TelemetryPing {
             "created": date,
             "tz": timezoneOffset,
         ]
+
+        if let searches = SearchTelemetry.getData(profile.prefs) {
+            out["searches"] = searches
+            SearchTelemetry.resetCount(profile.prefs)
+        }
 
         payload = JSON(out)
     }

--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -11,7 +11,27 @@ private let log = Logger.browserLogger
 private let ServerURL = "https://incoming.telemetry.mozilla.org".asURL!
 private let AppName = "Fennec"
 
+public protocol TelemetryEvent {
+    func record(prefs: Prefs)
+}
+
 public class Telemetry {
+    private static var prefs: Prefs?
+
+    public class func initWithPrefs(prefs: Prefs) {
+        assert(self.prefs == nil, "Prefs already initialized")
+        self.prefs = prefs
+    }
+
+    public class func recordEvent(event: TelemetryEvent) {
+        guard let prefs = prefs else {
+            assertionFailure("Prefs not initialized")
+            return
+        }
+
+        event.record(prefs)
+    }
+
     public class func sendPing(ping: TelemetryPing) {
         let payload = ping.payload.toString()
 


### PR DESCRIPTION
The first commit creates/send the core ping only if we have an active network connection. The second commit adds search recording to our `SearchViewController` and reports this data with the core ping.

When creating the core ping, we immediately reset the search data that we're reporting. That means if we create the ping but the ping isn't successful, we'll drop the data. That's why the network connectivity check was added to the PR: it increases the likelihood that the ping will succeed.

Unless we want to take the time to implement a telemetry fault-handling layer that stores and resends unique pings, I think this is the best we can do. The other option would be to reset the count only after receiving an HTTP 200, where we'd instead be sending potentially duplicate pings instead of dropping them. I agree with [mcomella's comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1271378#c4) that missing data is better than bad data.