### PR TITLE
Bug 1278555 - isEditable query for bookmarks no respect Local vs Buffer bookmarks

### DIFF
--- a/Storage/SQL/SQLiteBookmarksModel.swift
+++ b/Storage/SQL/SQLiteBookmarksModel.swift
@@ -252,11 +252,14 @@ public class SQLiteBookmarksModelFactory: BookmarksModelFactory {
 }
 
 
-private func isEditableQuery(direction: Direction) -> String {
-    let isLocal = direction == .Local ? "1" : "0"
+private func isEditableExpression(direction: Direction) -> String {
+    if direction == .Buffer {
+        return "0"
+    }
+
     return "SELECT exists( " +
            "   SELECT exists(SELECT 1 FROM \(TableBookmarksBuffer)) AS hasBuffer, exists(SELECT 1 FROM \(TableBookmarksMirror)) AS hasMirror " +
-           "   WHERE hasBuffer == 0 OR (hasBuffer == 1 AND hasMirror == 0 AND \(isLocal)) " +
+           "   WHERE hasBuffer IS 0 OR hasMirror IS 0" +
            ")"
 }
 
@@ -267,7 +270,7 @@ extension SQLiteBookmarks {
         let args: Args = guids.map { $0 as AnyObject }
         let varlist = BrowserDB.varlist(args.count)
         let values =
-        "SELECT -1 AS id, guid, type, is_deleted, parentid, parentName, feedUri, pos, title, bmkUri, siteUri, folderName, faviconID, (\(isEditableQuery(direction))) AS isEditable " +
+        "SELECT -1 AS id, guid, type, is_deleted, parentid, parentName, feedUri, pos, title, bmkUri, siteUri, folderName, faviconID, (\(isEditableExpression(direction))) AS isEditable " +
         "FROM \(direction.valueView) WHERE guid IN \(varlist) AND NOT is_deleted"
 
         let withIcon = [
@@ -306,7 +309,7 @@ extension SQLiteBookmarks {
         "WHERE parent = ?"
 
         let values =
-        "SELECT -1 AS id, guid, type, is_deleted, parentid, parentName, feedUri, pos, title, bmkUri, siteUri, folderName, faviconID, (\(isEditableQuery(direction))) AS isEditable " +
+        "SELECT -1 AS id, guid, type, is_deleted, parentid, parentName, feedUri, pos, title, bmkUri, siteUri, folderName, faviconID, (\(isEditableExpression(direction))) AS isEditable " +
         "FROM \(valueView)"
 
         // We exclude queries and dynamic containers, because we can't


### PR DESCRIPTION
According to https://github.com/mozilla/firefox-ios/pull/1780#issuecomment-220616887, local bookmarks should still be editable even if we have unmerged buffer changes if we have never synced before (mirror is empty). This patch adds the direction to the isEditable query to allow local bookmarks to be editable if we have not synced before.