### PR TITLE
Bug 1290838 – Sync devices list is not scrollable when accessed without internet connection

### DIFF
--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -246,9 +246,7 @@ public class BrowserDB {
     func withConnection<T>(flags flags: SwiftData.Flags, inout err: NSError?, callback: (connection: SQLiteDBConnection, inout err: NSError?) -> T) -> T {
         var res: T!
         err = db.withConnection(flags) { connection in
-            // This should never occur. Make it fail hard in debug builds.
-            assert(!(connection is FailedSQLiteDBConnection))
-
+            // An error may occur if the internet connection is dropped.
             var err: NSError? = nil
             res = callback(connection: connection, err: &err)
             return err


### PR DESCRIPTION
This fixes two issues with the synced devices history list when using
Firefox with a poor or nonexistent internet connection.