### PR TITLE
Bug 1276204 - ensure animation runs when dismissing presented view co…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1007,7 +1007,7 @@ class BrowserViewController: UIViewController {
                 return
         }
         if let presentedViewController = currentViewController.presentedViewController {
-            presentedViewController.dismissViewControllerAnimated(false, completion: nil)
+            presentedViewController.dismissViewControllerAnimated(true, completion: nil)
         }
         if currentViewController != self {
             self.navigationController?.popViewControllerAnimated(true)


### PR DESCRIPTION
…ntroller on open new tab

otherwise transition animations may leave views in the wrong place (i.e. toolbar buttons)

https://bugzilla.mozilla.org/show_bug.cgi?id=1276204