### PR TITLE
Bug 1281299 - Handle IPv6 addresses when extracting URL domains

### DIFF
--- a/SharedTests/NSURLExtensionsTests.swift
+++ b/SharedTests/NSURLExtensionsTests.swift
@@ -170,4 +170,11 @@ class NSURLExtensionsTests : XCTestCase {
         XCTAssertEqual(host!, "bugzilla.mozilla.org")
         XCTAssertEqual(nsURL!.fragment!, "h=dupes%7CData%20%26%20BI%20Services%20Team%7C")
     }
+
+    func testIPv6Domain() {
+        let url = "http://[::1]/foo/bar".asURL!
+        XCTAssertTrue(url.isIPv6)
+        XCTAssertNil(url.baseDomain())
+        XCTAssertEqual(url.normalizedHost()!, "[::1]")
+    }
 }

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -173,16 +173,14 @@ extension NSURL {
     :returns: The base domain string for the given host name.
     */
     public func baseDomain() -> String? {
-        if let host = self.host {
-            // If this is just a hostname and not a FQDN, use the entire hostname.
-            if !host.contains(".") {
-                return host
-            }
+        guard !isIPv6, let host = host else { return nil }
 
-            return publicSuffixFromHost(host, withAdditionalParts: 1)
-        } else {
-            return nil
+        // If this is just a hostname and not a FQDN, use the entire hostname.
+        if !host.contains(".") {
+            return host
         }
+
+        return publicSuffixFromHost(host, withAdditionalParts: 1)
     }
 
     /**
@@ -194,19 +192,28 @@ extension NSURL {
      */
     public func domainURL() -> NSURL {
         if let normalized = self.normalizedHost() {
-            return NSURL(scheme: self.scheme, host: normalized, path: "/") ?? self
+            // Use NSURLComponents instead of NSURL since the former correctly preserves
+            // brackets for IPv6 hosts, whereas the latter escapes them.
+            let components = NSURLComponents()
+            components.scheme = self.scheme
+            components.host = normalized
+            components.path = "/"
+            return components.URL ?? self
         }
         return self
     }
 
     public func normalizedHost() -> String? {
-        if var host = self.host {
-            if let range = host.rangeOfString("^(www|mobile|m)\\.", options: .RegularExpressionSearch) {
-                host.replaceRange(range, with: "")
-            }
-            return host
+        // Use components.host instead of self.host since the former correctly preserves
+        // brackets for IPv6 hosts, whereas the latter strips them.
+        guard let components = NSURLComponents(URL: self, resolvingAgainstBaseURL: false),
+              var host = components.host else { return nil }
+
+        if let range = host.rangeOfString("^(www|mobile|m)\\.", options: .RegularExpressionSearch) {
+            host.replaceRange(range, with: "")
         }
-        return nil
+
+        return host
     }
 
     /**
@@ -235,6 +242,10 @@ extension NSURL {
 
     public var isLocal: Bool {
         return host?.lowercaseString == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+
+    public var isIPv6: Bool {
+        return host?.containsString(":") ?? false
     }
 }
 

--- a/Utils/FaviconFetcher.swift
+++ b/Utils/FaviconFetcher.swift
@@ -205,27 +205,29 @@ public class FaviconFetcher : NSObject, NSXMLParserDelegate {
 
     // Returns the default favicon for a site based on the first letter of the site's domain
     class func getDefaultFavicon(url: NSURL) -> UIImage {
-        if let letterFromUrl = url.baseDomain() {
-            let faviconLetter = String(letterFromUrl[letterFromUrl.startIndex]).uppercaseString
-            if let cachedFavicon = characterToFaviconCache[faviconLetter] {
-                return cachedFavicon
-            }
-
-            var faviconImage = UIImage()
-            let faviconLabel = UILabel(frame: CGRect(x: 0, y: 0, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize))
-            faviconLabel.text = faviconLetter
-            faviconLabel.textAlignment = .Center
-            faviconLabel.font = UIFont.systemFontOfSize(18, weight: UIFontWeightMedium)
-            faviconLabel.textColor = UIColor.grayColor()
-            UIGraphicsBeginImageContextWithOptions(faviconLabel.bounds.size, false, 0.0)
-            faviconLabel.layer.renderInContext(UIGraphicsGetCurrentContext()!)
-            faviconImage = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-
-            characterToFaviconCache[faviconLetter] = faviconImage
-            return faviconImage
+        guard let character = url.baseDomain()?.characters.first else {
+            return defaultFavicon
         }
-        return defaultFavicon
+
+        let faviconLetter = String(character).uppercaseString
+
+        if let cachedFavicon = characterToFaviconCache[faviconLetter] {
+            return cachedFavicon
+        }
+
+        var faviconImage = UIImage()
+        let faviconLabel = UILabel(frame: CGRect(x: 0, y: 0, width: TwoLineCellUX.ImageSize, height: TwoLineCellUX.ImageSize))
+        faviconLabel.text = faviconLetter
+        faviconLabel.textAlignment = .Center
+        faviconLabel.font = UIFont.systemFontOfSize(18, weight: UIFontWeightMedium)
+        faviconLabel.textColor = UIColor.grayColor()
+        UIGraphicsBeginImageContextWithOptions(faviconLabel.bounds.size, false, 0.0)
+        faviconLabel.layer.renderInContext(UIGraphicsGetCurrentContext()!)
+        faviconImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        characterToFaviconCache[faviconLetter] = faviconImage
+        return faviconImage
     }
 }
 


### PR DESCRIPTION
We're crashing on [this line](https://github.com/mozilla/firefox-ios/blob/e8f885d0f169f55dd466838a09ba0a440b6bc83c/Client/Frontend/Browser/SearchViewController.swift#L536).

What's happening:
 1. [`tileURL` calls `domainURL`](https://github.com/mozilla/firefox-ios/blob/e8f885d0f169f55dd466838a09ba0a440b6bc83c/Storage/Site.swift#L69).
 2. [`domainURL` returns a new URL with a normalized host](https://github.com/mozilla/firefox-ios/blob/e8f885d0f169f55dd466838a09ba0a440b6bc83c/Utils/Extensions/NSURLExtensions.swift#L197). With the URL `http://[::1]`, `url.host` returns `::1` (not `[::1]`), so the "normalized" URL becomes `http://::1`.
 3. Since `http://::1` isn't a valid URL, the `url.baseDomain()` call [here](https://github.com/mozilla/firefox-ios/blob/e8f885d0f169f55dd466838a09ba0a440b6bc83c/Utils/FaviconFetcher.swift#L208) returns an empty string.
 4. Finally, we crash on an OOB error [here](https://github.com/mozilla/firefox-ios/blob/e8f885d0f169f55dd466838a09ba0a440b6bc83c/Utils/FaviconFetcher.swift#L209) since we try to access the first element of an empty string.

To fix this, we can tweak `domainURL` and `baseDomain` to return more reasonable values for IPv6 hosts.