### PR TITLE
Bug 1278545 - Selecting all -> Delete on > 500 logins doesn't delete the logins

### DIFF
--- a/StorageTests/TestLogins.swift
+++ b/StorageTests/TestLogins.swift
@@ -87,6 +87,21 @@ class TestSQLiteLogins: XCTestCase {
         let result = logins.getAllLogins().value.successValue!
         XCTAssertEqual(result.count, 2)
     }
+    
+    func testRemoveManyLogins() {
+        log.debug("Remove a large number of logins at once")
+        var guids: [GUID] = []
+        for i in 0..<2000 {
+            let login = Login.createWithHostname("mozilla.org", username: "Fire", password: "fox", formSubmitURL: formSubmitURL)
+            if i <= 1000 {
+                guids += [login.guid]
+            }
+            addLogin(login).value
+        }
+        logins.removeLoginsWithGUIDs(guids).value
+        let result = logins.getAllLogins().value.successValue!
+        XCTAssertEqual(result.count, 999)
+    }
 
     func testUpdateLogin() {
         let expectation = self.expectationWithDescription("Update login")


### PR DESCRIPTION
The login deletion query makes use of host parameters to remove login entries with specific IDs. SQLite has a limit of 999 host parameters per statement, so when this was exceeded the statement failed. This instead batches the deletions to avoid hitting the parameter limit.