### PR TITLE
Bug 1278854 - Added back sharedItem assignment so SendTo can properly send tabs

### DIFF
--- a/Extensions/SendTo/ActionViewController.swift
+++ b/Extensions/SendTo/ActionViewController.swift
@@ -38,6 +38,7 @@ class ActionViewController: UIViewController, ClientPickerViewControllerDelegate
                 return
             }
 
+            self.sharedItem = item
             let clientPickerViewController = ClientPickerViewController()
             clientPickerViewController.clientPickerDelegate = self
             clientPickerViewController.profile = self.profile


### PR DESCRIPTION
Looks like the assignment for `sharedItem` was removed in this commit https://github.com/mozilla/firefox-ios/commit/493d1eb99d9d7f7641e9175edf40f5fb7ea098a4#diff-107cdb8c546d1e1a77a543a7545b6673. Added it back in.