### PR TITLE
Bug 1282583 - Tabs opened from context menus or window.open() are appended to the tab list

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2366,12 +2366,11 @@ extension BrowserViewController: WKUIDelegate {
         screenshotHelper.takeScreenshot(currentTab)
 
         // If the page uses window.open() or target="_blank", open the page in a new tab.
-        // TODO: This doesn't work for window.open() without user action (bug 1124942).
         let newTab: Tab
         if #available(iOS 9, *) {
-            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, isPrivate: currentTab.isPrivate)
+            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterCurrentTab: true, isPrivate: currentTab.isPrivate)
         } else {
-            newTab = tabManager.addTab(navigationAction.request, configuration: configuration)
+            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterCurrentTab: true)
         }
         tabManager.selectTab(newTab)
 
@@ -2835,7 +2834,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let newTabTitle = NSLocalizedString("Open In New Tab", comment: "Context menu item for opening a link in a new tab")
                 let openNewTabAction =  UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                        self.tabManager.addTab(NSURLRequest(URL: url))
+                        self.tabManager.addTab(NSURLRequest(URL: url), afterCurrentTab: true)
                     })
                 }
                 actionSheetController.addAction(openNewTabAction)
@@ -2845,7 +2844,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let openNewPrivateTabTitle = NSLocalizedString("Open In New Private Tab", tableName: "PrivateBrowsing", comment: "Context menu option for opening a link in a new private tab")
                 let openNewPrivateTabAction =  UIAlertAction(title: openNewPrivateTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                        self.tabManager.addTab(NSURLRequest(URL: url), isPrivate: true)
+                        self.tabManager.addTab(NSURLRequest(URL: url), afterCurrentTab: true, isPrivate: true)
                     })
                 }
                 actionSheetController.addAction(openNewPrivateTabAction)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2356,21 +2356,23 @@ private let SchemesAllowedToOpenPopups = ["http", "https", "javascript", "data"]
 
 extension BrowserViewController: WKUIDelegate {
     func webView(webView: WKWebView, createWebViewWithConfiguration configuration: WKWebViewConfiguration, forNavigationAction navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        guard let currentTab = tabManager.selectedTab else { return nil }
+        guard let parentTab = tabManager[webView] else { return nil }
 
         if !navigationAction.isAllowed {
             log.warning("Denying unprivileged request: \(navigationAction.request)")
             return nil
         }
 
-        screenshotHelper.takeScreenshot(currentTab)
+        if let currentTab = tabManager.selectedTab {
+            screenshotHelper.takeScreenshot(currentTab)
+        }
 
         // If the page uses window.open() or target="_blank", open the page in a new tab.
         let newTab: Tab
         if #available(iOS 9, *) {
-            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterCurrentTab: true, isPrivate: currentTab.isPrivate)
+            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterTab: parentTab, isPrivate: parentTab.isPrivate)
         } else {
-            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterCurrentTab: true)
+            newTab = tabManager.addTab(navigationAction.request, configuration: configuration, afterTab: parentTab)
         }
         tabManager.selectTab(newTab)
 
@@ -2834,7 +2836,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let newTabTitle = NSLocalizedString("Open In New Tab", comment: "Context menu item for opening a link in a new tab")
                 let openNewTabAction =  UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                        self.tabManager.addTab(NSURLRequest(URL: url), afterCurrentTab: true)
+                        self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab)
                     })
                 }
                 actionSheetController.addAction(openNewTabAction)
@@ -2844,7 +2846,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let openNewPrivateTabTitle = NSLocalizedString("Open In New Private Tab", tableName: "PrivateBrowsing", comment: "Context menu option for opening a link in a new private tab")
                 let openNewPrivateTabAction =  UIAlertAction(title: openNewPrivateTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
-                        self.tabManager.addTab(NSURLRequest(URL: url), afterCurrentTab: true, isPrivate: true)
+                        self.tabManager.addTab(NSURLRequest(URL: url), afterTab: currentTab, isPrivate: true)
                     })
                 }
                 actionSheetController.addAction(openNewPrivateTabAction)

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -90,6 +90,9 @@ class Tab: NSObject {
 
     private(set) var screenshot: UIImage?
     var screenshotUUID: NSUUID?
+    
+    // If this tab has been opened from another, its parent will point to the tab from which it was opened
+    var parent: Tab? = nil
 
     private var helperManager: HelperManager? = nil
     private var configuration: WKWebViewConfiguration? = nil
@@ -455,6 +458,17 @@ class Tab: NSObject {
         }
 
         updateAppState()
+    }
+    
+    func isDescendentOf(ancestor: Tab) -> Bool {
+        var tab = parent
+        while tab != nil {
+            if tab! == ancestor {
+                return true
+            }
+            tab = tab?.parent
+        }
+        return false
     }
 
     func setNoImageMode(enabled: Bool = false, force: Bool) {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -278,10 +278,15 @@ class TabManager : NSObject {
             delegate.get()?.tabManager(self, didCreateTab: tab)
         }
 
-        if !afterCurrentTab || selectedTab?.isPrivate != tab.isPrivate {
+        if !afterCurrentTab || selectedTab == nil || selectedTab?.isPrivate != tab.isPrivate {
             tabs.append(tab)
-        } else {
-            tabs.insert(tab, atIndex: _selectedIndex + 1)
+        } else if let selectedTab = selectedTab {
+            var insertIndex = _selectedIndex + 1
+            while insertIndex < tabs.count && tabs[insertIndex].isDescendentOf(selectedTab) {
+                insertIndex += 1
+            }
+            tab.parent = selectedTab
+            tabs.insert(tab, atIndex: insertIndex)
         }
 
         for delegate in delegates {


### PR DESCRIPTION
When opening new tabs from the context menu, or programmatically, tabs are now inserted directly after the tab from which they were opened.