### PR TITLE
Bug 1286983 – Enter URL keyboard shortcut should automatically show the URL Bar

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1212,6 +1212,7 @@ class BrowserViewController: UIViewController {
     }
 
     func selectLocationBar(){
+        scrollController.showToolbars(animated: true)
         urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 


### PR DESCRIPTION
When using the ⌘L command to edit the URL, the URL bar is now shown
first.