### PR TITLE
Bug 1274549 - Calculate the height of BoolSetting cells more accurately using contentView's frame

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -528,12 +528,10 @@ class SettingsTableViewController: UITableViewController {
     }
 
     private func calculateStatusCellHeightForSetting(setting: Setting) -> CGFloat {
-        let topBottomMargin: CGFloat = 10
+        dummyToggleCell.layoutSubviews()
 
-        let tableWidth = tableView.frame.width
-        let accessoryWidth = dummyToggleCell.accessoryView!.frame.width
-        let insetsWidth = 2 * tableView.separatorInset.left
-        let width = tableWidth - accessoryWidth - insetsWidth
+        let topBottomMargin: CGFloat = 10
+        let width = dummyToggleCell.contentView.frame.width - 2 * dummyToggleCell.separatorInset.left
 
         return
             heightForLabel(dummyToggleCell.textLabel!, width: width, text: setting.title?.string) +


### PR DESCRIPTION
Looks like the math for calculating the height of BoolSettings was a bit off which caused the height to be improperly calculated for the setting in the Homepage screen. Instead of using the tableView's width, I use the dummy cell's contentView frame which is more accurate for the calculation.