### PR TITLE
Bug 1278545 - Selecting all -> Delete on > 500 logins doesn't delete the logins

### DIFF
--- a/Storage/SQL/SQLiteLogins.swift
+++ b/Storage/SQL/SQLiteLogins.swift
@@ -531,7 +531,7 @@ public class SQLiteLogins: BrowserLogins {
         return removeLoginsWithGUIDs([guid])
     }
     
-    private func getDeletionStatementsForGUIDs(guids: [GUID], nowMillis: Timestamp) -> [(sql: String, args: Args?)] {
+    private func getDeletionStatementsForGUIDs(guids: ArraySlice<GUID>, nowMillis: Timestamp) -> [(sql: String, args: Args?)] {
         let inClause = BrowserDB.varlist(guids.count)
 
         // Immediately delete anything that's marked as new -- i.e., it's never reached
@@ -572,7 +572,7 @@ public class SQLiteLogins: BrowserLogins {
     public func removeLoginsWithGUIDs(guids: [GUID]) -> Success {
         let timestamp = NSDate.now()
         return db.run(chunk(guids, by: BrowserDB.MaxVariableNumber).flatMap {
-            self.getDeletionStatementsForGUIDs(Array($0), nowMillis: timestamp)
+            self.getDeletionStatementsForGUIDs($0, nowMillis: timestamp)
         }) >>> effect(self.notifyLoginDidChange)
     }
 

--- a/StorageTests/TestLogins.swift
+++ b/StorageTests/TestLogins.swift
@@ -87,6 +87,21 @@ class TestSQLiteLogins: XCTestCase {
         let result = logins.getAllLogins().value.successValue!
         XCTAssertEqual(result.count, 2)
     }
+    
+    func testRemoveManyLogins() {
+        log.debug("Remove a large number of logins at once")
+        var guids: [GUID] = []
+        for i in 0..<2000 {
+            let login = Login.createWithHostname("mozilla.org", username: "Fire", password: "fox", formSubmitURL: formSubmitURL)
+            if i <= 1000 {
+                guids += [login.guid]
+            }
+            addLogin(login).value
+        }
+        logins.removeLoginsWithGUIDs(guids).value
+        let result = logins.getAllLogins().value.successValue!
+        XCTAssertEqual(result.count, 999)
+    }
 
     func testUpdateLogin() {
         let expectation = self.expectationWithDescription("Update login")


### PR DESCRIPTION
The login deletion query makes use of host parameters to remove login entries with specific IDs. SQLite has a limit of 999 host parameters per statement, so when this was exceeded the statement failed. This instead batches the deletions to avoid hitting the parameter limit.