### PR TITLE
Bug 1224538 – Pan gesture is ignored if it starts while the toolbars are appearing

### DIFF
--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -209,7 +209,7 @@ private extension TabScrollingController {
         }
 
         if animated {
-            UIView.animateWithDuration(duration, animations: animation, completion: completion)
+            UIView.animateWithDuration(duration, delay: 0, options: .AllowUserInteraction, animations: animation, completion: completion)
         } else {
             animation()
             completion?(finished: true)


### PR DESCRIPTION
An hour of debugging, only to find there wasn’t any logic at fault in
the scrolling code.