### PR TITLE
Bug 1211201 – Accessing the URL bar can take more scrolling than expected

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -29,7 +29,7 @@ private let ActionSheetTitleMaxLength = 120
 
 private struct BrowserViewControllerUX {
     private static let BackgroundColor = UIConstants.AppBackgroundColor
-    private static let ShowHeaderTapAreaHeight: CGFloat = 32
+    private static let ShowHeaderTapAreaHeight: CGFloat = 24
     private static let BookmarkStarAnimationDuration: Double = 0.5
     private static let BookmarkStarAnimationOffset: CGFloat = 80
 }
@@ -83,7 +83,7 @@ class BrowserViewController: UIViewController {
     var footer: UIView!
     var footerBackdrop: UIView!
     private var footerBackground: BlurWrapper?
-    private var topTouchArea: UIButton!
+    private var topTouchArea: URLBarMinifiedView!
     let urlBarTopTabsContainer = UIView(frame: CGRect.zero)
 
     // Backdrop used for displaying greyed background for private tabs
@@ -353,9 +353,8 @@ class BrowserViewController: UIViewController {
         view.addSubview(statusBarOverlay)
 
         log.debug("BVC setting up top touch area…")
-        topTouchArea = UIButton()
-        topTouchArea.isAccessibilityElement = false
-        topTouchArea.addTarget(self, action: #selector(BrowserViewController.SELtappedTopArea), forControlEvents: UIControlEvents.TouchUpInside)
+        topTouchArea = URLBarMinifiedView()
+        topTouchArea.touchTarget.addTarget(self, action: #selector(BrowserViewController.SELtappedTopArea), forControlEvents: UIControlEvents.TouchUpInside)
         view.addSubview(topTouchArea)
 
         log.debug("BVC setting up URL bar…")
@@ -2330,6 +2329,8 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         let tab: Tab! = tabManager[webView]
         tabManager.expireSnackbars()
+        
+        topTouchArea.updateForTab(tab)
 
         if let url = webView.URL where !ErrorPageHelper.isErrorPageURL(url) && !AboutUtils.isAboutHomeURL(url) {
             tab.lastExecutedTime = NSDate.now()
@@ -3247,7 +3248,7 @@ class BlurWrapper: UIView {
     }
     
 
-    private var effectView: UIVisualEffectView
+    var effectView: UIVisualEffectView
     private var wrappedView: UIView
     private lazy var background: UIView = {
         let background = UIView()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3247,7 +3247,7 @@ class BlurWrapper: UIView {
     }
     
 
-    var effectView: UIVisualEffectView
+    private var effectView: UIVisualEffectView
     private var wrappedView: UIView
     private lazy var background: UIView = {
         let background = UIView()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -926,7 +926,10 @@ class BrowserViewController: UIViewController {
                 navigationToolbar.updateReloadStatus(loading)
             }
 
-            if (!loading) {
+            if !loading {
+                if let tab = tabManager.selectedTab {
+                    topTouchArea.updateForTab(tab)
+                }
                 runScriptsOnWebView(webView)
             }
         case KVOURL:

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -553,6 +553,7 @@ class BrowserViewController: UIViewController {
         presentIntroViewController()
         log.debug("BVC intro presented.")
         self.webViewContainerToolbar.hidden = false
+        self.topTouchArea.hidden = false
 
         screenshotHelper.viewIsVisible = true
         log.debug("BVC taking pending screenshots….")
@@ -1453,6 +1454,7 @@ extension BrowserViewController: URLBarDelegate {
 
     func urlBarDidPressTabs(urlBar: URLBarView) {
         self.webViewContainerToolbar.hidden = true
+        self.topTouchArea.hidden = true
         updateFindInPageVisibility(visible: false)
 
         let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -990,6 +990,7 @@ class BrowserViewController: UIViewController {
     /// Call this whenever the page URL changes.
     private func updateURLBarDisplayURL(tab: Tab) {
         urlBar.currentURL = tab.displayURL
+        topTouchArea.updateForTab(tab)
 
         let isPage = tab.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isWebPage: isPage)
@@ -2329,8 +2330,6 @@ extension BrowserViewController: WKNavigationDelegate {
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
         let tab: Tab! = tabManager[webView]
         tabManager.expireSnackbars()
-        
-        topTouchArea.updateForTab(tab)
 
         if let url = webView.URL where !ErrorPageHelper.isErrorPageURL(url) && !AboutUtils.isAboutHomeURL(url) {
             tab.lastExecutedTime = NSDate.now()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -21,6 +21,7 @@ private let log = Logger.browserLogger
 private let KVOLoading = "loading"
 private let KVOEstimatedProgress = "estimatedProgress"
 private let KVOURL = "URL"
+private let KVOTitle = "title"
 private let KVOCanGoBack = "canGoBack"
 private let KVOCanGoForward = "canGoForward"
 private let KVOContentSize = "contentSize"
@@ -927,9 +928,6 @@ class BrowserViewController: UIViewController {
             }
 
             if !loading {
-                if let tab = tabManager.selectedTab {
-                    topTouchArea.updateForTab(tab)
-                }
                 runScriptsOnWebView(webView)
             }
         case KVOURL:
@@ -945,6 +943,9 @@ class BrowserViewController: UIViewController {
                     updateUIForReaderHomeStateForTab(tab)
                 }
             }
+        case KVOTitle:
+            guard let tab = tabManager[webView] else { break }
+            self.topTouchArea.updateForTab(tab)
         case KVOCanGoBack:
             guard webView == tabManager.selectedTab?.webView,
                 let canGoBack = change?[NSKeyValueChangeNewKey] as? Bool else { break }
@@ -994,7 +995,6 @@ class BrowserViewController: UIViewController {
     /// Call this whenever the page URL changes.
     private func updateURLBarDisplayURL(tab: Tab) {
         urlBar.currentURL = tab.displayURL
-        topTouchArea.updateForTab(tab)
 
         let isPage = tab.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isWebPage: isPage)
@@ -1778,6 +1778,7 @@ extension BrowserViewController: TabDelegate {
         webView.addObserver(self, forKeyPath: KVOCanGoBack, options: .New, context: nil)
         webView.addObserver(self, forKeyPath: KVOCanGoForward, options: .New, context: nil)
         tab.webView?.addObserver(self, forKeyPath: KVOURL, options: .New, context: nil)
+        tab.webView?.addObserver(self, forKeyPath: KVOTitle, options: .New, context: nil)
 
         webView.scrollView.addObserver(self.scrollController, forKeyPath: KVOContentSize, options: .New, context: nil)
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -937,11 +937,11 @@ extension ToolbarTextField: Themeable {
     }
 }
 
-class URLBarMinifiedView: BlurWrapper {
+class URLBarMinifiedView: UIView {
     
     let touchTarget: UIButton
+    private let blurWrapper: BlurWrapper
     private let title: UILabel
-    private let border: UIView
     
     init() {
         self.touchTarget = UIButton()
@@ -952,31 +952,34 @@ class URLBarMinifiedView: BlurWrapper {
         self.title.textAlignment = .Center
         self.title.lineBreakMode = .ByTruncatingMiddle
         
-        self.border = UIView()
-        self.border.backgroundColor = UIConstants.BorderColor
+        let border = UIView()
+        border.backgroundColor = UIConstants.BorderColor
         
-        super.init(view: touchTarget)
+        self.blurWrapper = BlurWrapper(view: self.touchTarget)
+        self.blurWrapper.addSubview(border)
+        self.blurWrapper.addSubview(self.title)
         
-        self.addSubview(self.border)
-        self.addSubview(self.title)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func updateConstraints() {
-        super.updateConstraints()
+        super.init(frame: .zero)
         
-        self.title.snp_remakeConstraints() { make in
+        self.addSubview(self.blurWrapper)
+        
+        self.blurWrapper.snp_makeConstraints() { make in
+            make.center.width.height.equalTo(self)
+        }
+        
+        self.title.snp_makeConstraints() { make in
             make.center.equalTo(self)
             make.width.equalTo(self).offset(-UIConstants.DefaultPadding)
         }
         
-        self.border.snp_remakeConstraints() { make in
+        border.snp_makeConstraints() { make in
             make.bottom.left.right.equalTo(self)
             make.height.equalTo(0.5)
         }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     func updateForTab(tab: Tab) {

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -984,5 +984,12 @@ class URLBarMinifiedView: UIView {
     
     func updateForTab(tab: Tab) {
         self.title.text = tab.displayTitle
+        if tab.isPrivate {
+            self.blurWrapper.blurStyle = .Dark
+            self.title.textColor = UIColor.lightTextColor()
+        } else {
+            self.blurWrapper.blurStyle = .ExtraLight
+            self.title.textColor = UIColor.darkTextColor()
+        }
     }
 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -936,3 +936,50 @@ extension ToolbarTextField: Themeable {
         highlightColor = theme.highlightColor!
     }
 }
+
+class URLBarMinifiedView: BlurWrapper {
+    
+    let touchTarget: UIButton
+    private let title: UILabel
+    private let border: UIView
+    
+    init() {
+        self.touchTarget = UIButton()
+        self.touchTarget.isAccessibilityElement = false
+        
+        self.title = UILabel()
+        self.title.font = UIConstants.DefaultChromeFont
+        self.title.textAlignment = .Center
+        self.title.lineBreakMode = .ByTruncatingMiddle
+        
+        self.border = UIView()
+        self.border.backgroundColor = UIConstants.BorderColor
+        
+        super.init(view: touchTarget)
+        
+        self.addSubview(self.border)
+        self.addSubview(self.title)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func updateConstraints() {
+        super.updateConstraints()
+        
+        self.title.snp_remakeConstraints() { make in
+            make.center.equalTo(self)
+            make.width.equalTo(self).offset(-UIConstants.DefaultPadding)
+        }
+        
+        self.border.snp_remakeConstraints() { make in
+            make.bottom.left.right.equalTo(self)
+            make.height.equalTo(0.5)
+        }
+    }
+    
+    func updateForTab(tab: Tab) {
+        self.title.text = tab.displayTitle
+    }
+}


### PR DESCRIPTION
Previously, a touch target existed to let the user show the URL bar
when it was hidden, but the feature was not at all obvious. Now it is
represented by a much smaller URL bar that users can tap on to bring
the main bar back, without obscuring much of the page.