### PR TITLE
Bug 1282967 – Incorrect top tab selected visually when switching tabs using the full tab view

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -93,6 +93,7 @@ class TopTabsViewController: UIViewController {
         super.viewWillAppear(animated)
         collectionView.dataSource = self
         collectionView.delegate = tabLayoutDelegate
+        collectionView.reloadData()
     }
     
     override func viewDidLoad() {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -94,6 +94,7 @@ class TopTabsViewController: UIViewController {
         collectionView.dataSource = self
         collectionView.delegate = tabLayoutDelegate
         collectionView.reloadData()
+        self.scrollToCurrentTab(false)
     }
     
     override func viewDidLoad() {
@@ -144,12 +145,6 @@ class TopTabsViewController: UIViewController {
     
     func tabsTapped() {
         delegate?.topTabsDidPressTabs()
-    }
-    
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        collectionView.reloadData()
-        self.scrollToCurrentTab(false)
     }
     
     func newTabTapped() {


### PR DESCRIPTION
Here we simply make sure we reload the collectionView before it is
drawn so that the correct tab is always correctly selected when it is
viewed.