### PR TITLE
Bug 1292236 – Tab tray button reverts to normal theme when pressed on a new private tab

### DIFF
--- a/Client/Frontend/Widgets/TabsButton.swift
+++ b/Client/Frontend/Widgets/TabsButton.swift
@@ -143,6 +143,8 @@ class TabsButton: UIControl {
         button.accessibilityLabel = accessibilityLabel
         button.titleLabel.text = titleLabel.text
 
+        button.theme = theme
+
         // Copy all of the styable properties over to the new TabsButton
         button.titleLabel.font = titleLabel.font
         button.titleLabel.textColor = titleLabel.textColor


### PR DESCRIPTION
This is the biggest problem with property observers. It’s so hard to
track what’s actually going on, because it’s unclear when a variable
assignment is getting modified behind the scenes without looking
through _all_ the declarations.