### PR TITLE
Bug 1278564 — Failure to apply remote value-only bookmark changes

### DIFF
--- a/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
+++ b/Sync/Synchronizers/Bookmarks/BookmarksSynchronizer.swift
@@ -320,10 +320,9 @@ class ThreeWayBookmarksStorageMerger: BookmarksStorageMerger {
     // This is exposed for testing.
     func getMerger() -> Deferred<Maybe<ThreeWayTreeMerger>> {
         return self.storage.treesForEdges() >>== { (local, remote) in
-            if local.isEmpty && remote.isEmpty {
-                // We should never have been called!
-                return deferMaybe(BookmarksMergeError())
-            }
+            // At this point *might* have two empty trees. This should only be the case if
+            // there are value-only changes (e.g., a renamed bookmark).
+            // We don't fail in that case, but we could optimize here.
 
             // Find the mirror tree so we can compare.
             return self.storage.treeForMirror() >>== { mirror in

--- a/SyncTests/TestBookmarkTreeMerging.swift
+++ b/SyncTests/TestBookmarkTreeMerging.swift
@@ -748,11 +748,6 @@ class TestBookmarkTreeMerging: FailFastTestCase {
         } else {
             XCTFail("Mobile isn't a folder.")
         }
-
-
-        // If we try to merge again, we'll get a merge error because both sides are empty.
-        let getSecondMerger = storageMerger.getMerger().value
-        XCTAssertTrue(getSecondMerger.isFailure)
     }
 
     /**


### PR DESCRIPTION
The issue here is that a value-only change doesn't result in a remote (or local) tree. There was a sanity check in the merger to make sure that we weren't called with nothing to do, because upstream callers should short-circuit in that case. That check turns out to be too aggressive.

This PR adds a test and makes it work by removing that check.

We also need to remove an observational test elsewhere that verified the sanity check itself, and thus would now fail.