### PR TITLE
Bug 1281405 - Add matching removeObserver for willEnterForegroundNotification for the SensitiveViewController

### DIFF
--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -20,7 +20,7 @@ class SensitiveViewController: UIViewController {
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
         let notificationCenter = NSNotificationCenter.defaultCenter()
-        notificationCenter.removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplicationWillEnterForegroundNotification, object: nil)
         notificationCenter.removeObserver(self, name: UIApplicationWillResignActiveNotification, object: nil)
     }
 


### PR DESCRIPTION
As part of https://github.com/mozilla/firefox-ios/pull/1881/files#diff-b9c96e0cc2ba673b11af9041882f92ecR28, we moved to listening for willEnterForeground events instead of didBecomeActive. Just forgot to update the notification we remove the observer for.