### PR TITLE
Bug 1293668 – The menu is not correctly positioned on iPads when using split screen feature

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -182,6 +182,14 @@ class BrowserViewController: UIViewController {
     private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection) {
         let showToolbar = shouldShowFooterForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
+        
+        if let mvc = menuViewController where showToolbar != (toolbar != nil) {
+            // Hide the menu, and then re-open it so that the menu is always the correct one for the given traits
+            mvc.dismissViewControllerAnimated(true, completion: nil)
+            dispatch_async(dispatch_get_main_queue()) {
+                self.tabToolbarDidPressMenu(self.navigationToolbar, button: self.navigationToolbar.menuButton)
+            }
+        }
 
         urlBar.topTabsIsShowing = showTopTabs
         urlBar.setShowToolbar(!showToolbar)

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -179,16 +179,16 @@ class BrowserViewController: UIViewController {
         }
     }
 
-    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection) {
+    private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator? = nil) {
         let showToolbar = shouldShowFooterForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
         
         if let mvc = menuViewController where showToolbar != (toolbar != nil) {
             // Hide the menu, and then re-open it so that the menu is always the correct one for the given traits
             mvc.dismissViewControllerAnimated(true, completion: nil)
-            dispatch_async(dispatch_get_main_queue()) {
+            coordinator?.animateAlongsideTransition(nil, completion: { _ in
                 self.tabToolbarDidPressMenu(self.navigationToolbar, button: self.navigationToolbar.menuButton)
-            }
+            })
         }
 
         urlBar.topTabsIsShowing = showTopTabs
@@ -261,7 +261,7 @@ class BrowserViewController: UIViewController {
         // During split screen launching on iPad, this callback gets fired before viewDidLoad gets a chance to
         // set things up. Make sure to only update the toolbar state if the view is ready for it.
         if isViewLoaded() {
-            updateToolbarStateForTraitCollection(newCollection)
+            updateToolbarStateForTraitCollection(newCollection, withTransitionCoordinator: coordinator)
         }
 
         displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)


### PR DESCRIPTION
Reopen the menu every time the toolbar usage changes so that the menu
is always the correct one for the screen.