### PR TITLE
Bug 1278224 - Wrapped loadLogins selector with parameter-less version to avoid Swift default param selector bug

### DIFF
--- a/Client/Frontend/Login Management/LoginListViewController.swift
+++ b/Client/Frontend/Login Management/LoginListViewController.swift
@@ -85,7 +85,7 @@ class LoginListViewController: SensitiveViewController {
         super.viewDidLoad()
 
         let notificationCenter = NSNotificationCenter.defaultCenter()
-        notificationCenter.addObserver(self, selector: #selector(LoginListViewController.loadLogins(_:)), name: NotificationDataRemoteLoginChangesWereApplied, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(LoginListViewController.remoteLoginsDidChange), name: NotificationDataRemoteLoginChangesWereApplied, object: nil)
 
         automaticallyAdjustsScrollViewInsets = false
         self.view.backgroundColor = UIColor.whiteColor()
@@ -186,7 +186,11 @@ class LoginListViewController: SensitiveViewController {
 
 // MARK: - Selectors
 private extension LoginListViewController {
-    @objc func loadLogins(query: String? = nil) {
+    @objc func remoteLoginsDidChange() {
+        loadLogins()
+    }
+
+    func loadLogins(query: String? = nil) {
         loadingStateView.hidden = false
 
         // Fill in an in-flight query and re-query


### PR DESCRIPTION
Invoking the selector `loadLogins(query: String? = nil)` from a NSNotification caused a runtime crash saying it couldn't find the selector. I think this has to do with the interop between Swift's default param and Obj-C handling of it as a selector. I've wrapped the `loadLogins` call with a parameterless selector to avoid this.