### PR TITLE
Bug 1290147 – User can unintentionally enter private browsing with top tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -401,7 +401,7 @@ class TabManager : NSObject {
             if !tab.isPrivate {
                 addTab()
             } else {
-                selectTab(tabs.first)
+                selectTab(tabs.last)
             }
         }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -354,13 +354,14 @@ class TabManager : NSObject {
         assert(NSThread.isMainThread())
         // If the removed tab was selected, find the new tab to select.
         if tab === selectedTab {
-            if let index = getIndex(tab) {
-                if index + 1 < count {
-                    selectTab(tabs[index + 1])
+            let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
+            if let index = viableTabs.indexOf(tab) {
+                if index + 1 < viableTabs.count {
+                    selectTab(viableTabs[index + 1])
                 } else if index - 1 >= 0 {
-                    selectTab(tabs[index - 1])
+                    selectTab(viableTabs[index - 1])
                 } else {
-                    assert(count == 1, "Removing last tab")
+                    assert(viableTabs.count == 1, "Removing last tab")
                     selectTab(nil)
                 }
             }
@@ -395,12 +396,17 @@ class TabManager : NSObject {
         }
 
         // Make sure we never reach 0 normal tabs
-        if !tab.isPrivate && normalTabs.count == 0 {
-            addTab()
+        let viableTabs: [Tab] = tab.isPrivate ? privateTabs : normalTabs
+        if viableTabs.count == 0 {
+            if !tab.isPrivate {
+                addTab()
+            } else {
+                selectTab(tabs.first)
+            }
         }
 
         if flushToDisk {
-        	storeChanges()
+            storeChanges()
         }
     }
 


### PR DESCRIPTION
Tabs will now only be selected if they are at the same, or a lower,
privacy level than the tab being removed.