### PR TITLE
Bug 1273864 - set the page control colour to match the menu tint colour

### DIFF
--- a/Client/Frontend/Widgets/Menu/MenuView.swift
+++ b/Client/Frontend/Widgets/Menu/MenuView.swift
@@ -85,6 +85,8 @@ class MenuView: UIView {
     override var tintColor: UIColor! {
         didSet {
             menuPagingView.tintColor = tintColor
+            pageControl.currentPageIndicatorTintColor = tintColor
+            pageControl.pageIndicatorTintColor = tintColor.colorWithAlphaComponent(0.25)
         }
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1273864