### PR TITLE
Bug 1276639 – Hide URL bar icons if bar is hidden.

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -798,10 +798,15 @@ extension URLBarView: Themeable {
 
 extension URLBarView: AppStateDelegate {
     func appDidUpdateState(appState: AppState) {
-        let showShareButton = HomePageAccessors.isButtonInMenu(appState)
-        homePageButton.hidden = showShareButton
-        shareButton.hidden = !showShareButton
-        homePageButton.enabled = HomePageAccessors.isButtonEnabled(appState)
+        if toolbarIsShowing {
+            let showShareButton = HomePageAccessors.isButtonInMenu(appState)
+            homePageButton.hidden = showShareButton
+            shareButton.hidden = !showShareButton
+            homePageButton.enabled = HomePageAccessors.isButtonEnabled(appState)
+        } else {
+            homePageButton.hidden = true
+            shareButton.hidden = true
+        }
     }
 }
 


### PR DESCRIPTION
Otherwise, the icons show up when the app is restored in private browsing.

https://bugzilla.mozilla.org/show_bug.cgi?id=1276639