### PR TITLE
Bug 1262113 - After performing an action in the Share menu it will re-open on iPads

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -124,12 +124,17 @@ class BrowserViewController: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-        displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
-
+        
         guard let displayedPopoverController = self.displayedPopoverController else {
             return
         }
+        
+        guard displayedPopoverController.isViewLoaded() && displayedPopoverController.view.window != nil else {
+            self.displayedPopoverController = nil
+            return
+        }
+
+        displayedPopoverController.dismissViewControllerAnimated(true, completion: nil)
 
         coordinator.animateAlongsideTransition(nil) { context in
             self.updateDisplayedPopoverProperties?()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -124,17 +124,14 @@ class BrowserViewController: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        
+
+        displayedPopoverController?.dismissViewControllerAnimated(true) {
+            self.displayedPopoverController = nil
+        }
+
         guard let displayedPopoverController = self.displayedPopoverController else {
             return
         }
-        
-        guard displayedPopoverController.isViewLoaded() && displayedPopoverController.view.window != nil else {
-            self.displayedPopoverController = nil
-            return
-        }
-
-        displayedPopoverController.dismissViewControllerAnimated(true, completion: nil)
 
         coordinator.animateAlongsideTransition(nil) { context in
             self.updateDisplayedPopoverProperties?()


### PR DESCRIPTION
The displayedPopoverController variable was not being cleared when the
popover was dismissed through an action, so when the view resized, it
was being re-shown.