### PR TITLE
Bug 1289893 – History menu opens from bottom when long pressing the back button on iPad

### DIFF
--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -27,6 +27,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
     private var isPrivate: Bool
     private var dismissing = false
     private var currentRow = 0
+    private var verticalConstraints: [Constraint] = []
     
     lazy var tableView: UITableView = {
         let tableView = UITableView()
@@ -66,6 +67,8 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
             self.transitioningDelegate = backForwardTransitionDelegate
         }
     }
+    
+    var snappedToBottom: Bool = true
     
     init(profile: Profile, backForwardList: WKBackForwardList, isPrivate: Bool) {
         self.profile = profile
@@ -122,45 +125,82 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         guard let bvc = self.bvc else {
             return
         }
-        tableView.snp_updateConstraints { make in
-            make.bottom.equalTo(self.view).offset(bvc.shouldShowFooterForTraitCollection(newCollection) ? -UIConstants.ToolbarHeight : 0)
+        if bvc.shouldShowFooterForTraitCollection(newCollection) != snappedToBottom {
+            self.dismissing = true
+            tableView.snp_updateConstraints { make in
+                if snappedToBottom {
+                    make.bottom.equalTo(self.view).offset(0)
+                } else {
+                    make.top.equalTo(self.view).offset(0)
+                }
+                make.height.equalTo(0)
+            }
+            snappedToBottom = !snappedToBottom
         }
     }
     
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        tableView.snp_updateConstraints { make in
-            make.height.equalTo(min(CGFloat(BackForwardViewUX.RowHeight*listData.count), size.height/2))
+        let correctHeight = {
+            self.tableView.snp_updateConstraints { make in
+                make.height.equalTo(min(CGFloat(BackForwardViewUX.RowHeight * self.listData.count), size.height / 2))
+            }
+        }
+        if !self.dismissing {
+            correctHeight()
+        } else {
+            coordinator.animateAlongsideTransition(nil) { _ in
+                self.remakeVerticalConstraints()
+                correctHeight()
+                self.dismissing = false
+            }
+        }
+    }
+    
+    func remakeVerticalConstraints() {
+        guard let bvc = self.bvc else {
+            return
+        }
+        for constraint in self.verticalConstraints {
+            constraint.deactivate()
+        }
+        self.verticalConstraints = []
+        tableView.snp_makeConstraints { make in
+            if snappedToBottom {
+                verticalConstraints += [make.bottom.equalTo(self.view).offset(-bvc.footer.frame.height).constraint]
+            } else {
+                verticalConstraints += [make.top.equalTo(self.view).offset(bvc.header.frame.height).constraint]
+            }
+        }
+        shadow.snp_makeConstraints() { make in
+            if snappedToBottom {
+                verticalConstraints += [
+                    make.bottom.equalTo(tableView.snp_top).constraint,
+                    make.top.equalTo(self.view).constraint
+                ]
+                
+            } else {
+                verticalConstraints += [
+                    make.top.equalTo(tableView.snp_bottom).constraint,
+                    make.bottom.equalTo(self.view).constraint
+                ]
+            }
         }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        guard let bvc = self.bvc else {
-            return
-        }
         view.addSubview(shadow)
         view.addSubview(tableView)
-        let snappedToBottom = bvc.toolbar != nil
+        self.snappedToBottom = self.bvc?.toolbar != nil 
         tableView.snp_makeConstraints { make in
             make.height.equalTo(0)
             make.left.right.equalTo(self.view)
-            if snappedToBottom {
-                make.bottom.equalTo(self.view).offset(-bvc.footer.frame.height)
-            } else {
-                make.top.equalTo(self.view).offset(bvc.header.frame.height)
-            }
         }
         shadow.snp_makeConstraints { make in
             make.left.right.equalTo(self.view)
-            if snappedToBottom {
-                make.bottom.equalTo(tableView.snp_top)
-                make.top.equalTo(self.view)
-            } else {
-                make.top.equalTo(tableView.snp_bottom)
-                make.bottom.equalTo(self.view)
-            }
         }
+        remakeVerticalConstraints()
         view.layoutIfNeeded()
         scrollTableViewToIndex(currentRow)
         setupDismissTap()

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -141,14 +141,25 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
         }
         view.addSubview(shadow)
         view.addSubview(tableView)
+        let snappedToBottom = bvc.toolbar != nil
         tableView.snp_makeConstraints { make in
             make.height.equalTo(0)
             make.left.right.equalTo(self.view)
-            make.bottom.equalTo(self.view).offset(-bvc.footer.frame.height)
+            if snappedToBottom {
+                make.bottom.equalTo(self.view).offset(-bvc.footer.frame.height)
+            } else {
+                make.top.equalTo(self.view).offset(bvc.header.frame.height)
+            }
         }
         shadow.snp_makeConstraints { make in
-            make.top.left.right.equalTo(self.view)
-            make.bottom.equalTo(tableView.snp_top)
+            make.left.right.equalTo(self.view)
+            if snappedToBottom {
+                make.bottom.equalTo(tableView.snp_top)
+                make.top.equalTo(self.view)
+            } else {
+                make.top.equalTo(tableView.snp_bottom)
+                make.bottom.equalTo(self.view)
+            }
         }
         view.layoutIfNeeded()
         scrollTableViewToIndex(currentRow)

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -126,7 +126,6 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
             return
         }
         if bvc.shouldShowFooterForTraitCollection(newCollection) != snappedToBottom {
-            self.dismissing = true
             tableView.snp_updateConstraints { make in
                 if snappedToBottom {
                     make.bottom.equalTo(self.view).offset(0)
@@ -146,14 +145,9 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
                 make.height.equalTo(min(CGFloat(BackForwardViewUX.RowHeight * self.listData.count), size.height / 2))
             }
         }
-        if !self.dismissing {
+        coordinator.animateAlongsideTransition(nil) { _ in
+            self.remakeVerticalConstraints()
             correctHeight()
-        } else {
-            coordinator.animateAlongsideTransition(nil) { _ in
-                self.remakeVerticalConstraints()
-                correctHeight()
-                self.dismissing = false
-            }
         }
     }
     

--- a/Client/Frontend/Browser/BackForwardListViewController.swift
+++ b/Client/Frontend/Browser/BackForwardListViewController.swift
@@ -169,7 +169,7 @@ class BackForwardListViewController: UIViewController, UITableViewDataSource, UI
             if snappedToBottom {
                 verticalConstraints += [make.bottom.equalTo(self.view).offset(-bvc.footer.frame.height).constraint]
             } else {
-                verticalConstraints += [make.top.equalTo(self.view).offset(bvc.header.frame.height).constraint]
+                verticalConstraints += [make.top.equalTo(self.view).offset(bvc.header.frame.height + UIApplication.sharedApplication().statusBarFrame.size.height).constraint]
             }
         }
         shadow.snp_makeConstraints() { make in

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -51,7 +51,6 @@ class BrowserViewController: UIViewController {
     private let webViewContainerToolbar = UIView()
     private var findInPageBar: FindInPageBar?
     private let findInPageContainer = UIView()
-    private weak var backForwardViewController: BackForwardListViewController?
 
     lazy private var customSearchEngineButton: UIButton = {
         let searchButton = UIButton()
@@ -178,19 +177,9 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator?) {
+    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection) {
         let showToolbar = shouldShowFooterForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
-        
-        // If the history buttons are changing their position, we'll hide the back/forward list until the transition finishes.
-        if showToolbar != (toolbar != nil) {
-            if backForwardViewController != nil {
-                coordinator?.animateAlongsideTransition(nil) { _ in
-                    self.showBackForwardList()
-                }
-            }
-            backForwardViewController?.dismissViewControllerAnimated(true, completion: nil)
-        }
 
         urlBar.topTabsIsShowing = showTopTabs
         urlBar.setShowToolbar(!showToolbar)
@@ -263,7 +252,7 @@ class BrowserViewController: UIViewController {
         // During split screen launching on iPad, this callback gets fired before viewDidLoad gets a chance to
         // set things up. Make sure to only update the toolbar state if the view is ready for it.
         if isViewLoaded() {
-            updateToolbarStateForTraitCollection(newCollection, withTransitionCoordinator: coordinator)
+            updateToolbarStateForTraitCollection(newCollection)
         }
 
         displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
@@ -420,7 +409,7 @@ class BrowserViewController: UIViewController {
         scrollController.snackBars = snackBars
 
         log.debug("BVC updating toolbar state…")
-        self.updateToolbarStateForTraitCollection(self.traitCollection, withTransitionCoordinator: nil)
+        self.updateToolbarStateForTraitCollection(self.traitCollection)
 
         log.debug("BVC setting up constraints…")
         setupConstraints()
@@ -1734,7 +1723,6 @@ extension BrowserViewController: TabToolbarDelegate {
             backForwardViewController.bvc = self
             backForwardViewController.modalPresentationStyle = UIModalPresentationStyle.OverCurrentContext
             backForwardViewController.backForwardTransitionDelegate = BackForwardListAnimator()
-            self.backForwardViewController = backForwardViewController
             self.presentViewController(backForwardViewController, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
The history menu is now locked to the bar from which it was opened — be that the URL bar on wider displays, or the bottom toolbar on portrait iPhones.