### PR TITLE
Bug 1277572 – Change new tab behaviour based on user setting

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -99,11 +99,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             log.error("Failed to assign AVAudioSession category to allow playing with silent switch on for aural progress bar")
         }
 
-        let defaultRequest = PrivilegedRequest(URL: UIConstants.DefaultHomePage)
         let imageStore = DiskImageStore(files: profile.files, namespace: "TabManagerScreenshots", quality: UIConstants.ScreenshotQuality)
 
         log.debug("Configuring tabManager…")
-        self.tabManager = TabManager(defaultNewTabRequest: defaultRequest, prefs: profile.prefs, imageStore: imageStore)
+        self.tabManager = TabManager(prefs: profile.prefs, imageStore: imageStore)
         self.tabManager.stateDelegate = self
 
         // Add restoration class, the factory that will return the ViewController we

--- a/Client/Frontend/Accessors/NewTabAccessors.swift
+++ b/Client/Frontend/Accessors/NewTabAccessors.swift
@@ -55,21 +55,26 @@ enum NewTabPage: String {
         }
     }
 
-    var url: NSURL? {
+    var homePanelType: HomePanelType? {
         switch self {
-        case .BlankPage:
-            return nil
-        case .HomePage:
-            return nil
         case .TopSites:
-            return NSURL(string:"#panel=0", relativeToURL: UIConstants.AboutHomePage)
+            return HomePanelType.TopSites
         case .Bookmarks:
-            return NSURL(string:"#panel=1", relativeToURL: UIConstants.AboutHomePage)
+            return HomePanelType.Bookmarks
         case .History:
-            return NSURL(string:"#panel=2", relativeToURL: UIConstants.AboutHomePage)
+            return HomePanelType.History
         case .ReadingList:
-            return NSURL(string:"#panel=3", relativeToURL: UIConstants.AboutHomePage)
+            return HomePanelType.ReadingList
+        default:
+            return nil
         }
+    }
+
+    var url: NSURL? {
+        guard let homePanel = self.homePanelType else {
+            return nil
+        }
+        return homePanel.localhostURL
     }
 
     static let allValues = [BlankPage, TopSites, Bookmarks, History, ReadingList, HomePage]

--- a/Client/Frontend/Accessors/NewTabAccessors.swift
+++ b/Client/Frontend/Accessors/NewTabAccessors.swift
@@ -8,7 +8,7 @@ import XCGLogger
 
 /// Accessors to find what a new tab should do when created without a URL.
 struct NewTabAccessors {
-    static let PrefKey = "NewTabPrefKey"
+    static let PrefKey = PrefsKeys.KeyNewTab
     static let Default = NewTabPage.TopSites
 
     static func getNewTabPage(prefs: Prefs) -> NewTabPage {

--- a/Client/Frontend/Accessors/NewTabAccessors.swift
+++ b/Client/Frontend/Accessors/NewTabAccessors.swift
@@ -55,5 +55,22 @@ enum NewTabPage: String {
         }
     }
 
+    var url: NSURL? {
+        switch self {
+        case .BlankPage:
+            return nil
+        case .HomePage:
+            return nil
+        case .TopSites:
+            return NSURL(string:"#panel=0", relativeToURL: UIConstants.AboutHomePage)
+        case .Bookmarks:
+            return NSURL(string:"#panel=1", relativeToURL: UIConstants.AboutHomePage)
+        case .History:
+            return NSURL(string:"#panel=2", relativeToURL: UIConstants.AboutHomePage)
+        case .ReadingList:
+            return NSURL(string:"#panel=3", relativeToURL: UIConstants.AboutHomePage)
+        }
+    }
+
     static let allValues = [BlankPage, TopSites, Bookmarks, History, ReadingList, HomePage]
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1526,7 +1526,11 @@ extension BrowserViewController: URLBarDelegate {
     }
 
     func urlBarDidEnterOverlayMode(urlBar: URLBarView) {
-        showHomePanelController(inline: false)
+        if [.HomePage, .BlankPage].contains(NewTabAccessors.getNewTabPage(profile.prefs)) {
+            UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
+        } else {
+            showHomePanelController(inline: false)
+        }
     }
 
     func urlBarDidLeaveOverlayMode(urlBar: URLBarView) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1327,7 +1327,7 @@ extension BrowserViewController: MenuActionDelegate {
     private func openHomePanel(panel: HomePanelType, forAppState appState: AppState) {
         switch appState.ui {
         case .Tab(_):
-            self.openURLInNewTab(HomePanelViewController.urlForHomePanelOfType(panel)!, isPrivate: appState.ui.isPrivate())
+            self.openURLInNewTab(panel.localhostURL, isPrivate: appState.ui.isPrivate())
         case .HomePanels(_):
             self.homePanelController?.selectedPanel = panel
         default: break

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -290,8 +290,28 @@ class TabManager : NSObject {
             tab.createWebview()
         }
         tab.navigationDelegate = self.navDelegate
-        tab.loadRequest(request ?? defaultNewTabRequest)
 
+        if let request = request {
+            tab.loadRequest(request)
+        } else {
+            let newTabChoice = NewTabAccessors.getNewTabPage(prefs)
+            switch newTabChoice {
+            case .HomePage:
+                // We definitely have a homepage if we've got here 
+                // (so we can safely dereference it).
+                let url = HomePageAccessors.getHomePage(prefs)!
+                tab.loadRequest(NSURLRequest(URL: url))
+            case .BlankPage:
+                // Do nothing: we're already seeing a blank page.
+                break
+            default:
+                // The common case, where the NewTabPage enum defines
+                // one of the about:home pages.
+                if let url = newTabChoice.url {
+                    tab.loadRequest(PrivilegedRequest(URL: url))
+                }
+            }
+        }
         if flushToDisk {
         	storeChanges()
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -59,7 +59,6 @@ class TabManager : NSObject {
 
     private(set) var tabs = [Tab]()
     private var _selectedIndex = -1
-    private let defaultNewTabRequest: NSURLRequest
     private let navDelegate: TabManagerNavDelegate
     private(set) var isRestoring = false
 
@@ -102,11 +101,10 @@ class TabManager : NSObject {
         }
     }
 
-    init(defaultNewTabRequest: NSURLRequest, prefs: Prefs, imageStore: DiskImageStore?) {
+    init(prefs: Prefs, imageStore: DiskImageStore?) {
         assert(NSThread.isMainThread())
 
         self.prefs = prefs
-        self.defaultNewTabRequest = defaultNewTabRequest
         self.navDelegate = TabManagerNavDelegate()
         self.imageStore = imageStore
         super.init()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -1089,19 +1089,19 @@ extension TabTrayController: MenuActionDelegate {
                 }
             case .OpenTopSites:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.TopSites)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelType.TopSites.localhostURL))
                 }
             case .OpenBookmarks:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.Bookmarks)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelType.Bookmarks.localhostURL))
                 }
             case .OpenHistory:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.History)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelType.History.localhostURL))
                 }
             case .OpenReadingList:
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.openNewTab(PrivilegedRequest(URL: HomePanelViewController.urlForHomePanelOfType(.ReadingList)!))
+                    self.openNewTab(PrivilegedRequest(URL: HomePanelType.ReadingList.localhostURL))
                 }
             default: break
             }

