### PR TITLE
Bug 1281841 – Logins screen unaccessible via passcode if Touch ID is enabled, then unenrolled from

### DIFF
--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -31,7 +31,7 @@ class AppAuthenticator {
 
                 dispatch_async(dispatch_get_main_queue()) {
                     switch code {
-                    case .UserFallback:
+                    case .UserFallback, .TouchIDNotEnrolled, .TouchIDNotAvailable, .TouchIDLockout:
                         fallback?()
                     case .UserCancel:
                         cancel?()


### PR DESCRIPTION
We simply add a few other cases that will lead to the fallback being
used, which prevents the user from being prevented from accessing the
logins screen.