### PR TITLE
Bug 1275202 – Tabs will not be aligned after changing device orientation in tabs tray

### DIFF
--- a/Client/Frontend/Browser/SwipeAnimator.swift
+++ b/Client/Frontend/Browser/SwipeAnimator.swift
@@ -33,6 +33,8 @@ class SwipeAnimator: NSObject {
     
     private var prevOffset: CGPoint!
     private let params: SwipeAnimationParameters
+    
+    private var panGestureRecogniser: UIPanGestureRecognizer!
 
     var containerCenter: CGPoint {
         return CGPoint(x: CGRectGetWidth(container.frame) / 2, y: CGRectGetHeight(container.frame) / 2)
@@ -45,9 +47,14 @@ class SwipeAnimator: NSObject {
 
         super.init()
 
-        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(SwipeAnimator.SELdidPan(_:)))
-        container.addGestureRecognizer(panGesture)
-        panGesture.delegate = self
+        self.panGestureRecogniser = UIPanGestureRecognizer(target: self, action: #selector(SwipeAnimator.SELdidPan(_:)))
+        container.addGestureRecognizer(self.panGestureRecogniser)
+        self.panGestureRecogniser.delegate = self
+    }
+
+    func cancelExistingGestures() {
+        self.panGestureRecogniser.enabled = false
+        self.panGestureRecogniser.enabled = true
     }
 }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -434,6 +434,12 @@ class TabTrayController: UIViewController {
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
+        if let visibleCells = self.collectionView.visibleCells() as? [TabCell] {
+            for cell in visibleCells {
+                cell.animator.cancelExistingGestures()
+            }
+        }
+
         coordinator.animateAlongsideTransition({ _ in
             self.collectionView.collectionViewLayout.invalidateLayout()
         }, completion: nil)


### PR DESCRIPTION
Any gestures are now cancelled to avoid any problems with the changing layout during rotation.