### PR TITLE
Bug 1261926 better awesomebar bookmarks

### DIFF
--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -559,11 +559,11 @@ extension SQLiteHistory: BrowserHistory {
         "INNER JOIN \(TableDomains) ON \(TableDomains).id = \(TableHistory).domain_id " +
         "INNER JOIN \(TableVisits) ON \(TableVisits).siteID = \(TableHistory).id "
 
-        if includeBookmarks {
+        if includeBookmarks && AppConstants.MOZ_AWESOMEBAR_DUPES {
             ungroupedSQL.appendContentsOf("LEFT JOIN \(ViewAllBookmarks) on \(ViewAllBookmarks).url = \(TableHistory).url ")
         }
         ungroupedSQL.appendContentsOf(whereClause.stringByReplacingOccurrencesOfString("url", withString: "\(TableHistory).url").stringByReplacingOccurrencesOfString("title", withString: "\(TableHistory).title"))
-        if includeBookmarks {
+        if includeBookmarks && AppConstants.MOZ_AWESOMEBAR_DUPES {
             ungroupedSQL.appendContentsOf(" AND \(ViewAllBookmarks).url IS NULL")
         }
         ungroupedSQL.appendContentsOf(" GROUP BY historyID")
@@ -628,7 +628,7 @@ extension SQLiteHistory: BrowserHistory {
                 "1 AS is_bookmarked",
                 "FROM", ViewAwesomebarBookmarksWithIcons,
                 whereClause,                  // The columns match, so we can reuse this.
-                "GROUP BY url",
+                AppConstants.MOZ_AWESOMEBAR_DUPES ? "GROUP BY url" : "",
                 "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
             ].joinWithSeparator(" ")
 

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -632,7 +632,7 @@ extension SQLiteHistory: BrowserHistory {
             ].joinWithSeparator(" ")
 
             let sql =
-            "SELECT * FROM (SELECT * FROM (\(historyWithIconsSQL)) UNION ALL SELECT * FROM (\(bookmarksWithIconsSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+            "SELECT * FROM (SELECT * FROM (\(historyWithIconsSQL)) UNION SELECT * FROM (\(bookmarksWithIconsSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
             return (sql, args)
         }
 
@@ -652,8 +652,7 @@ extension SQLiteHistory: BrowserHistory {
             "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
         ].joinWithSeparator(" ")
 
-
-        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION ALL SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
+        let allSQL = "SELECT * FROM (SELECT * FROM (\(historySQL)) UNION SELECT * FROM (\(bookmarksSQL))) ORDER BY is_bookmarked DESC, frecencies DESC"
         return (allSQL, args)
     }
 }

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -628,6 +628,7 @@ extension SQLiteHistory: BrowserHistory {
                 "1 AS is_bookmarked",
                 "FROM", ViewAwesomebarBookmarksWithIcons,
                 whereClause,                  // The columns match, so we can reuse this.
+                "GROUP BY url",
                 "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
             ].joinWithSeparator(" ")
 
@@ -649,6 +650,7 @@ extension SQLiteHistory: BrowserHistory {
             "1 AS is_bookmarked",
             "FROM", ViewAwesomebarBookmarks,
             whereClause,                  // The columns match, so we can reuse this.
+            "GROUP BY url",
             "ORDER BY visitDate DESC LIMIT \(bookmarksLimit)",
         ].joinWithSeparator(" ")
 

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -78,4 +78,23 @@ public struct AppConstants {
             return true
         #endif
     }()
+
+
+
+    /// Enables/disables the de-duplication of awesomebar seach results functionality
+    public static let MOZ_AWESOMEBAR_DUPES: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return true
+        #elseif MOZ_CHANNEL_BETA
+            return true
+        #elseif MOZ_CHANNEL_NIGHTLY
+            return true
+        #elseif MOZ_CHANNEL_FENNEC
+            return true
+        #elseif MOZ_CHANNEL_AURORA
+            return true
+        #else
+            return true
+        #endif
+    }()
 }


### PR DESCRIPTION
I extracted the query and executed it directly against the DB. The changes made here are the ones that had the least impact on performance of the query while producing the desired results.

Performance pre changes: 0.031 seconds
Performance post changes: 0.032 seconds

Here I exclude any history items that are also bookmarks and then remove any duplicate bookmarks and then remove duplicates from the union of those two sets

https://bugzilla.mozilla.org/show_bug.cgi?id=1261926