### PR TITLE
Bug 1282887 - Use PrivilegedRequest for RDS reloads

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -342,7 +342,7 @@ class Tab: NSObject {
                 webView?.customUserAgent = userAgent
 
                 // Reload the initial URL to avoid UA specific redirection
-                loadRequest(NSURLRequest(URL: currentItem.initialURL, cachePolicy: .ReloadIgnoringLocalCacheData, timeoutInterval: 60))
+                loadRequest(PrivilegedRequest(URL: currentItem.initialURL, cachePolicy: .ReloadIgnoringLocalCacheData, timeoutInterval: 60))
                 return
             }
         }


### PR DESCRIPTION
`testBackForwardNavigationRestoresMobileOrDesktopSite` triggers Request Desktop Site, which loads the same page by firing `loadRequest` with a new `NSURLRequest`. As of [bug 1263627](https://bugzilla.mozilla.org/show_bug.cgi?id=1263627), any localhost requests will fail unless those requests are `PrivilegedRequest`s. That means we're failing now for any situations where we change UAs for localhost URLs.

Not a practical concern since changing the UA for our local pages will have no effect anyway, but fixing it makes the test pass.