--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -52,6 +52,10 @@ enum HomePanelType: Int {
     case Bookmarks = 1
     case History = 2
     case ReadingList = 3
+
+    var localhostURL: NSURL {
+        return NSURL(string:"#panel=\(self.rawValue)", relativeToURL: UIConstants.AboutHomePage)!
+    }
 }
 
 class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelDelegate {
@@ -320,9 +324,5 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
                 self.finishEditingButton = nil
             }
         })
-    }
-
-    static func urlForHomePanelOfType(type: HomePanelType) -> NSURL? {
-        return NSURL(string:"#panel=\(type.rawValue)", relativeToURL: UIConstants.AboutHomePage)
     }
 }

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -7,7 +7,6 @@ import Shared
 
 public struct UIConstants {
     static let AboutHomePage = NSURL(string: "\(WebServer.sharedInstance.base)/about/home/")!
-    static let DefaultHomePage = NSURL(string:"#panel=0", relativeToURL: AboutHomePage)!
 
     static let AppBackgroundColor = UIColor.blackColor()
     static let SystemBlueColor = UIColor(red: 0 / 255, green: 122 / 255, blue: 255 / 255, alpha: 1)

--- a/ClientTests/TabManagerTests.swift
+++ b/ClientTests/TabManagerTests.swift
@@ -30,7 +30,7 @@ class TabManagerTests: XCTestCase {
 
     func testTabManagerStoresChangesInDB() {
         let profile = TabManagerMockProfile()
-        let manager = TabManager(defaultNewTabRequest: NSURLRequest(URL: NSURL(fileURLWithPath: "http://localhost")), prefs: profile.prefs, imageStore: nil)
+        let manager = TabManager(prefs: profile.prefs, imageStore: nil)
         let configuration = WKWebViewConfiguration()
         configuration.processPool = WKProcessPool()
 

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -275,6 +275,10 @@ public class BrowserProfile: Profile {
             }
             // Set the default homepage.
             prefs.setString(PrefsDefaults.ChineseHomePageURL, forKey: PrefsKeys.KeyDefaultHomePageURL)
+
+            if prefs.stringForKey("NewTabPrefKey") == nil {
+                prefs.setString("HomePage", forKey: "NewTabPrefKey")
+            }
         } else {
             // Remove the default homepage. This does not change the user's preference,
             // just the behaviour when there is no homepage.

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -139,11 +139,11 @@ public struct AppConstants {
         #elseif MOZ_CHANNEL_BETA
             return false
         #elseif MOZ_CHANNEL_NIGHTLY
-            return false
+            return true
         #elseif MOZ_CHANNEL_FENNEC
             return true
         #elseif MOZ_CHANNEL_AURORA
-            return false
+            return true
         #else
             return true
         #endif

--- a/Utils/Prefs.swift
+++ b/Utils/Prefs.swift
@@ -11,10 +11,12 @@ public struct PrefsKeys {
     public static let KeyTopSitesCacheSize = "topSitesCacheSize"
     public static let KeyDefaultHomePageURL = "KeyDefaultHomePageURL"
     public static let KeyHomePageButtonIsInMenu = "HomePageButtonIsInMenuPrefKey"
+    public static let KeyNewTab = "NewTabPrefKey"
 }
 
 public struct PrefsDefaults {
     public static let ChineseHomePageURL = "http://mobile.firefoxchina.cn/"
+    public static let ChineseNewTabDefault = "HomePage"
 }
 
 public protocol Prefs {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1277572

This PR covers the cases of actually doing the work of opening the correct URL for the new tab.

It includes special handling for three main cases: HomePanels, Homepage and Blank page.

It also includes setting of default behaviour in China.

Finally, it includes disabling showing the homepanels if the user has selected the URL bar for blank pages and home pages, as it would make blank pages (especially) indistinguishable from the current behaviour.

It does not cover the actual setting itself, which was done in https://bugzilla.mozilla.org/show_bug.cgi?id=1277581