### PR TITLE
Bug 1285029 – Today widget "Go to copied link" title is same colour as subtitle

### DIFF
--- a/Extensions/Today/TodayViewController.swift
+++ b/Extensions/Today/TodayViewController.swift
@@ -319,7 +319,7 @@ class ButtonWithSublabel: UIButton {
         let imageView = self.imageView!
 
         let subtitleLabel = self.subtitleLabel
-        subtitleLabel.textColor = UIColor.whiteColor()
+        subtitleLabel.textColor = UIColor.lightGrayColor()
         self.addSubview(subtitleLabel)
 
         imageView.snp_remakeConstraints { make in


### PR DESCRIPTION
The button subtitle has been changed to use a light grey instead of
white.