### PR TITLE
Bug 1270765 - Only invalidate Top Sites if something has changed post-sync

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -114,19 +114,19 @@ class TopSitesPanel: UIViewController {
 
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
-        case NotificationFirefoxAccountChanged, NotificationProfileDidFinishSyncing, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged:
-            // Only reload top sites if there the cache is dirty since the finish syncing 
+        case NotificationProfileDidFinishSyncing:
+            // Only reload top sites if there the cache is dirty since the finish syncing
             // notification is fired everytime the user re-enters the app from the background.
-            self.profile.history.areTopSitesDirtyWithLimit(self.maxFrecencyLimit) >>== { dirty in
+            self.profile.history.areTopSitesDirty(withLimit: self.maxFrecencyLimit) >>== { dirty in
                 if dirty {
                     self.refreshTopSites(self.maxFrecencyLimit)
                 }
             }
-            break
+        case NotificationFirefoxAccountChanged, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged:
+            self.refreshTopSites(self.maxFrecencyLimit)
         default:
             // no need to do anything at all
             log.warning("Received unexpected notification \(notification.name)")
-            break
         }
     }
 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -115,7 +115,13 @@ class TopSitesPanel: UIViewController {
     func notificationReceived(notification: NSNotification) {
         switch notification.name {
         case NotificationFirefoxAccountChanged, NotificationProfileDidFinishSyncing, NotificationPrivateDataClearedHistory, NotificationDynamicFontChanged:
-            refreshTopSites(maxFrecencyLimit)
+            // Only reload top sites if there the cache is dirty since the finish syncing 
+            // notification is fired everytime the user re-enters the app from the background.
+            self.profile.history.areTopSitesDirtyWithLimit(self.maxFrecencyLimit) >>== { dirty in
+                if dirty {
+                    self.refreshTopSites(self.maxFrecencyLimit)
+                }
+            }
             break
         default:
             // no need to do anything at all

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -35,7 +35,7 @@ public protocol BrowserHistory {
     func setTopSitesCacheSize(size: Int32)
     func clearTopSitesCache() -> Success
     func refreshTopSitesCache() -> Success
-    func areTopSitesDirtyWithLimit(limit: Int) -> Deferred<Maybe<Bool>>
+    func areTopSitesDirty(withLimit limit: Int) -> Deferred<Maybe<Bool>>
 }
 
 /**

--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -35,6 +35,7 @@ public protocol BrowserHistory {
     func setTopSitesCacheSize(size: Int32)
     func clearTopSitesCache() -> Success
     func refreshTopSitesCache() -> Success
+    func areTopSitesDirtyWithLimit(limit: Int) -> Deferred<Maybe<Bool>>
 }
 
 /**

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -294,7 +294,7 @@ extension SQLiteHistory: BrowserHistory {
         return updateTopSitesCacheWithLimit(cacheSize)
     }
 
-    public func areTopSitesDirtyWithLimit(limit: Int) -> Deferred<Maybe<Bool>> {
+    public func areTopSitesDirty(withLimit limit: Int) -> Deferred<Maybe<Bool>> {
         let (whereData, groupBy) = self.topSiteClauses()
         let (query, args) = self.filteredSitesByFrecencyQueryWithHistoryLimit(limit, bookmarksLimit: 0, groupClause: groupBy, whereData: whereData)
         let cacheArgs: Args = [limit]


### PR DESCRIPTION
Looks like flicker was being caused by the collection view always reloading everytime a sync finishes. Since we always re-sync after coming from the background, this occurs everytime the user re-enters the app. I've added some logic for checking if the Top Sites cache is actually dirty and to not reload otherwise.