### PR TITLE
Bug 1294807 – Private top tabs are visible when the app is backgrounded

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -291,6 +291,7 @@ class BrowserViewController: UIViewController {
         webViewContainerBackdrop.alpha = 1
         webViewContainer.alpha = 0
         urlBar.locationContainer.alpha = 0
+        topTabsViewController?.switchForegroundStatus(isInForeground: false)
         presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
         presentedViewController?.view.alpha = 0
     }
@@ -301,6 +302,7 @@ class BrowserViewController: UIViewController {
         UIView.animateWithDuration(0.2, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: {
             self.webViewContainer.alpha = 1
             self.urlBar.locationContainer.alpha = 1
+            self.topTabsViewController?.switchForegroundStatus(isInForeground: true)
             self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
             self.presentedViewController?.view.alpha = 1
             self.view.backgroundColor = UIColor.clearColor()

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -151,6 +151,17 @@ class TopTabsViewController: UIViewController {
         updateTabCount(tabsToDisplay.count)
     }
     
+    func switchForegroundStatus(isInForeground reveal: Bool) {
+        // Called when the app leaves the foreground to make sure no information is inadvertently revealed
+        if let cells = self.collectionView.visibleCells() as? [TopTabCell] {
+            let alpha: CGFloat = reveal ? 1 : 0
+            for cell in cells {
+                cell.titleText.alpha = alpha
+                cell.favicon.alpha = alpha
+            }
+        }
+    }
+    
     func updateTabCount(count: Int, animated: Bool = true) {
         self.tabsButton.updateTabCount(count, animated: animated)
     }


### PR DESCRIPTION
Now favicon and titles are hidden along with everything else in private
mode, with top tabs.