### PR TITLE
Bug 1279245 - Fixes issue where Firefox becomes unresponsive

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -490,7 +490,8 @@ class TabTrayController: UIViewController {
         privateMode = !privateMode
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs
-        if !privateMode && profile.prefs.boolForKey("settings.closePrivateTabs") ?? false {
+        let exitingPrivateMode = !privateMode && profile.prefs.boolForKey("settings.closePrivateTabs") ?? false
+        if exitingPrivateMode {
             tabManager.removeAllPrivateTabsAndNotify(false)
         }
 
@@ -503,7 +504,8 @@ class TabTrayController: UIViewController {
             toView = emptyPrivateTabsView
         } else {
             emptyPrivateTabsView.hidden = true
-            let newSnapshot = collectionView.snapshotViewAfterScreenUpdates(true)
+            //when exiting private mode don't screenshot the collectionview (causes the UI to hang)
+            let newSnapshot = collectionView.snapshotViewAfterScreenUpdates(!exitingPrivateMode)
             newSnapshot.frame = collectionView.frame
             view.insertSubview(newSnapshot, aboveSubview: fromView)
             collectionView.alpha = 0


### PR DESCRIPTION
This was one tricky bug. I figured it had something to do with animations. I still don't understand why this happens. 

The odd thing is that it happens _only_ when you have 2+ tabs in the tab tray. It doesn't happen when you have 1 tab in the tab tray. So weird. 