### PR TITLE
Bug 1211201 – Accessing the URL bar can take more scrolling than expected

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -54,6 +54,7 @@ private extension TrayToBrowserAnimator {
 
 
         let finalFrame = calculateExpandedCellFrameFromBVC(bvc)
+        bvc.urlBar.alpha = 1
         bvc.footer.alpha = shouldDisplayFooterForBVC(bvc) ? 1 : 0
         bvc.urlBar.isTransitioning = true
 
@@ -165,8 +166,7 @@ private extension BrowserToTrayAnimator {
                 cell.layoutIfNeeded()
 
                 transformHeaderFooterForBVC(bvc, toFrame: finalFrame, container: container)
-
-                bvc.urlBar.updateAlphaForSubviews(0)
+                bvc.urlBar.alpha = 0
                 bvc.footer.alpha = 0
                 tabCollectionViewSnapshot.alpha = 1
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -131,13 +131,12 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
-        guard let displayedPopoverController = self.displayedPopoverController else {
-            return
-        }
-
         coordinator.animateAlongsideTransition(nil) { context in
-            self.updateDisplayedPopoverProperties?()
-            self.presentViewController(displayedPopoverController, animated: true, completion: nil)
+            self.scrollController.showToolbars(animated: false)
+            if let displayedPopoverController = self.displayedPopoverController {
+                self.updateDisplayedPopoverProperties?()
+                self.presentViewController(displayedPopoverController, animated: true, completion: nil)
+            }
         }
     }
 
@@ -272,7 +271,6 @@ class BrowserViewController: UIViewController {
             let contentOffset = scrollView.contentOffset
             coordinator.animateAlongsideTransition({ context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y + 1), animated: true)
-                self.scrollController.showToolbars(animated: false)
             }, completion: { context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y), animated: false)
             })

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -459,7 +459,7 @@ class BrowserViewController: UIViewController {
     }
     
     func didTapURLBar(recogniser: UITapGestureRecognizer) {
-        if self.urlBar.state < 1.0 {
+        if self.urlBar.transitionValue < 1.0 {
             self.scrollController.showToolbars(animated: true)
         }
     }
@@ -608,7 +608,7 @@ class BrowserViewController: UIViewController {
 
     func resetBrowserChrome() {
         // animate and reset transform for tab chrome
-        urlBar.state = 1.0
+        urlBar.transitionValue = 1.0
 
         [header,
             footer,

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -264,7 +264,7 @@ class BrowserViewController: UIViewController {
 
         displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
 
-        // WKWebView looks like it has a bug where it doesn't invalidate it's visible area when the user
+        // WKWebView looks like it has a bug where it doesn't invalidate its visible area when the user
         // performs a device rotation. Since scrolling calls
         // _updateVisibleContentRects (https://github.com/WebKit/webkit/blob/master/Source/WebKit2/UIProcess/API/Cocoa/WKWebView.mm#L1430)
         // this method nudges the web view's scroll view by a single pixel to force it to invalidate.

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -100,6 +100,7 @@ class TabLocationView: UIView {
     }()
 
     var urlTextLeading: CGFloat = 0
+    var urlTextTrailing: CGFloat = 0
 
     lazy var urlTextField: UITextField = {
         let urlTextField = DisplayTextField()
@@ -183,8 +184,8 @@ class TabLocationView: UIView {
             self.urlTextLeading = self.lockImageView.hidden ? TabLocationViewUX.LocationContentInset : self.lockImageView.bounds.width
             make.leading.equalTo(self).offset(self.urlTextLeading)
 
-            let urlTextTrailing = self.readerModeButton.hidden ? -TabLocationViewUX.LocationContentInset : -self.readerModeButton.bounds.width
-            make.trailing.equalTo(self).offset(urlTextTrailing)
+            self.urlTextTrailing = self.readerModeButton.hidden ? -TabLocationViewUX.LocationContentInset : -self.readerModeButton.bounds.width
+            make.trailing.equalTo(self).offset(self.urlTextTrailing)
         }
 
         super.updateConstraints()

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -150,7 +150,10 @@ class TabLocationView: UIView {
         addSubview(readerModeButton)
 
         lockImageView.snp_makeConstraints { make in
-            make.leading.centerY.equalTo(self)
+            make.leading.equalTo(self)
+            // Because the lock has greater visual weight lower down, we offset it slightly to make it look vertically centred.
+            let verticalOffset = -0.5
+            make.centerY.equalTo(self).offset(verticalOffset)
             make.width.equalTo(self.lockImageView.intrinsicContentSize().width + CGFloat(TabLocationViewUX.LocationContentInset * 2))
         }
 

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -24,7 +24,7 @@ struct TabLocationViewUX {
     static let BaseURLFontColor = UIColor.grayColor()
     static let BaseURLPitch = 0.75
     static let HostPitch = 1.0
-    static let LocationContentInset = 8
+    static let LocationContentInset: CGFloat = 8
 
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
@@ -99,6 +99,8 @@ class TabLocationView: UIView {
         return NSAttributedString(string: placeholderText, attributes: [NSForegroundColorAttributeName: UIColor.grayColor()])
     }()
 
+    var urlTextLeading: CGFloat = 0
+
     lazy var urlTextField: UITextField = {
         let urlTextField = DisplayTextField()
 
@@ -117,7 +119,7 @@ class TabLocationView: UIView {
         return urlTextField
     }()
 
-    private lazy var lockImageView: UIImageView = {
+    lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: UIImage(named: "lock_verified.png"))
         lockImageView.hidden = true
         lockImageView.isAccessibilityElement = true
@@ -175,20 +177,19 @@ class TabLocationView: UIView {
         urlTextField.snp_remakeConstraints { make in
             make.top.bottom.equalTo(self)
 
-            if lockImageView.hidden {
-                make.leading.equalTo(self).offset(TabLocationViewUX.LocationContentInset)
-            } else {
-                make.leading.equalTo(self.lockImageView.snp_trailing)
-            }
+            self.urlTextLeading = self.lockImageView.hidden ? TabLocationViewUX.LocationContentInset : self.lockImageView.bounds.width
+            make.leading.equalTo(self).offset(self.urlTextLeading)
 
-            if readerModeButton.hidden {
-                make.trailing.equalTo(self).offset(-TabLocationViewUX.LocationContentInset)
-            } else {
-                make.trailing.equalTo(self.readerModeButton.snp_leading)
-            }
+            let urlTextTrailing = self.readerModeButton.hidden ? -TabLocationViewUX.LocationContentInset : -self.readerModeButton.bounds.width
+            make.trailing.equalTo(self).offset(urlTextTrailing)
         }
 
         super.updateConstraints()
+    }
+    
+    func setBackgroundAlpha(alpha: CGFloat) {
+        self.backgroundColor = self.backgroundColor?.colorWithAlphaComponent(alpha)
+        self.readerModeButton.alpha = alpha
     }
 
     func SELtapReaderModeButton() {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -47,18 +47,16 @@ class TabScrollingController: NSObject {
 
     private var urlBarState: CGFloat {
         get {
-            return self.urlBar?.state ?? 0.0
+            return self.urlBar?.transitionValue ?? 0.0
         }
         set {
             guard let urlBar = self.urlBar else {
                 return
             }
-            urlBar.state = newValue
-            let inverseState = 1.0 - urlBar.state
+            urlBar.transitionValue = newValue
+            let inverseState = 1.0 - urlBar.transitionValue
             self.headerTopConstraint?.updateOffset(inverseState * self.minifiedHeaderTopOffset)
             self.footerBottomConstraint?.updateOffset(inverseState * self.bottomScrollHeight)
-            self.header?.superview?.setNeedsLayout()
-            self.footer?.superview?.setNeedsLayout()
         }
     }
 
@@ -189,7 +187,6 @@ private extension TabScrollingController {
             scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
         }
 
-//        print("\(updatedOffset) \(clamp(updatedOffset, min: self.minifiedHeaderTopOffset, max: 0)) \(1.0 - (clamp(updatedOffset, min: self.minifiedHeaderTopOffset, max: 0) / self.minifiedHeaderTopOffset))")
         self.urlBarState = 1.0 - (clamp(updatedOffset, min: self.minifiedHeaderTopOffset, max: 0) / self.minifiedHeaderTopOffset)
     }
 

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -395,7 +395,11 @@ class URLBarView: UIView {
                 }
             } else {
                 tabsButton.snp_remakeConstraints { make in
-                    make.centerY.equalTo(self)
+                    if self.toolbarIsShowing {
+                        make.centerY.equalTo(self)
+                    } else {
+                        make.centerY.equalTo(self.locationContainer)
+                    }
                     make.trailing.equalTo(self)
                     make.size.equalTo(UIConstants.ToolbarHeight)
                 }

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -101,8 +101,10 @@ class URLBarView: UIView {
             // Spacing
             let offsetToHide = UIConstants.ToolbarHeight + URLBarViewUX.URLBarCurveOffset - URLBarViewUX.LocationLeftPadding
             let offsetForState = inverseState * offsetToHide
-            self.tabsButton.snp_updateConstraints { make in
-                make.trailing.equalTo(offsetForState)
+            if !self.topTabsIsShowing {
+                self.tabsButton.snp_updateConstraints { make in
+                    make.trailing.equalTo(offsetForState)
+                }
             }
             self.curveShape.snp_updateConstraints { make in
                 self.rightBarConstraint = make.right.equalTo(self.defaultRightOffset + offsetForState).constraint
@@ -414,9 +416,6 @@ class URLBarView: UIView {
                     make.leading.equalTo(self).offset(URLBarViewUX.LocationLeftPadding)
                     make.trailing.equalTo(self.tabsButton.snp_leading).offset(-14)
                 }
-
-                make.height.equalTo(URLBarViewUX.LocationHeight)
-                make.centerY.equalTo(self)
             }
         }
         // Fire the didSet handler to update the constraints regarding the minified URL bar

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -115,9 +115,9 @@ class URLBarView: UIView {
                 make.top.equalTo(border + offset * inverseState)
                 make.bottom.equalTo(-border + offset * inverseState)
             }
-            if let window = self.window, text = self.locationView.urlTextField.text, font = self.locationView.urlTextField.font {
+            if let text = self.locationView.urlTextField.text, font = self.locationView.urlTextField.font {
                 let urlTextWidth = min(NSString(string: text).boundingRectWithSize(self.locationView.urlTextField.bounds.size, options: .TruncatesLastVisibleLine, attributes: [NSFontAttributeName: font], context: nil).width, self.locationView.urlTextField.bounds.width)
-                let maxOffset = window.bounds.width / 2 - self.locationView.convertPoint(CGPoint(x: urlTextWidth / 2 + self.locationView.urlTextLeading, y: 0), toView: nil).x
+                let maxOffset = self.bounds.width / 2 - self.locationView.convertPoint(CGPoint(x: urlTextWidth / 2 + self.locationView.urlTextLeading, y: 0), toView: self).x
                 self.locationView.urlTextField.snp_updateConstraints { make in
                     make.leading.equalTo(self.locationView.urlTextLeading + inverseState * maxOffset)
                     make.trailing.equalTo(self.locationView.urlTextTrailing + inverseState * maxOffset)

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -92,11 +92,11 @@ class URLBarView: UIView {
     }
 
     // The transition between the URL bar being fully displayed (1.0) and being minimised (0.0)
-    var state: CGFloat = 1.0 {
+    var transitionValue: CGFloat = 1.0 {
         didSet {
-            let inverseState = 1.0 - state
+            let inverseState = 1.0 - transitionValue
             // Interaction
-            self.locationContainer.userInteractionEnabled = state == 1.0
+            self.locationContainer.userInteractionEnabled = transitionValue == 1.0
 
             // Spacing
             let offsetToHide = UIConstants.ToolbarHeight + URLBarViewUX.URLBarCurveOffset - URLBarViewUX.LocationLeftPadding
@@ -125,9 +125,9 @@ class URLBarView: UIView {
             }
 
             // Transparency
-            self.locationContainer.layer.borderColor = self.locationBorderColor.colorWithAlphaComponent(state * self.locationBorderColor.alpha).CGColor
-            self.locationView.setBackgroundAlpha(state)
-            self.actionButtons.forEach { $0.alpha = state }
+            self.locationContainer.layer.borderColor = self.locationBorderColor.colorWithAlphaComponent(transitionValue * self.locationBorderColor.alpha).CGColor
+            self.locationView.setBackgroundAlpha(transitionValue)
+            self.actionButtons.forEach { $0.alpha = transitionValue }
             self.border.alpha = inverseState
         }
     }

--- a/Utils/Extensions/UIColorExtensions.swift
+++ b/Utils/Extensions/UIColorExtensions.swift
@@ -28,4 +28,10 @@ extension UIColor {
         NSScanner(string: colorString).scanHexInt(&colorInt)
         self.init(rgb: (Int) (colorInt ?? 0xaaaaaa))
     }
+
+    public var alpha: CGFloat {
+        var alpha: CGFloat = 0
+        self.getWhite(nil, alpha: &alpha)
+        return alpha
+    }
 }


### PR DESCRIPTION
Here a transition is added to the URL bar so that it doesn’t completely disappear when scrolling, but shrinks to a minimised state. This means the URL bar can be brought back much more intuitively, and gives the user a little more context whilst browsing.