### PR TITLE
Bug 1273813 - ensure that the menu in tab/home panel is dismissed cor…

### DIFF
--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -423,6 +423,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
         // The height of the suggestions row may change, so call reloadData() to recalculate cell heights.
         coordinator.animateAlongsideTransition({ _ in
             self.tableView.reloadData()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1036,7 +1036,7 @@ extension TabTrayController: UIAdaptivePresentationControllerDelegate, UIPopover
 extension TabTrayController: MenuViewControllerDelegate {
     func menuViewControllerDidDismiss(menuViewController: MenuViewController) { }
 
-    func shouldCloseMenu(menuViewController: MenuViewController, forTraitCollection traitCollection: UITraitCollection) -> Bool {
+    func shouldCloseMenu(menuViewController: MenuViewController, forRotationToNewSize size: CGSize, forTraitCollection traitCollection: UITraitCollection) -> Bool {
         return false
     }
 }

--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -8,7 +8,7 @@ private let maxNumberOfItemsPerPage = 6
 
 protocol MenuViewControllerDelegate: class {
     func menuViewControllerDidDismiss(menuViewController: MenuViewController)
-    func shouldCloseMenu(menuViewController: MenuViewController, forTraitCollection traitCollection: UITraitCollection) -> Bool
+    func shouldCloseMenu(menuViewController: MenuViewController, forRotationToNewSize size: CGSize, forTraitCollection traitCollection: UITraitCollection) -> Bool
 }
 
 enum MenuViewPresentationStyle {
@@ -151,12 +151,7 @@ class MenuViewController: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        if delegate?.shouldCloseMenu(self, forTraitCollection: self.traitCollection) ?? false {
-            // on rotation, any popovers are dismissed and then redisplayed once rotation is completed.
-            // however, as the first thing we do here is dismiss, that causes the menu to 'flash' before dismissal
-            // therefore set the source of the popoverPresentation offscreen so that we can't see it when it is redisplayedy.
-            // not the nicest solution but I can't find another wa
-            popoverPresentationController?.sourceRect = CGRectMake(-320, -320, 0, 0)
+        if delegate?.shouldCloseMenu(self, forRotationToNewSize: size, forTraitCollection: self.traitCollection) ?? false {
             self.dismissViewControllerAnimated(false, completion: {
                 self.delegate?.menuViewControllerDidDismiss(self)
             })


### PR DESCRIPTION
…rectly on rotation on all iOS versions

https://bugzilla.mozilla.org/show_bug.cgi?id=1273813

1. don't treat it as other displayedPopoverController's handled by the browser view controller so the menu itself determines whether it needs to be dismissed on rotation (this also stops the re-presentation issue from before and gets rid of that nasty hack)
2. change the strategy we use to determine if the menu should be dismissed - size classes alone are not enough as this causes issues on iOS 8.x and gets called several times on setting preferred content size in popover mode
3. update shouldCloseMenu protocol method to pass in the expected new size and use that to determine orientation