### PR TITLE
Bug 1289197 – Pressing Go in an empty URL bar searches for the empty string

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -680,8 +680,12 @@ extension URLBarView: TabLocationViewDelegate {
 extension URLBarView: AutocompleteTextFieldDelegate {
     func autocompleteTextFieldShouldReturn(autocompleteTextField: AutocompleteTextField) -> Bool {
         guard let text = locationTextField?.text else { return true }
-        delegate?.urlBar(self, didSubmitText: text)
-        return true
+        if !text.stringByTrimmingCharactersInSet(.whitespaceCharacterSet()).isEmpty {
+            delegate?.urlBar(self, didSubmitText: text)
+            return true
+        } else {
+            return false
+        }
     }
 
     func autocompleteTextField(autocompleteTextField: AutocompleteTextField, didEnterText text: String) {


### PR DESCRIPTION
This simply prevents users searching for a whitespace-only string, as a
temporary fix for the issue.