### PR TITLE
Bug 1290331 - Removed incorrect and confusing .NotStarted sync warning messaging

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -551,6 +551,11 @@
 		E601386A1C89EB9800DF9756 /* SQLite.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9A62DB1C4002B1005C83DC /* SQLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E60222DC1C6E55610061C436 /* FxA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28CE83D01A1D1D5100576538 /* FxA.framework */; };
 		E60222E31C6E57B20061C436 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9A62DB1C4002B1005C83DC /* SQLite.framework */; };
+		E60D03181D511398002FE3F6 /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
+		E60D03261D511554002FE3F6 /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
+		E60D03271D511554002FE3F6 /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
+		E60D03281D511555002FE3F6 /* SyncStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */; };
+		E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */; };
 		E6108FF91C84E91C005D25E8 /* BasePasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */; };
 		E61453BE1B750A1700C3F9D7 /* RollingFileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */; };
 		E6231C011B90A44F005ABB0D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C001B90A44F005ABB0D /* libz.tbd */; };
@@ -1596,6 +1601,8 @@
 		E60961861B62B8A700DD640F /* Fennec.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Fennec.xcconfig; path = Configuration/Fennec.xcconfig; sourceTree = "<group>"; };
 		E60961881B62B8BE00DD640F /* FirefoxNightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FirefoxNightly.xcconfig; path = Configuration/FirefoxNightly.xcconfig; sourceTree = "<group>"; };
 		E60961891B62B8C800DD640F /* Firefox.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Firefox.xcconfig; path = Configuration/Firefox.xcconfig; sourceTree = "<group>"; };
+		E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncStatusResolver.swift; sourceTree = "<group>"; };
+		E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncStatusResolverTests.swift; sourceTree = "<group>"; };
 		E6108FF81C84E91C005D25E8 /* BasePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePasscodeViewController.swift; sourceTree = "<group>"; };
 		E61453BD1B750A1700C3F9D7 /* RollingFileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RollingFileLoggerTests.swift; sourceTree = "<group>"; };
 		E6231C001B90A44F005ABB0D /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -2566,6 +2573,7 @@
 		D34DC84C1A16C40C00D49B7B /* Providers */ = {
 			isa = PBXGroup;
 			children = (
+				E60D03171D511398002FE3F6 /* SyncStatusResolver.swift */,
 				D34DC84D1A16C40C00D49B7B /* Profile.swift */,
 				0BD19A661A25309B0084FBA7 /* NSUserDefaultsPrefs.swift */,
 			);
@@ -3131,6 +3139,7 @@
 				2F697F7D1A9FD22D009E03AE /* SearchEnginesTests.swift */,
 				D3FA777A1A43B2990010CD32 /* SearchTests.swift */,
 				2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */,
+				E60D03291D5118DB002FE3F6 /* SyncStatusResolverTests.swift */,
 				7BBFEE731BB405D900A305AA /* TabManagerTests.swift */,
 				0BA8964A1A250E6500C1010C /* TestBookmarks.swift */,
 				0BF42D4E1A7CD09600889E28 /* TestFavicons.swift */,
@@ -4614,6 +4623,7 @@
 			files = (
 				E444F7E01B4B1C1A00FEB19B /* NSUserDefaultsPrefs.swift in Sources */,
 				E4BA8AA81B4B15EF00BC2E95 /* ActionRequestHandler.swift in Sources */,
+				E60D03281D511555002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				E444F7E21B4B1C6800FEB19B /* SearchEngines.swift in Sources */,
 				E444F7DF1B4B1C1200FEB19B /* Profile.swift in Sources */,
 				E444F7E31B4B1C8000FEB19B /* OpenSearch.swift in Sources */,
@@ -4737,6 +4747,7 @@
 				E46C51C31B41ADD800EB349F /* Try.m in Sources */,
 				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,
+				E60D03181D511398002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				7B31E6851CBC09DC00A57805 /* MenuPresentationAnimator.swift in Sources */,
 				C4E3983D1D21F1E7004E89BA /* TopTabsViews.swift in Sources */,
 				0BB5B2891AC0A2B90052877D /* Toolbar.swift in Sources */,
@@ -4885,6 +4896,7 @@
 				7BC7B4BE1C904BF90046E9D2 /* MenuTests.swift in Sources */,
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
+				E60D032A1D5118DB002FE3F6 /* SyncStatusResolverTests.swift in Sources */,
 				7BBFEEA01BB409F300A305AA /* AboutUtils.swift in Sources */,
 				A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */,
 				0BF42D4F1A7CD09600889E28 /* TestFavicons.swift in Sources */,
@@ -4911,6 +4923,7 @@
 				E418D0D91A251B3200CAE47A /* Profile.swift in Sources */,
 				F8708D321A0970B70051AB07 /* ShareViewController.swift in Sources */,
 				28CDA55C1A43C37C005C318C /* NSUserDefaultsPrefs.swift in Sources */,
+				E60D03271D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				E41A7D4B1A1BE04500245963 /* InitialViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4921,6 +4934,7 @@
 			files = (
 				D38B2D8B1A8D98D10040E6B5 /* SearchEngines.swift in Sources */,
 				D3C744D01A687D6C004CE85D /* URIFixup.swift in Sources */,
+				E60D03261D511554002FE3F6 /* SyncStatusResolver.swift in Sources */,
 				D38B2D8D1A8D98DA0040E6B5 /* OpenSearch.swift in Sources */,
 				E4BCAAB91B0537E300855D82 /* InstructionsViewController.swift in Sources */,
 				E42CCDE81A23A73D00B794D3 /* Profile.swift in Sources */,

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -109,7 +109,7 @@ class SyncNowSetting: WithAccountSetting {
         case .Bad(let message):
             guard let message = message else { return syncNowTitle }
             return NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowErrorTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
-        case .Stale(let message):
+        case .Warning(let message):
             return  NSAttributedString(string: message, attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowWarningTextColor, NSFontAttributeName: DynamicFontHelper.defaultHelper.DefaultStandardFont])
         case .InProgress:
             return syncingTitle
@@ -182,7 +182,7 @@ class SyncNowSetting: WithAccountSetting {
                     cell.detailTextLabel?.attributedText = status
                     cell.accessoryView = nil
                 }
-            case .Stale(_):
+            case .Warning(_):
                 // add the amber warning symbol
                 // add a link to the MANA page
                 cell.detailTextLabel?.attributedText = nil

--- a/ClientTests/SyncStatusResolverTests.swift
+++ b/ClientTests/SyncStatusResolverTests.swift
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import Client
+@testable import Sync
+
+import Shared
+import Storage
+import XCTest
+
+private class RandomError: MaybeErrorType {
+    var description = "random_error"
+}
+
+class SyncStatusResolverTests: XCTestCase {
+
+    func testAllCompleted() {
+        let results: EngineResults = [
+            ("tabs", .Completed),
+            ("clients", .Completed)
+        ]
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Good)
+    }
+
+    func testAllCompletedExceptOneDisabledRemotely() {
+        let results: EngineResults = [
+            ("tabs", .Completed),
+            ("clients", .NotStarted(.EngineRemotelyNotEnabled(collection: "clients")))
+        ]
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Good)
+    }
+
+    func testAllCompletedExceptNotStartedBecauseNoAccount() {
+        let results: EngineResults = [
+            ("tabs", .Completed),
+            ("clients", .NotStarted(.NoAccount))
+        ]
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Warning(message: Strings.FirefoxSyncOfflineTitle))
+    }
+
+    func testAllCompletedExceptNotStartedBecauseOffline() {
+        let results: EngineResults = [
+            ("tabs", .Completed),
+            ("clients", .NotStarted(.Offline))
+        ]
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Bad(message: Strings.FirefoxSyncOfflineTitle))
+    }
+
+    func testOfflineAndNoAccount() {
+        let results: EngineResults = [
+            ("tabs", .NotStarted(.NoAccount)),
+            ("clients", .NotStarted(.Offline))
+        ]
+
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Bad(message: Strings.FirefoxSyncOfflineTitle))
+    }
+
+    func testAllPartial() {
+        let results: EngineResults = [
+            ("tabs", .Partial),
+            ("clients", .Partial)
+        ]
+        let maybeResults = Maybe(success: results)
+
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        XCTAssertTrue(resolver.resolveResults() == SyncDisplayState.Good)
+    }
+
+    func testBookmarkMergeError() {
+        let maybeResults: Maybe<EngineResults> = Maybe(failure: BookmarksMergeError())
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        let expected = SyncDisplayState.Warning(message: String(format: Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
+        XCTAssertTrue(resolver.resolveResults() == expected)
+    }
+
+    func testBookmarksDatabaseError() {
+        let maybeResults: Maybe<EngineResults> = Maybe(failure: BookmarksDatabaseError(err: nil))
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        let expected = SyncDisplayState.Warning(message: String(format: Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
+        XCTAssertTrue(resolver.resolveResults() == expected)
+    }
+
+    func testRandomFailure() {
+        let maybeResults: Maybe<EngineResults> = Maybe(failure: RandomError())
+        let resolver = SyncStatusResolver(engineResults: maybeResults)
+        let expected = SyncDisplayState.Bad(message: nil)
+        XCTAssertTrue(resolver.resolveResults() == expected)
+    }
+}

--- a/Providers/SyncStatusResolver.swift
+++ b/Providers/SyncStatusResolver.swift
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Sync
+import XCGLogger
+import Deferred
+import Shared
+import Storage
+
+public enum SyncDisplayState {
+    case InProgress
+    case Good
+    case Bad(message: String?)
+    case Warning(message: String)
+
+    func asObject() -> [String: String]? {
+        switch self {
+        case .Bad(let msg):
+            guard let message = msg else {
+                return ["state": "Error"]
+            }
+            return ["state": "Error",
+                    "message": message]
+        case .Warning(let message):
+            return ["state": "Warning",
+                    "message": message]
+        default:
+            break
+        }
+        return nil
+    }
+}
+
+public func ==(a: SyncDisplayState, b: SyncDisplayState) -> Bool {
+    switch (a, b) {
+    case (.InProgress,   .InProgress):
+        return true
+    case (.Good,   .Good):
+        return true
+    case (.Bad(let a), .Bad(let b)) where a == b:
+        return true
+    case (.Warning(let a), .Warning(let b)) where a == b:
+        return true
+    default:
+        return false
+    }
+}
+
+private let log = Logger.syncLogger
+
+/*
+ * Translates the fine-grained SyncStatuses of each sync engine into a more coarse-grained
+ * display-oriented state for displaying warnings/errors to the user.
+ */
+public struct SyncStatusResolver {
+
+    let engineResults: Maybe<EngineResults>
+
+    public func resolveResults() -> SyncDisplayState {
+        guard let results = engineResults.successValue else {
+            switch engineResults.failureValue {
+            case _ as BookmarksMergeError, _ as BookmarksDatabaseError:
+                return SyncDisplayState.Warning(message: String(format: Strings.FirefoxSyncPartialTitle, Strings.localizedStringForSyncComponent("bookmarks") ?? ""))
+            default:
+                return SyncDisplayState.Bad(message: nil)
+            }
+        }
+
+        // Run through the engine results and produce a relevant display status for each one
+        let displayStates: [SyncDisplayState] = results.map { (engineIdentifier, syncStatus) in
+            log.debug("Sync status for \(engineIdentifier): \(syncStatus)")
+
+            // Explicitly call out each of the enum cases to let us lean on the compiler when
+            // we add new error states
+            switch syncStatus {
+            case .NotStarted(let reason):
+                switch reason {
+                case .Offline:
+                    return .Bad(message: Strings.FirefoxSyncOfflineTitle)
+                case .NoAccount:
+                    return .Warning(message: Strings.FirefoxSyncOfflineTitle)
+                case .Backoff(_):
+                    return .Good
+                case .EngineRemotelyNotEnabled(_):
+                    return .Good
+                case .EngineFormatOutdated(_):
+                    return .Good
+                case .EngineFormatTooNew(_):
+                    return .Good
+                case .StorageFormatOutdated(_):
+                    return .Good
+                case .StorageFormatTooNew(_):
+                    return .Good
+                case .StateMachineNotReady:
+                    return .Good
+                case .RedLight:
+                    return .Good
+                case .Unknown:
+                    return .Good
+                }
+            case .Completed:
+                return .Good
+            case .Partial:
+                return .Good
+            }
+        }
+
+        // TODO: Instead of finding the worst offender in a list of statuses, we should better surface
+        // what might have happened with a particular engine when syncing.
+        let aggregate: SyncDisplayState = displayStates.reduce(.Good) { carried, displayState in
+            switch displayState {
+
+            case .Bad(_):
+                return displayState
+
+            case .Warning(_):
+                // If the state we're carrying is worse than the stale one, keep passing
+                // along the worst one
+                switch carried {
+                case .Bad(_):
+                    return carried
+                default:
+                    return displayState
+                }
+            default:
+                // This one is good so just pass on what was being carried
+                return carried
+            }
+        }
+
+        log.debug("Resolved sync display state: \(aggregate)")
+        return aggregate
+    }
+}


### PR DESCRIPTION
When the sync operations complete, we are erroneously interpreting .NotStarted sync results caused by users disabling a particular sync option (tabs, history, etc) as 'Sync is unavailable'. Related, in the case the user is offline, we show the message 'Sync is offline'. The first case is not correct and we should reporting a good sync. In the second, the messaging is unclear. Are the sync servers offline? I think the messaging can be improved here. In the meantime, I propose we remove both checks until we improve the messaging/UI around reporting sync errors.