### PR TITLE
Bug 1282929 - Don't require PrivilegedRequests for non-HTTP(S) URLs

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3324,7 +3324,11 @@ extension BrowserViewController: JSPromptAlertControllerDelegate {
 private extension WKNavigationAction {
     /// Allow local requests only if the request is privileged.
     private var isAllowed: Bool {
-        return !(request.URL?.isLocal ?? false) || request.isPrivileged
+        guard let url = request.URL else {
+            return true
+        }
+
+        return !url.isWebPage() || !url.isLocal || request.isPrivileged
     }
 }
 


### PR DESCRIPTION
Our `isLocal` check returns `true` if the request has no host, which will be the case for all of these external URIs. Our local webserver is HTTP(S)-only, so there's no need to block other kinds of requests.