### PR TITLE
Bug 1251260 – Cancelling a Touch ID prompt on 'Logins' persists the row select highlight

### DIFF
--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -141,6 +141,7 @@ class TouchIDSetting: Setting {
 
     override func onConfigureCell(cell: UITableViewCell) {
         super.onConfigureCell(cell)
+        cell.selectionStyle = .None
 
         // In order for us to recognize a tap gesture without toggling the switch,
         // the switch is wrapped in a UIView which has a tap gesture recognizer. This way

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -597,7 +597,11 @@ class LoginsSetting: Setting {
             success: {
                 self.settings?.navigateToLoginsList()
             },
-            cancel: nil,
+            cancel: {
+                if let selectedRow = self.settings?.tableView.indexPathForSelectedRow {
+                    self.settings!.tableView.deselectRowAtIndexPath(selectedRow, animated: true)
+                }
+            },
             fallback: {
                 AppAuthenticator.presentPasscodeAuthentication(self.navigationController, delegate: self.settings)
             })

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -599,7 +599,7 @@ class LoginsSetting: Setting {
             },
             cancel: {
                 if let selectedRow = self.settings?.tableView.indexPathForSelectedRow {
-                    self.settings!.tableView.deselectRowAtIndexPath(selectedRow, animated: true)
+                    self.settings?.tableView.deselectRowAtIndexPath(selectedRow, animated: true)
                 }
             },
             fallback: {


### PR DESCRIPTION
This fixes two issues with rows in the settings menus remaining
highlighted after being tapped.