### PR TITLE
Bug 1171522 - Closing cross-origin windows

### DIFF
--- a/Client/Assets/WindowCloseHelper.js
+++ b/Client/Assets/WindowCloseHelper.js
@@ -10,7 +10,6 @@
         window.__firefox__.messages = {};
     }
     window.__firefox__.messages.close = "FIREFOX_MESSAGE_CLOSE";
-    window.__firefox__.messages.close = "FIREFOX_MESSAGE_REDIRECT";
  
     var _close = window.close;
  

--- a/Client/Assets/WindowCloseHelper.js
+++ b/Client/Assets/WindowCloseHelper.js
@@ -3,9 +3,55 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function () {
-  var _close = window.close;
-  window.close = function () {
-    webkit.messageHandlers.windowCloseHelper.postMessage(null);
-    _close();
-  };
+    if (!window.__firefox__) {
+        window.__firefox__ = {};
+    }
+    if (!window.__firefox__.messages) {
+        window.__firefox__.messages = {};
+    }
+    window.__firefox__.messages.close = "FIREFOX_MESSAGE_CLOSE";
+ 
+    var _close = window.close;
+    window.close = function () {
+        webkit.messageHandlers.windowCloseHelper.postMessage(null);
+        _close();
+    };
+    // A close message applies to the current window, so we need to execute the
+    // close method in the context of the child window when we want to close a
+    // window opened via window.open(). To do this we use window.postMessage, at
+    // the expense of a side effect in the case of a website sending a message
+    // identical to one contained in window.__firefox__.messages.close.
+    window.addEventListener("message", function (event) {
+        if (event.data === window.__firefox__.messages.close) {
+            window.close();
+            event.stopPropogation();
+        }
+    }, true);
+    var _open = window.open;
+    window.open = function (strUrl, strWindowName, strWindowFeatures) {
+        // If we simply return the reference returned by window.open(),
+        // then (the read-only) window.close() will fail to execute when the
+        // opened window is cross-domain. Thus, we return a proxy object with an
+        // overwritten .close() method to invoke our special handle function.
+        var opened = _open.apply(this, arguments);
+        var proxy = {};
+        for (var property in opened) {
+            if (typeof opened[property] === "function") {
+                proxy[property] = opened[property].bind(opened);
+            } else {
+                Object.defineProperty(proxy, property, {
+                    get: function () {
+                        return opened[property];
+                    },
+                    set: function (value) {
+                        opened[property] = value;
+                    }
+                });
+            }
+        }
+        proxy.close = function () {
+            opened.postMessage(window.__firefox__.messages.close, "*");
+        }
+        return proxy;
+    };
 })();

--- a/Client/Assets/WindowCloseHelper.js
+++ b/Client/Assets/WindowCloseHelper.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function () {
+ 
     if (!window.__firefox__) {
         window.__firefox__ = {};
     }
@@ -12,6 +13,7 @@
     window.__firefox__.messages.close = "FIREFOX_MESSAGE_CLOSE";
  
     var _close = window.close;
+ 
     window.close = function () {
         webkit.messageHandlers.windowCloseHelper.postMessage(null);
         _close();
@@ -24,7 +26,7 @@
     window.addEventListener("message", function (event) {
         if (event.data === window.__firefox__.messages.close) {
             window.close();
-            event.stopPropogation();
+            event.stopPropagation();
         }
     }, true);
     var _open = window.open;

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2486,9 +2486,7 @@ extension BrowserViewController: WKUIDelegate {
     @available(iOS 9, *)
     func webViewDidClose(webView: WKWebView) {
         if let tab = tabManager[webView] {
-            dispatch_async(dispatch_get_main_queue()) {
-                self.tabManager.removeTab(tab)
-            }
+            self.tabManager.removeTab(tab)
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1745,9 +1745,11 @@ extension BrowserViewController: TabDelegate {
         let errorHelper = ErrorPageHelper()
         tab.addHelper(errorHelper, name: ErrorPageHelper.name())
 
-        let windowCloseHelper = WindowCloseHelper(tab: tab)
-        windowCloseHelper.delegate = self
-        tab.addHelper(windowCloseHelper, name: WindowCloseHelper.name())
+        if #available(iOS 9, *) {} else {
+            let windowCloseHelper = WindowCloseHelper(tab: tab)
+            windowCloseHelper.delegate = self
+            tab.addHelper(windowCloseHelper, name: WindowCloseHelper.name())
+        }
 
         let findInPageHelper = FindInPageHelper(tab: tab)
         findInPageHelper.delegate = self
@@ -2479,6 +2481,15 @@ extension BrowserViewController: WKUIDelegate {
 
         openInHelper.open()
         decisionHandler(WKNavigationResponsePolicy.Cancel)
+    }
+    
+    @available(iOS 9, *)
+    func webViewDidClose(webView: WKWebView) {
+        if let tab = tabManager[webView] {
+            dispatch_async(dispatch_get_main_queue()) {
+                self.tabManager.removeTab(tab)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Cross-origin window.close() calls are now supported. This case occurred
with Persona login windows, which were not closing. Firefox now has the
same behaviour as Safari in this case.