### PR TITLE
Bug 1279478 - don't display an error when sync status is bad

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -107,6 +107,7 @@ class SyncNowSetting: WithAccountSetting {
 
         switch syncStatus {
         case .Bad(let message):
+            guard let message = message else { return syncNowTitle }
             return NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowErrorTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .Stale(let message):
             return  NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowWarningTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
@@ -170,12 +171,17 @@ class SyncNowSetting: WithAccountSetting {
         cell.textLabel?.lineBreakMode = .ByWordWrapping
         if let syncStatus = profile.syncManager.syncDisplayState {
             switch syncStatus {
-            case .Bad(_):
-                // add the red warning symbol
-                // add a link to the MANA page
-                cell.detailTextLabel?.attributedText = nil
-                cell.accessoryView = troubleshootButton
-                addIcon(errorIcon, toCell: cell)
+            case .Bad(let message):
+                if let _ = message {
+                    // add the red warning symbol
+                    // add a link to the MANA page
+                    cell.detailTextLabel?.attributedText = nil
+                    cell.accessoryView = troubleshootButton
+                    addIcon(errorIcon, toCell: cell)
+                } else {
+                    cell.detailTextLabel?.attributedText = status
+                    cell.accessoryView = nil
+                }
             case .Stale(_):
                 // add the amber warning symbol
                 // add a link to the MANA page

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -22,12 +22,15 @@ public let ProfileRemoteTabsSyncDelay: NSTimeInterval = 0.1
 public enum SyncDisplayState {
     case InProgress
     case Good
-    case Bad(message: String)
+    case Bad(message: String?)
     case Stale(message: String)
 
     func asObject() -> [String: String]? {
         switch self {
-        case .Bad(let message):
+        case .Bad(let msg):
+            guard let message = msg else {
+                return ["state": "Error"]
+            }
             return ["state": "Error",
                     "message": message]
         case .Stale(let message):
@@ -869,7 +872,7 @@ public class BrowserProfile: Profile {
             }
             guard let results = result.successValue else {
                 guard let _ = result.failureValue as? BookmarksMergeError else {
-                    return SyncDisplayState.Bad(message: Strings.FirefoxSyncFailedTitle)
+                    return SyncDisplayState.Bad(message: nil)
                 }
                 return SyncDisplayState.Stale(message: String(format:Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
             }


### PR DESCRIPTION
But do continue to log the sync status as bad so we continue to get telemetry as to the reasons why we are getting certain sync states