### PR TITLE
Bug 1276542 – Show homepage after intro page.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2683,6 +2683,11 @@ extension BrowserViewController: IntroViewControllerDelegate {
             }
             presentViewController(introViewController, animated: true) {
                 self.profile.prefs.setInt(1, forKey: IntroViewControllerSeenProfileKey)
+                // On first run (and forced) open up the homepage in the background.
+                let state = self.getCurrentAppState()
+                if let homePageURL = HomePageAccessors.getHomePage(state), tab = self.tabManager.selectedTab where DeviceInfo.hasConnectivity() {
+                    tab.loadRequest(NSURLRequest(URL: homePageURL))
+                }
             }
 
             return true


### PR DESCRIPTION
This means that the default home page is shown on first run.

We do this right after we show the intro page show that once the intro tour is finished, then the home page is instantly accessible.

This does not interfere with the What's New Page (given that what's new won't be run on first run).

https://bugzilla.mozilla.org/show_bug.cgi?id=1276542