### PR TITLE
Bug 1277227 - Ignore rotation event when background app to prevent out of sync Top Sites

### DIFF
--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -62,10 +62,11 @@ class TopSitesPanel: UIViewController {
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-        coordinator.animateAlongsideTransition({ context in
-            self.collection?.reloadData()
-        }, completion: nil)
+        if UIApplication.sharedApplication().applicationState != .Background {
+            coordinator.animateAlongsideTransition({ context in
+                self.collection?.reloadData()
+            }, completion: nil)
+        }
     }
 
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {


### PR DESCRIPTION
So this is strange. The viewWillTransitionToSize call in TopSitesPanel gets fired when the app becomes backgrounded on iPad devices. Since we reload the top sites panel here, it's re-laying everything out in the opposite orientation. When the user re-enters the app, the items and favicons get mixed up because its reconciling the opposite orientation with the actual one being shown. Unfortunately we need to implement this method to handle actual rotation events so removing it isn't an option. For now, I've added a check to make sure we only reload the top sites panel if we're rotating while in the app and not when becoming backgrounded.

Looking into this a bit, it seems that the API is called because the system needs to generate an app switcher snapshot for both orientations before being backgrounded so this is the expected (odd) behaviour of the API.