### PR TITLE
Bug 1293068 – Address bar spoofing with authinfo in front of URL in reader-view

### DIFF
--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -278,27 +278,20 @@ class Tab: NSObject {
     var displayURL: NSURL? {
         if let url = url {
             if ReaderModeUtils.isReaderModeURL(url) {
-                return ReaderModeUtils.decodeURL(url)
+                return ReaderModeUtils.decodeURL(url)?.havingRemovedAuthorisationComponents()
             }
 
             if ErrorPageHelper.isErrorPageURL(url) {
                 let decodedURL = ErrorPageHelper.originalURLFromQuery(url)
                 if !AboutUtils.isAboutURL(decodedURL) {
-                    return decodedURL
+                    return decodedURL?.havingRemovedAuthorisationComponents()
                 } else {
                     return nil
                 }
             }
 
-            if let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) where (urlComponents.user != nil) || (urlComponents.password != nil) {
-                urlComponents.user = nil
-                urlComponents.password = nil
-                return urlComponents.URL
-            }
-
-
             if !AboutUtils.isAboutURL(url) {
-                return url
+                return url.havingRemovedAuthorisationComponents()
             }
         }
         return nil

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -264,6 +264,17 @@ extension NSURL {
     public var schemeIsValid: Bool {
         return permanentURISchemes.contains(scheme)
     }
+
+    public func havingRemovedAuthorisationComponents() -> NSURL {
+        if let urlComponents = NSURLComponents(URL: self, resolvingAgainstBaseURL: false) {
+            urlComponents.user = nil
+            urlComponents.password = nil
+            if let url = urlComponents.URL {
+                return url
+            }
+        }
+        return self
+    }
 }
 
 //MARK: Private Helpers

--- a/Utils/Extensions/NSURLExtensions.swift
+++ b/Utils/Extensions/NSURLExtensions.swift
@@ -266,12 +266,13 @@ extension NSURL {
     }
 
     public func havingRemovedAuthorisationComponents() -> NSURL {
-        if let urlComponents = NSURLComponents(URL: self, resolvingAgainstBaseURL: false) {
-            urlComponents.user = nil
-            urlComponents.password = nil
-            if let url = urlComponents.URL {
-                return url
-            }
+        guard let urlComponents = NSURLComponents(URL: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+        urlComponents.user = nil
+        urlComponents.password = nil
+        if let url = urlComponents.URL {
+            return url
         }
         return self
     }


### PR DESCRIPTION
We now remove authorisation components regardless of the type of the URL. This seems like the safest option.