### PR TITLE
Bug 1279242 - Fix SQL query for searching logins to group OR clauses seperate from AND

### DIFF
--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -335,12 +335,12 @@ public class SQLiteLogins: BrowserLogins {
                 return "%\(query)%" as String?
             }
 
-            searchClauses.append(" username LIKE ? ")
+            searchClauses.append("username LIKE ? ")
             searchClauses.append(" password LIKE ? ")
-            searchClauses.append(" hostname LIKE ? ")
+            searchClauses.append(" hostname LIKE ?")
         }
 
-        let whereSearchClause = searchClauses.count > 0 ? "AND" + searchClauses.joinWithSeparator("OR") : ""
+        let whereSearchClause = searchClauses.count > 0 ? "AND (" + searchClauses.joinWithSeparator("OR") + ") " : ""
         let sql =
         "SELECT \(projection) FROM " +
             "\(TableLoginsLocal) WHERE is_deleted = 0 " + whereSearchClause +


### PR DESCRIPTION
When the query was run with no text, is_deleted = 0 was making sure that deleted logins wouldn't appear in the initial query. When text was used, the various OR clauses for searching username, passwords, email were appended to the end of the is_deleted = 0 query making deleted logins appears since it one of the OR cases would hold true and the is_deleted = 0 requirement was ignored.