### PR TITLE
Bug 1288463 – Support tab reordering in the tab tray

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -274,8 +274,9 @@ class TabManager : NSObject {
     func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
         assert(NSThread.isMainThread())
         
-        let fromIndex = tabs.indexOf((privateMode ? privateTabs : normalTabs)[visibleFromIndex]) ?? tabs.count - 1
-        let toIndex = tabs.indexOf((privateMode ? privateTabs : normalTabs)[visibleToIndex]) ?? tabs.count - 1
+        let currentTabs = privateMode ? privateTabs : normalTabs
+        let fromIndex = tabs.indexOf(currentTabs[visibleFromIndex]) ?? tabs.count - 1
+        let toIndex = tabs.indexOf(currentTabs[visibleToIndex]) ?? tabs.count - 1
         
         let previouslySelectedTab = selectedTab
         

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -270,6 +270,23 @@ class TabManager : NSObject {
         configureTab(tab, request: request, afterTab: afterTab, flushToDisk: flushToDisk, zombie: zombie)
         return tab
     }
+    
+    func moveTab(isPrivate privateMode: Bool, fromIndex visibleFromIndex: Int, toIndex visibleToIndex: Int) {
+        assert(NSThread.isMainThread())
+        
+        let fromIndex = tabs.indexOf((privateMode ? privateTabs : normalTabs)[visibleFromIndex]) ?? tabs.count - 1
+        let toIndex = tabs.indexOf((privateMode ? privateTabs : normalTabs)[visibleToIndex]) ?? tabs.count - 1
+        
+        let previouslySelectedTab = selectedTab
+        
+        tabs.insert(tabs.removeAtIndex(fromIndex), atIndex: toIndex)
+        
+        if let previouslySelectedTab = previouslySelectedTab, previousSelectedIndex = tabs.indexOf(previouslySelectedTab) {
+            _selectedIndex = previousSelectedIndex
+        }
+        
+        storeChanges()
+    }
 
     func configureTab(tab: Tab, request: NSURLRequest?, afterTab parent: Tab? = nil, flushToDisk: Bool, zombie: Bool) {
         assert(NSThread.isMainThread())

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -29,7 +29,7 @@ struct TabTrayControllerUX {
     static let MenuFixedWidth: CGFloat = 320
     
     static let RearrangeWobblePeriod: NSTimeInterval = 0.1
-     static let RearrangeTransitionDuration: NSTimeInterval = 0.2
+    static let RearrangeTransitionDuration: NSTimeInterval = 0.2
     static let RearrangeWobbleAngle: CGFloat = 0.02
     static let RearrangeDragScale: CGFloat = 1.1
     static let RearrangeDragAlpha: CGFloat = 0.9


### PR DESCRIPTION
You can now start reärranging your tabs by long-pressing on a tab, and then moving it around. iOS 9+.