### PR TITLE
Bug 1285491 – Incorrect menu version displayed in browsing mode after closing an about:home tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -739,20 +739,18 @@ class BrowserViewController: UIViewController {
         if let controller = homePanelController {
             UIView.animateWithDuration(0.2, delay: 0, options: .BeginFromCurrentState, animations: { () -> Void in
                 controller.view.alpha = 0
-            }, completion: { finished in
-                if finished {
-                    controller.willMoveToParentViewController(nil)
-                    controller.view.removeFromSuperview()
-                    controller.removeFromParentViewController()
-                    self.webViewContainer.accessibilityElementsHidden = false
-                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
-
-                    // Refresh the reading view toolbar since the article record may have changed
-                    if let readerMode = self.tabManager.selectedTab?.getHelper(name: ReaderMode.name()) as? ReaderMode where readerMode.state == .Active {
-                        self.showReaderModeBar(animated: false)
-                    }
-                }
+            }, completion: { _ in
+                controller.willMoveToParentViewController(nil)
+                controller.view.removeFromSuperview()
+                controller.removeFromParentViewController()
                 self.homePanelController = nil
+                self.webViewContainer.accessibilityElementsHidden = false
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
+
+                // Refresh the reading view toolbar since the article record may have changed
+                if let readerMode = self.tabManager.selectedTab?.getHelper(name: ReaderMode.name()) as? ReaderMode where readerMode.state == .Active {
+                    self.showReaderModeBar(animated: false)
+                }
             })
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -744,7 +744,6 @@ class BrowserViewController: UIViewController {
                     controller.willMoveToParentViewController(nil)
                     controller.view.removeFromSuperview()
                     controller.removeFromParentViewController()
-                    self.homePanelController = nil
                     self.webViewContainer.accessibilityElementsHidden = false
                     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil)
 
@@ -753,13 +752,14 @@ class BrowserViewController: UIViewController {
                         self.showReaderModeBar(animated: false)
                     }
                 }
+                self.homePanelController = nil
             })
         }
     }
 
     private func updateInContentHomePanel(url: NSURL?) {
         if !urlBar.inOverlayMode {
-            if AboutUtils.isAboutHomeURL(url){
+            if AboutUtils.isAboutHomeURL(url) {
                 let showInline = AppConstants.MOZ_MENU || ((tabManager.selectedTab?.canGoForward ?? false || tabManager.selectedTab?.canGoBack ?? false))
                 showHomePanelController(inline: showInline)
             } else {


### PR DESCRIPTION
This ensures the `homePanelController` is removed regardless of the
view from which it is.