### PR TITLE
Bug1282016 – ImagesVisibleInReaderModeInNoImagesMode

### DIFF
--- a/Client/Assets/NoImageModeHelper.js
+++ b/Client/Assets/NoImageModeHelper.js
@@ -31,9 +31,9 @@
 
   function blockImages (elem, enabled) {
     var imgs = document.getElementsByTagName("IMG");
-    for (var i=0; i<imgs.length;i++) {
-        var parent = imgs[i].parentNode;
-        parent.removeChild(imgs[i]);
+    while (imgs.length > 0) {
+        var parent = imgs[0].parentNode;
+        parent.removeChild(imgs[0]);
     }
   }
 


### PR DESCRIPTION
document.getElementsByTagName returns a live HTMLCollection, so
modifying the collection while iterating will cause elements to be
skipped.