### PR TITLE
Bug 1280447 - Adds force nil'ing out of cached popover properties on BVC on UIActivityViewController completion block for iOS 10

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1130,6 +1130,12 @@ class BrowserViewController: UIViewController {
             // After dismissing, check to see if there were any prompts we queued up
             self.showQueuedAlertIfAvailable()
 
+            // Usually the popover delegate would handle nil'ing out the references we have to it
+            // on the BVC when displaying as a popover but the delegate method doesn't seem to be
+            // invoked on iOS 10. See Bug 1297768 for additional details.
+            self.displayedPopoverController = nil
+            self.updateDisplayedPopoverProperties = nil
+
             if completed {
                 // We don't know what share action the user has chosen so we simply always
                 // update the toolbar and reader mode bar to reflect the latest status.


### PR DESCRIPTION
A simple workaround for this issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1297768. Guess we'll see if this is something that will be addressed in the remaining betas. The better fix for this issue would be to have the delegate method nil out the properties on dismissal but those delegate methods don't seem to be firing.