### PR TITLE
Bug 1294741 – Top sites editing has a couple of visual flaws

### DIFF
--- a/Client/Frontend/Home/HomePanelViewController.swift
+++ b/Client/Frontend/Home/HomePanelViewController.swift
@@ -324,6 +324,7 @@ class HomePanelViewController: UIViewController, UITextFieldDelegate, HomePanelD
             button.addTarget(self, action: #selector(HomePanelViewController.endEditing(_:)), forControlEvents: UIControlEvents.TouchUpInside)
             button.transform = translateDown
             button.titleLabel?.textAlignment = .Right
+            button.tintColor = self.isPrivateMode ? UIConstants.PrivateModeActionButtonTintColor : UIConstants.SystemBlueColor
             self.buttonContainerView.addSubview(button)
             button.snp_makeConstraints { make in
                 make.right.equalTo(self.buttonContainerView).offset(HomePanelViewControllerUX.EditDoneButtonRightPadding)

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -94,6 +94,7 @@ class TopSitesPanel: UIViewController {
         collection.dataSource = dataSource
         collection.registerClass(ThumbnailCell.self, forCellWithReuseIdentifier: ThumbnailIdentifier)
         collection.keyboardDismissMode = .OnDrag
+        collection.allowsSelection = false
         collection.accessibilityIdentifier = "Top Sites View"
         view.addSubview(collection)
         collection.snp_makeConstraints { make in


### PR DESCRIPTION
This fixes two visual flaws with top sites editing: an incorrectly-coloured “Done” button and the ability to select items whilst editing.