### PR TITLE
No bug: Add a note to remove capabilities for Free Developer Accounts

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,7 +60,9 @@ Since the bundle identifier we use for Firefox is tied to our developer account,
 
 1. Open Client/Configuration/Fennec.xcconfig
 2. Change MOZ_BUNDLE_ID to your own bundle identifier.
-3. Navigate to each of the application targets (Client/SendTo/ShareTo/ViewLater) and select your personal development account.
+3. Navigate to each of the application targets (Client/SendTo/ShareTo/ViewLater) and for each one:
+  1. select your personal development account
+  2. remove the code signing entitlements
 
 If you submit a patch, be sure to exclude these files because they are only relevant for your personal build.
 


### PR DESCRIPTION
When getting Firefox to run on a device using this method, I found it only succeeded if I removed the capabilities from the targets (as non developer accounts cannot have access to some of these). This updates the Building instructions file to reflect that change.