### PR TITLE
Bug 1274542 – Fix up open tab context menu items.

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -79,6 +79,7 @@ class TabScrollingController: NSObject {
 
     func showToolbars(animated animated: Bool, completion: ((finished: Bool) -> Void)? = nil) {
         if toolbarState == .Visible {
+            completion?(finished: true)
             return
         }
         toolbarState = .Visible
@@ -95,6 +96,7 @@ class TabScrollingController: NSObject {
 
     func hideToolbars(animated animated: Bool, completion: ((finished: Bool) -> Void)? = nil) {
         if toolbarState == .Collapsed {
+            completion?(finished: true)
             return
         }
         toolbarState = .Collapsed


### PR DESCRIPTION
The open tab/open private tab context menu item actions were only called after showToolbar animation completed.

If the toolbar was already shown, the call the completion block (i.e. open the tab) immediately.

There are no other callers of showTab with a completion block, and no callers of hidetab with a completion block.

https://bugzilla.mozilla.org/show_bug.cgi?id=1274542