### PR TITLE
Bug 1267167 – Today widgets open URLs in correct version of Firefox.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -5496,6 +5496,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = "firefox-nightly";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -5657,6 +5658,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = "firefox-internal";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -6337,6 +6339,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = "fennec-aurora";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -6799,6 +6802,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = "firefox-beta";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -7221,6 +7225,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = fennec;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -243,9 +243,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         guard let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) else {
             return false
         }
-        if components.scheme != "firefox" && components.scheme != "firefox-x-callback" {
+
+        guard let urlTypes = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleURLTypes") as? [AnyObject],
+                urlSchemes = urlTypes.first?["CFBundleURLSchemes"] as? [String] else {
+            // Something very strange has happened; org.mozilla.Client should be the zeroeth URL type.
+            log.error("Custom URL schemes not available for validating")
             return false
         }
+
+        guard let scheme = components.scheme where urlSchemes.contains(scheme) else {
+            log.warning("Cannot handle \(components.scheme) URL scheme")
+            return false
+        }
+
         var url: String?
         var isPrivate: Bool = false
         for item in (components.queryItems ?? []) as [NSURLQueryItem] {

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -32,6 +32,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>firefox</string>
+				<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>

--- a/Extensions/Today/Info.plist
+++ b/Extensions/Today/Info.plist
@@ -29,5 +29,7 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>TodayViewController</string>
 	</dict>
+	<key>MozInternalURLScheme</key>
+	<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
 </dict>
 </plist>

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -95,6 +95,14 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         return copiedURL != nil
     }
 
+    private var scheme: String {
+        guard let string = NSBundle.mainBundle().objectForInfoDictionaryKey("MozInternalURLScheme") as? String else {
+            // Something went wrong/weird, but we should fallback to the public one.
+            return "firefox"
+        }
+        return string
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -186,14 +194,15 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     // MARK: Button behaviour
 
     @objc func onPressNewTab(view: UIView) {
-        openContainingApp("firefox://")
+        openContainingApp()
     }
 
     @objc func onPressNewPrivateTab(view: UIView) {
-        openContainingApp("firefox://?private=true")
+        openContainingApp("?private=true")
     }
 
-    private func openContainingApp(urlString: String) {
+    private func openContainingApp(urlSuffix: String = "") {
+        let urlString = "\(scheme)://\(urlSuffix)"
         self.extensionContext?.openURL(NSURL(string: urlString)!) { success in
             log.info("Extension opened containing app: \(success)")
         }
@@ -204,7 +213,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             _ = NSURL(string: urlString) {
             let encodedString =
                 urlString.escape()
-            openContainingApp("firefox://?url=\(encodedString)")
+            openContainingApp("?url=\(encodedString)")
         }
     }
 }


### PR DESCRIPTION
This introduces a second URL scheme which is supposed to be internal to the app. The firefox scheme still exists, but allows us to be more predictable with different versions of the Firefox.

The biggest change to be aware of is the schemes are validated against the schemes registered in Info.plist (which is a bit redundant), and that it gets rid of any mention of the firefox-x-callback scheme, which was unused.

The Today widget needs to do a bit more work in order to pick the correct scheme.

This leaves every version of the app registering to open firefox:// URLs, which means any version of the app will be compatible with the OpenInFirefox library.

https://bugzilla.mozilla.org/show_bug.cgi?id=1267167