### PR TITLE
Bug 1274290 - Using google search operations that have the format 'operation:' do nothing when searching

### DIFF
--- a/Client/Frontend/Browser/URIFixup.swift
+++ b/Client/Frontend/Browser/URIFixup.swift
@@ -7,11 +7,13 @@ import Foundation
 class URIFixup {
     static func getURL(entry: String) -> NSURL? {
         let trimmed = entry.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-        var url = NSURL(string: trimmed)
 
         // First check if the URL includes a scheme. This will handle
         // all valid requests starting with "http://", "about:", etc.
-        if !(url?.scheme.isEmpty ?? true) {
+        // However, we ensure that the scheme is one that is listed in
+        // the official URI scheme list, so that other such search phrases
+        // like "filetype:" are recognised as searches rather than URLs.
+        if let url = NSURL(string: trimmed) where url.schemeIsValid {
             return url
         }
 
@@ -25,8 +27,7 @@ class URIFixup {
 
         // If there is a ".", prepend "http://" and try again. Since this
         // is strictly an "http://" URL, we also require a host.
-        url = NSURL(string: "http://\(trimmed)")
-        if url?.host != nil {
+        if let url = NSURL(string: "http://\(trimmed)") where url.host != nil {
             return url
         }
 

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -90,6 +90,9 @@ extension NSURL {
     }
 }
 
+// The list of permanent URI schemes has been taken from http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml 
+private let permanentURISchemes = ["aaa", "aaas", "about", "acap", "acct", "cap", "cid", "coap", "coaps", "crid", "data", "dav", "dict", "dns", "example", "file", "ftp", "geo", "go", "gopher", "h323", "http", "https", "iax", "icap", "im", "imap", "info", "ipp", "ipps", "iris", "iris.beep", "iris.lwz", "iris.xpc", "iris.xpcs", "jabber", "ldap", "mailto", "mid", "msrp", "msrps", "mtqp", "mupdate", "news", "nfs", "ni", "nih", "nntp", "opaquelocktoken", "pkcs11", "pop", "pres", "reload", "rtsp", "rtsps", "rtspu", "service", "session", "shttp", "sieve", "sip", "sips", "sms", "snmp", "soap.beep", "soap.beeps", "stun", "stuns", "tag", "tel", "telnet", "tftp", "thismessage", "tip", "tn3270", "turn", "turns", "tv", "urn", "vemmi", "vnc", "ws", "wss", "xcon", "xcon-userid", "xmlrpc.beep", "xmlrpc.beeps", "xmpp", "z39.50r", "z39.50s"]
+
 extension NSURL {
 
     public func withQueryParams(params: [NSURLQueryItem]) -> NSURL {
@@ -235,6 +238,14 @@ extension NSURL {
 
     public var isLocal: Bool {
         return host?.lowercaseString == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
+    
+    /**
+     Returns whether the URL's scheme is one of those listed on the official list of URI schemes.
+     This only accepts permanent schemes: historical and provisional schemes are not accepted.
+     */
+    public var schemeIsValid: Bool {
+        return permanentURISchemes.contains(scheme)
     }
 }
 


### PR DESCRIPTION
By only accepting URLs that have valid schemes (i.e. on the approved list of URI schemes), we can now make searching in the form “command:value” (used by Google, for instance). It would hypothetically need to be updated if this list changes, but as the list changes rarely (not considering the provisional schemes), this would not appear to be an issue.