### PR TITLE
Bug 1296112 – Top tabs has several issues with private mode authentication

### DIFF
--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -131,7 +131,7 @@ class QuickActions: NSObject {
 
     private func handleOpenURL(withBrowserViewController bvc: BrowserViewController, urlToOpen: NSURL) {
         // open bookmark in a non-private browsing tab
-        bvc.switchToPrivacyMode(isPrivate: false)
+        bvc.switchToPrivacyMode(isPrivate: false, completion: nil)
 
         // find out if bookmarked URL is currently open
         // if so, open to that tab,

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -23,17 +23,16 @@ class AppAuthenticator {
                 return
             }
 
-            guard let authError = error,
-                      code = LAError(rawValue: authError.code) else {
+            guard let authError = error, code = LAError(rawValue: authError.code) else {
                 return
             }
 
             dispatch_async(dispatch_get_main_queue()) {
                 switch code {
-                case .UserFallback, .TouchIDNotEnrolled, .TouchIDNotAvailable, .TouchIDLockout:
-                    fallback?()
-                default:
-                    cancel?()
+                    case .UserFallback, .TouchIDNotEnrolled, .TouchIDNotAvailable, .TouchIDLockout:
+                        fallback?()
+                    default:
+                        cancel?()
                 }
             }
         }

--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -43,7 +43,7 @@ private extension TrayToBrowserAnimator {
 
         // Create a fake cell to use for the upscaling animation
         let startingFrame = calculateCollapsedCellFrameUsingCollectionView(tabTray.collectionView, atIndex: expandFromIndex)
-        let cell = createTransitionCellFromTab(bvc.tabManager.selectedTab, withFrame: startingFrame)
+        let cell = createTransitionCellFromTab(bvc.tabManager.selectedTab, withFrame: startingFrame, concealPrivateContent: !tabManager.isInPrivateMode)
         cell.backgroundHolder.layer.cornerRadius = 0
 
         container.insertSubview(bvc.view, aboveSubview: tabCollectionViewSnapshot)
@@ -125,7 +125,7 @@ private extension BrowserToTrayAnimator {
 
         // Build a tab cell that we will use to animate the scaling of the browser to the tab
         let expandedFrame = calculateExpandedCellFrameFromBVC(bvc)
-        let cell = createTransitionCellFromTab(selectedTab, withFrame: expandedFrame)
+        let cell = createTransitionCellFromTab(selectedTab, withFrame: expandedFrame, concealPrivateContent: !tabManager.isInPrivateMode)
         if !tabManager.isInPrivateMode && selectedTab.isPrivate {
             // Hide the screenshot if the tab is being minimised in order to escape private browsing mode
             cell.background.image = nil
@@ -287,7 +287,7 @@ private func transformToolbarsToFrame(toolbars: [UIView?], toRect endRect: CGRec
     }
 }
 
-private func createTransitionCellFromTab(tab: Tab?, withFrame frame: CGRect) -> TabCell {
+private func createTransitionCellFromTab(tab: Tab?, withFrame frame: CGRect, concealPrivateContent: Bool) -> TabCell {
     let cell = TabCell(frame: frame)
     cell.background.image = tab?.screenshot
     cell.titleText.text = tab?.displayTitle
@@ -295,17 +295,19 @@ private func createTransitionCellFromTab(tab: Tab?, withFrame frame: CGRect) -> 
     if let tab = tab where tab.isPrivate {
         cell.style = .Dark
     }
-
-    if let favIcon = tab?.displayFavicon {
-        cell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
-    } else {
-        var defaultFavicon = UIImage(named: "defaultFavicon")
-        if tab?.isPrivate ?? false {
-            defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
-            cell.favicon.image = defaultFavicon
-            cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.whiteColor() : UIColor.darkGrayColor()
+    
+    if !concealPrivateContent {
+        if let favIcon = tab?.displayFavicon {
+            cell.favicon.sd_setImageWithURL(NSURL(string: favIcon.url)!)
         } else {
-            cell.favicon.image = defaultFavicon
+            var defaultFavicon = UIImage(named: "defaultFavicon")
+            if tab?.isPrivate ?? false {
+                defaultFavicon = defaultFavicon?.imageWithRenderingMode(.AlwaysTemplate)
+                cell.favicon.image = defaultFavicon
+                cell.favicon.tintColor = (tab?.isPrivate ?? false) ? UIColor.whiteColor() : UIColor.darkGrayColor()
+            } else {
+                cell.favicon.image = defaultFavicon
+            }
         }
     }
     return cell

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -317,7 +317,7 @@ class BrowserViewController: UIViewController {
     }
 
     func SELappWillResignActiveNotification() {
-        guard let privateTab = tabManager.selectedTab where privateTab.isPrivate else {
+        guard tabManager.isInPrivateMode else {
             return
         }
         tabManager.needsAuthentication = true
@@ -325,17 +325,19 @@ class BrowserViewController: UIViewController {
     }
 
     func SELappDidBecomeActiveNotification() {
-        if let navigationController = self.navigationController where self.tabTrayController == nil {
-            tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
-                guard success else {
-                    if #available(iOS 9, *) {
-                        if self.navigationController?.topViewController === self {
-                            self.openTabTray()
+        if let navigationController = self.navigationController {
+            if self.tabTrayController == nil {
+                tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
+                    guard success else {
+                        if #available(iOS 9, *) {
+                            if self.navigationController?.topViewController === self {
+                                self.openTabTray()
+                            }
                         }
+                        return
                     }
-                    return
+                    self.revealPrivateContent()
                 }
-                self.revealPrivateContent()
             }
         } else {
             revealPrivateContent()

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1260,24 +1260,24 @@ class BrowserViewController: UIViewController {
     }
 
     func reloadTab() {
-        if(homePanelController == nil) {
+        if homePanelController == nil {
             tabManager.selectedTab?.reload()
         }
     }
 
     func goBack() {
-        if(tabManager.selectedTab?.canGoBack == true && homePanelController == nil) {
+        if tabManager.selectedTab?.canGoBack == true && homePanelController == nil {
             tabManager.selectedTab?.goBack()
         }
     }
     func goForward() {
-        if(tabManager.selectedTab?.canGoForward == true && homePanelController == nil) {
+        if tabManager.selectedTab?.canGoForward == true && homePanelController == nil {
             tabManager.selectedTab?.goForward()
         }
     }
 
     func findOnPage() {
-        if(homePanelController == nil) {
+        if homePanelController == nil {
             tab( (tabManager.selectedTab)!, didSelectFindInPageForSelection: "")
         }
     }
@@ -1295,7 +1295,7 @@ class BrowserViewController: UIViewController {
     }
 
     func closeTab() {
-        if(tabManager.tabs.count > 1) {
+        if tabManager.tabs.count > 1 {
             tabManager.removeTab(tabManager.selectedTab!)
         } else {
             //need to close the last tab and show the favorites screen thing
@@ -1303,20 +1303,20 @@ class BrowserViewController: UIViewController {
     }
 
     func nextTab() {
-        if(tabManager.selectedIndex < (tabManager.tabs.count - 1) ) {
+        if tabManager.selectedIndex < (tabManager.tabs.count - 1) {
             tabManager.selectTab(tabManager.tabs[tabManager.selectedIndex+1])
         } else {
-            if(tabManager.tabs.count > 1) {
+            if tabManager.tabs.count > 1 {
                 tabManager.selectTab(tabManager.tabs[0])
             }
         }
     }
 
     func previousTab() {
-        if(tabManager.selectedIndex > 0) {
+        if tabManager.selectedIndex > 0 {
             tabManager.selectTab(tabManager.tabs[tabManager.selectedIndex-1])
         } else {
-            if(tabManager.tabs.count > 1) {
+            if tabManager.tabs.count > 1 {
                 tabManager.selectTab(tabManager.tabs[tabManager.count-1])
             }
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -289,7 +289,7 @@ class BrowserViewController: UIViewController {
     func SELtappedTopArea() {
         scrollController.showToolbars(animated: true)
     }
-    
+
     private func concealPrivateContents() {
         // If we are displying a private tab, hide any elements in the tab that we wouldn't want shown
         // when the app is in the home switcher
@@ -320,6 +320,7 @@ class BrowserViewController: UIViewController {
         guard let privateTab = tabManager.selectedTab where privateTab.isPrivate else {
             return
         }
+        tabManager.needsAuthentication = true
         concealPrivateContents()
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -325,7 +325,7 @@ class BrowserViewController: UIViewController {
     }
 
     func SELappDidBecomeActiveNotification() {
-        if let navigationController = self.navigationController {
+        if let navigationController = self.navigationController where self.tabTrayController == nil {
             tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
                 guard success else {
                     if #available(iOS 9, *) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -315,7 +315,6 @@ class BrowserViewController: UIViewController {
                     if self.navigationController?.topViewController === self {
                         self.openTabTray()
                     }
-                    self.tabTrayController.changePrivacyMode(false)
                 }
                 return
             }
@@ -1061,9 +1060,7 @@ class BrowserViewController: UIViewController {
                 return
             }
             if let tabTrayController = self.tabTrayController {
-                tabTrayController.changePrivacyMode(isPrivate)
-            } else {
-                self.tabManager.isInPrivateMode = isPrivate
+                tabTrayController.transitionBetweenModes()
             }
             self.applyTheme(isPrivate ? Theme.PrivateMode : Theme.NormalMode)
             completion?(true)

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -94,6 +94,7 @@ class TabManager: NSObject {
             }
         }
     }
+    var needsAuthentication = true
     var isAuthenticating = false
 
     var normalTabs: [Tab] {
@@ -179,6 +180,7 @@ class TabManager: NSObject {
     
     func authorisePrivateMode(navigationController: UINavigationController, toRemainInPrivateMode reverseAuthorisationRequirement: Bool, completion: Bool -> ()) {
         let succeedInAuthorising = {
+            self.needsAuthentication = false
             self.isAuthenticating = false
             self.isInPrivateMode = !reverseAuthorisationRequirement ? !self.isInPrivateMode : self.isInPrivateMode
             completion(true)
@@ -189,7 +191,7 @@ class TabManager: NSObject {
             completion(false)
         }
         self.isAuthenticating = true
-        if self.isInPrivateMode != reverseAuthorisationRequirement {
+        if self.isInPrivateMode != reverseAuthorisationRequirement || reverseAuthorisationRequirement && !self.needsAuthentication {
             succeedInAuthorising()
             return
         }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -181,6 +181,10 @@ class TabManager: NSObject {
             self.isInPrivateMode = !reverseAuthorisationRequirement ? !self.isInPrivateMode : self.isInPrivateMode
             completion(true)
         }
+        let failInAuthorising = {
+            self.isInPrivateMode = false
+            completion(false)
+        }
         if self.isInPrivateMode != reverseAuthorisationRequirement {
             succeedInAuthorising()
             return
@@ -190,13 +194,10 @@ class TabManager: NSObject {
             return
         }
         if authInfo.requiresValidation(.PrivateBrowsing) {
-            let cancelAction = { completion(false) }
             AppAuthenticator.presentTouchAuthenticationUsingInfo(authInfo,
                 touchIDReason: AuthenticationStrings.privateModeReason,
-                success: {
-                    succeedInAuthorising()
-                },
-                cancel: cancelAction,
+                success: succeedInAuthorising,
+                cancel: failInAuthorising,
                 fallback: {
                     AppAuthenticator.presentPasscodeAuthentication(navigationController,
                         success: {
@@ -204,7 +205,7 @@ class TabManager: NSObject {
                                 succeedInAuthorising()
                             }
                         },
-                    cancel: cancelAction)
+                    cancel: failInAuthorising)
                 }
             )
         } else {

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -94,6 +94,7 @@ class TabManager: NSObject {
             }
         }
     }
+    var isAuthenticating = false
 
     var normalTabs: [Tab] {
         assert(NSThread.isMainThread())
@@ -178,13 +179,16 @@ class TabManager: NSObject {
     
     func authorisePrivateMode(navigationController: UINavigationController, toRemainInPrivateMode reverseAuthorisationRequirement: Bool, completion: Bool -> ()) {
         let succeedInAuthorising = {
+            self.isAuthenticating = false
             self.isInPrivateMode = !reverseAuthorisationRequirement ? !self.isInPrivateMode : self.isInPrivateMode
             completion(true)
         }
         let failInAuthorising = {
+            self.isAuthenticating = false
             self.isInPrivateMode = false
             completion(false)
         }
+        self.isAuthenticating = true
         if self.isInPrivateMode != reverseAuthorisationRequirement {
             succeedInAuthorising()
             return

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -304,10 +304,10 @@ class TabTrayController: UIViewController {
         }
     }
     
-    private func switchToMode(privateMode privateMode: Bool) {
-        self.tabTrayState.isPrivate = privateMode
+    private func switchToMode() {
         tabDataSource.tabs = tabsToDisplay
-        toolbar.styleToolbar(isPrivate: tabManager.isInPrivateMode)
+        self.tabTrayState.isPrivate = self.tabManager.isInPrivateMode
+        toolbar.styleToolbar(isPrivate: self.tabManager.isInPrivateMode)
         collectionView?.reloadData()
     }
 
@@ -392,7 +392,7 @@ class TabTrayController: UIViewController {
                 make.bottom.equalTo(self.toolbar.snp_top)
             }
 
-            self.switchToMode(privateMode: self.tabManager.isInPrivateMode)
+            self.switchToMode()
 
             // register for previewing delegate to enable peek and pop if force touch feature available
             if traitCollection.forceTouchCapability == .Available {
@@ -522,7 +522,7 @@ class TabTrayController: UIViewController {
             fromView = snapshot
         }
         
-        self.switchToMode(privateMode: !self.tabManager.isInPrivateMode)
+        self.switchToMode()
         
         // If we are exiting private mode and we have the close private tabs option selected, make sure
         // we clear out all of the private tabs

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -307,8 +307,6 @@ class TabTrayController: UIViewController {
     }
     
     private func switchToMode(privateMode privateMode: Bool) {
-        tabManager.isInPrivateMode = privateMode
-        
         tabDataSource.tabs = tabsToDisplay
         toolbar.styleToolbar(isPrivate: tabManager.isInPrivateMode)
         collectionView?.reloadData()

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -290,9 +290,7 @@ class TabTrayController: UIViewController {
         return toolbar
     }()
 
-    var tabTrayState: TabTrayState {
-        return TabTrayState(isPrivate: tabManager.isInPrivateMode)
-    }
+    var tabTrayState = TabTrayState(isPrivate: false)
 
     var leftToolbarButtons: [UIButton] {
         return [toolbar.addTabButton]
@@ -307,6 +305,7 @@ class TabTrayController: UIViewController {
     }
     
     private func switchToMode(privateMode privateMode: Bool) {
+        self.tabTrayState.isPrivate = privateMode
         tabDataSource.tabs = tabsToDisplay
         toolbar.styleToolbar(isPrivate: tabManager.isInPrivateMode)
         collectionView?.reloadData()
@@ -392,7 +391,7 @@ class TabTrayController: UIViewController {
                 make.top.left.right.equalTo(self.collectionView)
                 make.bottom.equalTo(self.toolbar.snp_top)
             }
-            
+
             self.switchToMode(privateMode: self.tabManager.isInPrivateMode)
 
             // register for previewing delegate to enable peek and pop if force touch feature available
@@ -424,7 +423,7 @@ class TabTrayController: UIViewController {
         // Update the trait collection we reference in our layout delegate
         tabLayoutDelegate.traitCollection = traitCollection
     }
-    
+
     private func cancelExistingGestures() {
         if let visibleCells = self.collectionView.visibleCells() as? [TabCell] {
             for cell in visibleCells {
@@ -719,6 +718,12 @@ extension TabTrayController: PresentingModalViewControllerDelegate {
 
 extension TabTrayController: TabManagerDelegate {
     func tabManager(tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
+        if !tabManager.isInPrivateMode && self.tabTrayState.isPrivate {
+            // This means the last private tab has been closed, so the selected tab is no longer actually a private tab.
+            // We must therefore override the TabManager's private mode setting, because we want to remain in private mode,
+            // even without any private tabs.
+            tabManager.isInPrivateMode = true
+        }
     }
 
     func tabManager(tabManager: TabManager, didCreateTab tab: Tab) {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -510,7 +510,7 @@ class TabTrayController: UIViewController {
     }
     
     @available(iOS 9, *)
-    private func transitionBetweenModes() {
+    func transitionBetweenModes() {
         let scaleDownTransform = CGAffineTransformMakeScale(0.9, 0.9)
         
         let fromView: UIView
@@ -639,17 +639,6 @@ class TabTrayController: UIViewController {
     @available(iOS 9, *)
     private func privateTabsAreEmpty() -> Bool {
         return tabManager.isInPrivateMode && tabManager.privateTabs.count == 0
-    }
-
-    @available(iOS 9, *)
-    func changePrivacyMode(isPrivate: Bool) {
-        if isPrivate != tabManager.isInPrivateMode {
-            guard let _ = collectionView else {
-                switchToMode(privateMode: isPrivate)
-                return
-            }
-            attemptToTogglePrivateMode()
-        }
     }
 
     private func openNewTab(request: NSURLRequest? = nil) {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -669,11 +669,10 @@ class TabTrayController: UIViewController {
 
 // MARK: - App Notifications
 extension TabTrayController {
-    func SELappWillResignActiveNotification() {
-        tabManager.needsAuthentication = true
-        if tabManager.isInPrivateMode {
-            collectionView.alpha = 0
-        }
+    private func concealPrivateContent() {
+        collectionView.alpha = 0
+        presentedViewController?.popoverPresentationController?.containerView?.alpha = 0
+        presentedViewController?.view.alpha = 0
     }
     
     private func revealPrivateContent() {
@@ -681,7 +680,16 @@ extension TabTrayController {
         // as part of a private mode tab
         UIView.animateWithDuration(0.2, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: {
             self.collectionView.alpha = 1
+            self.presentedViewController?.popoverPresentationController?.containerView?.alpha = 1
+            self.presentedViewController?.view.alpha = 1
         }, completion: nil)
+    }
+
+    func SELappWillResignActiveNotification() {
+        tabManager.needsAuthentication = true
+        if tabManager.isInPrivateMode {
+            self.concealPrivateContent()
+        }
     }
 
     func SELappDidBecomeActiveNotification() {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -568,18 +568,17 @@ class TabTrayController: UIViewController {
     }
 
     @available(iOS 9, *)
-    func attemptToTogglePrivateMode() -> Success {
+    func attemptToTogglePrivateMode(completion: (Bool -> ())? = nil) {
         guard let navigationController = self.navigationController else {
-            return deferMaybe(AuthorisationError(description: "Failed to switch the private mode due to an inexistent navigation controller."))
+            completion?(false)
+            return
         }
-        let success = Success()
-        tabManager.authorisePrivateMode(navigationController).uponQueue(dispatch_get_main_queue()) { result in
-            if result.isSuccess {
+        tabManager.authorisePrivateMode(navigationController) { success in
+            if success {
                 self.transitionBetweenModes()
             }
-            success.fill(result)
+            completion?(success)
         }
-        return success
     }
     
     @available(iOS 9, *)
@@ -1196,8 +1195,8 @@ extension TabTrayController: MenuActionDelegate {
                 if #available(iOS 9, *) {
                     dispatch_async(dispatch_get_main_queue()) {
                         if !self.tabManager.isInPrivateMode {
-                            self.attemptToTogglePrivateMode().uponQueue(dispatch_get_main_queue()) { result in
-                                if result.isSuccess {
+                            self.attemptToTogglePrivateMode() { success in
+                                if success {
                                     self.openNewTab()
                                 }
                             }

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -671,18 +671,35 @@ class TabTrayController: UIViewController {
 // MARK: - App Notifications
 extension TabTrayController {
     func SELappWillResignActiveNotification() {
+        tabManager.needsAuthentication = true
         if tabManager.isInPrivateMode {
             collectionView.alpha = 0
         }
     }
-
-    func SELappDidBecomeActiveNotification() {
+    
+    private func revealPrivateContent() {
         // Re-show any components that might have been hidden because they were being displayed
         // as part of a private mode tab
         UIView.animateWithDuration(0.2, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: {
             self.collectionView.alpha = 1
-        },
-        completion: nil)
+        }, completion: nil)
+    }
+
+    func SELappDidBecomeActiveNotification() {
+        if let navigationController = self.navigationController {
+            tabManager.authorisePrivateMode(navigationController, toRemainInPrivateMode: true) { success in
+                guard success else {
+                    if #available(iOS 9, *) {
+                        self.transitionBetweenModes()
+                    }
+                    return
+                }
+                self.revealPrivateContent()
+            }
+        } else {
+            revealPrivateContent()
+        }
+        
     }
 }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -190,9 +190,12 @@ class TopTabsViewController: UIViewController {
     }
     
     func togglePrivateModeTapped() {
-        delegate?.didAttemptToTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab)
-        self.collectionView.reloadData()
-        self.scrollToCurrentTab(false, centerCell: true)
+        delegate?.didAttemptToTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab).uponQueue(dispatch_get_main_queue()) { result in
+            if result.isSuccess {
+                self.collectionView.reloadData()
+                self.scrollToCurrentTab(false, centerCell: true)
+            }
+        }
     }
     
     func closeTab() {

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -24,7 +24,7 @@ struct TopTabsUX {
 protocol TopTabsDelegate: class {
     func topTabsDidPressTabs()
     func topTabsDidPressNewTab()
-    func didAttemptToTogglePrivateMode(cachedTab: Tab?) -> Success
+    func didAttemptToTogglePrivateMode(cachedTab: Tab?, completion: Bool -> ())
     func topTabsDidChangeTab()
 }
 
@@ -190,8 +190,8 @@ class TopTabsViewController: UIViewController {
     }
     
     func togglePrivateModeTapped() {
-        delegate?.didAttemptToTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab).uponQueue(dispatch_get_main_queue()) { result in
-            if result.isSuccess {
+        delegate?.didAttemptToTogglePrivateMode(isPrivate ? lastNormalTab : lastPrivateTab) { success in
+            if success {
                 self.collectionView.reloadData()
                 self.scrollToCurrentTab(false, centerCell: true)
             }

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -309,6 +309,10 @@ extension TopTabsViewController: UICollectionViewDataSource {
                 tabCell.favicon.image = defaultFavicon
             }
         }
+
+        let alpha: CGFloat = tabManager.isInPrivateMode && tabManager.isAuthenticating ? 0 : 1
+        tabCell.titleText.alpha = alpha
+        tabCell.favicon.alpha = alpha
         
         return tabCell
     }

--- a/UITests/PrivateModeAuthenticationTests.swift
+++ b/UITests/PrivateModeAuthenticationTests.swift
@@ -52,12 +52,12 @@ class PrivateModeAuthenticationTests: KIFTestCase {
         enterPasscode(PrivateModeAuthenticationTests.passcode)
         checkBrowsingMode(isPrivate: enterPrivateMode)
     }
-    
+
     private func enterIncorrectPasscode() {
         enterPasscode(PrivateModeAuthenticationTests.incorrectPasscode)
         checkBrowsingMode(isPrivate: false)
     }
-    
+
     private func checkActionEnablesPrivateBrowsingMode(action: () -> ()) {
         enablePasscodeAuthentication()
         checkBrowsingMode(isPrivate: false)
@@ -102,7 +102,7 @@ class PrivateModeAuthenticationTests: KIFTestCase {
             self.tester().tapViewWithAccessibilityLabel("New Private Tab")
         }
     }
-    
+
     func testPasscodeAuthenticationForNewPrivateTabFromTabTray() {
         tester().tapViewWithAccessibilityLabel("Show Tabs")
         tester().tapViewWithAccessibilityLabel("Menu")
@@ -110,7 +110,7 @@ class PrivateModeAuthenticationTests: KIFTestCase {
             self.tester().tapViewWithAccessibilityLabel("New Private Tab")
         }
     }
-    
+
     func testPasscodeAuthenticationForNewPrivateTabFromTodayView() {
         checkActionEnablesPrivateBrowsingMode {
             self.getAppDelegate().launchFromURL(LaunchParams(url: NSURL(string: "\(self.webRoot)/pageWithLink.html"), isPrivate: true))


### PR DESCRIPTION
We’ve now switched to responding to privacy mode changes using callbacks rather than Deferred values, as this prevents the UI propagation delay and causes things to execute predictably in the correct order without race conditions.