### PR TITLE
Bug 1283918 – "Go to copied link" in Today widget is incorrectly vertically aligned

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -339,12 +339,9 @@ class ButtonWithSublabel: UIButton {
 
     func remakeConstraints() {
         self.label.snp_remakeConstraints { make in
-            if !self.subtitleLabel.hidden {
-                make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2)
-            } else {
-                // Vertically centre the label if there is no URL to display
-                make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2 + self.label.frame.height / 2)
-            }
+            // Vertically centre the label if there is no URL to display
+            let labelOffset = !self.subtitleLabel.hidden ? 0 : self.label.frame.height / 2
+            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2 + labelOffset)
             make.left.equalTo(self.snp_left).offset(TodayUX.defaultWidgetTextMargin).priorityHigh()
         }
     }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -319,7 +319,7 @@ class ButtonWithSublabel: UIButton {
         let imageView = self.imageView!
 
         let subtitleLabel = self.subtitleLabel
-        subtitleLabel.textColor = UIColor.lightGrayColor()
+        subtitleLabel.textColor = UIColor.whiteColor()
         self.addSubview(subtitleLabel)
 
         imageView.snp_remakeConstraints { make in

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -330,7 +330,7 @@ class ButtonWithSublabel: UIButton {
         subtitleLabel.lineBreakMode = .ByTruncatingTail
         subtitleLabel.snp_makeConstraints { make in
             make.left.equalTo(titleLabel.snp_left)
-            make.top.equalTo(titleLabel.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2 + subtitleLabel.frame.height / 2)
+            make.top.equalTo(titleLabel.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2)
             make.right.lessThanOrEqualTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
         }
 

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -330,7 +330,7 @@ class ButtonWithSublabel: UIButton {
         subtitleLabel.lineBreakMode = .ByTruncatingTail
         subtitleLabel.snp_makeConstraints { make in
             make.left.equalTo(titleLabel.snp_left)
-            make.top.equalTo(titleLabel.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2)
+            make.top.equalTo(titleLabel.snp_bottom).offset(TodayUX.verticalWidgetMargin / 2 + subtitleLabel.frame.height / 2)
             make.right.lessThanOrEqualTo(self.snp_right).offset(-TodayUX.horizontalWidgetMargin)
         }
 
@@ -339,7 +339,7 @@ class ButtonWithSublabel: UIButton {
 
     func remakeConstraints() {
         self.label.snp_remakeConstraints { make in
-            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2)
+            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2 + self.label.frame.height / 2)
             make.left.equalTo(self.snp_left).offset(TodayUX.defaultWidgetTextMargin).priorityHigh()
         }
     }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -339,7 +339,12 @@ class ButtonWithSublabel: UIButton {
 
     func remakeConstraints() {
         self.label.snp_remakeConstraints { make in
-            make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2 + self.label.frame.height / 2)
+            if !self.subtitleLabel.hidden {
+                make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2)
+            } else {
+                // Vertically centre the label if there is no URL to display
+                make.top.equalTo(self.snp_top).offset(TodayUX.verticalWidgetMargin / 2 + self.label.frame.height / 2)
+            }
             make.left.equalTo(self.snp_left).offset(TodayUX.defaultWidgetTextMargin).priorityHigh()
         }
     }

--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -319,7 +319,7 @@ class ButtonWithSublabel: UIButton {
         let imageView = self.imageView!
 
         let subtitleLabel = self.subtitleLabel
-        subtitleLabel.textColor = UIColor.whiteColor()
+        subtitleLabel.textColor = UIColor.lightGrayColor()
         self.addSubview(subtitleLabel)
 
         imageView.snp_remakeConstraints { make in


### PR DESCRIPTION
This vertically centres the text in the Today widget button.