### PR TITLE
Bug 1293066 – firefox: URL scheme bypasses localhost navigation blocking

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -290,7 +290,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func launchFromURL(params: LaunchParams) {
         let isPrivate = params.isPrivate ?? false
-        if let newURL = params.url {
+        if let newURL = params.url where !newURL.isLocal {
             self.browserViewController.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate)
         } else {
             self.browserViewController.openBlankNewTabAndFocus(isPrivate: isPrivate)

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -290,8 +290,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func launchFromURL(params: LaunchParams) {
         let isPrivate = params.isPrivate ?? false
-        if let newURL = params.url where !newURL.isLocal {
-            self.browserViewController.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate)
+        if let newURL = params.url {
+            self.browserViewController.switchToTabForURLOrOpen(newURL, isPrivate: isPrivate, isPrivileged: false)
         } else {
             self.browserViewController.openBlankNewTabAndFocus(isPrivate: isPrivate)
         }
@@ -525,7 +525,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool {
         if let url = userActivity.webpageURL {
-            browserViewController.switchToTabForURLOrOpen(url)
+            browserViewController.switchToTabForURLOrOpen(url, isPrivileged: true)
             return true
         }
         return false
@@ -534,7 +534,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func viewURLInNewTab(notification: UILocalNotification) {
         if let alertURL = notification.userInfo?[TabSendURLKey] as? String {
             if let urlToOpen = NSURL(string: alertURL) {
-                browserViewController.openURLInNewTab(urlToOpen)
+                browserViewController.openURLInNewTab(urlToOpen, isPrivileged: true)
             }
         }
     }

--- a/Client/Application/QuickActions.swift
+++ b/Client/Application/QuickActions.swift
@@ -136,6 +136,6 @@ class QuickActions: NSObject {
         // find out if bookmarked URL is currently open
         // if so, open to that tab,
         // otherwise, create a new tab with the bookmarked URL
-        bvc.switchToTabForURLOrOpen(urlToOpen)
+        bvc.switchToTabForURLOrOpen(urlToOpen, isPrivileged: true)
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -577,7 +577,7 @@ class BrowserViewController: UIViewController {
 
         if shouldShowWhatsNewTab() {
             if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
-                self.openURLInNewTab(whatsNewURL, isPrivileged: true)
+                self.openURLInNewTab(whatsNewURL, isPrivileged: false)
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
             }
         }
@@ -1411,7 +1411,7 @@ extension BrowserViewController: MenuActionDelegate {
 
 extension BrowserViewController: SettingsDelegate {
     func settingsOpenURLInNewTab(url: NSURL) {
-        self.openURLInNewTab(url, isPrivileged: true)
+        self.openURLInNewTab(url, isPrivileged: false)
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -577,7 +577,7 @@ class BrowserViewController: UIViewController {
 
         if shouldShowWhatsNewTab() {
             if let whatsNewURL = SupportUtils.URLForTopic("new-ios") {
-                self.openURLInNewTab(whatsNewURL)
+                self.openURLInNewTab(whatsNewURL, isPrivileged: true)
                 profile.prefs.setString(AppInfo.appVersion, forKey: LatestAppVersionProfileKey)
             }
         }
@@ -594,7 +594,7 @@ class BrowserViewController: UIViewController {
     }
 
     private func showQueuedAlertIfAvailable() {
-        if var queuedAlertInfo = tabManager.selectedTab?.dequeueJavascriptAlertPrompt() {
+        if let queuedAlertInfo = tabManager.selectedTab?.dequeueJavascriptAlertPrompt() {
             let alertController = queuedAlertInfo.alertController()
             alertController.delegate = self
             presentViewController(alertController, animated: true, completion: nil)
@@ -1039,22 +1039,22 @@ class BrowserViewController: UIViewController {
         self.tabTrayController = tabTrayController
     }
 
-    func switchToTabForURLOrOpen(url: NSURL, isPrivate: Bool = false) {
+    func switchToTabForURLOrOpen(url: NSURL, isPrivate: Bool = false, isPrivileged: Bool) {
         popToBVC()
         if let tab = tabManager.getTabForURL(url) {
             tabManager.selectTab(tab)
         } else {
-            openURLInNewTab(url, isPrivate: isPrivate)
+            openURLInNewTab(url, isPrivate: isPrivate, isPrivileged: isPrivileged)
         }
     }
 
-    func openURLInNewTab(url: NSURL?, isPrivate: Bool = false) {
+    func openURLInNewTab(url: NSURL?, isPrivate: Bool = false, isPrivileged: Bool) {
         if let selectedTab = tabManager.selectedTab {
             screenshotHelper.takeScreenshot(selectedTab)
         }
         let request: NSURLRequest?
         if let url = url {
-            request = PrivilegedRequest(URL: url)
+            request = isPrivileged ? PrivilegedRequest(URL: url) : NSURLRequest(URL: url)
         } else {
             request = nil
         }
@@ -1068,7 +1068,7 @@ class BrowserViewController: UIViewController {
 
     func openBlankNewTabAndFocus(isPrivate isPrivate: Bool = false) {
         popToBVC()
-        openURLInNewTab(nil, isPrivate: isPrivate)
+        openURLInNewTab(nil, isPrivate: isPrivate, isPrivileged: true)
         urlBar.tabLocationViewDidTapLocation(urlBar.locationView)
     }
 
@@ -1342,14 +1342,14 @@ extension BrowserViewController: MenuActionDelegate {
             switch menuAction {
             case .OpenNewNormalTab:
                 if #available(iOS 9, *) {
-                    self.openURLInNewTab(nil, isPrivate: false)
+                    self.openURLInNewTab(nil, isPrivate: false, isPrivileged: true)
                 } else {
                     self.tabManager.addTabAndSelect(nil)
                 }
             // this is a case that is only available in iOS9
             case .OpenNewPrivateTab:
                 if #available(iOS 9, *) {
-                    self.openURLInNewTab(nil, isPrivate: true)
+                    self.openURLInNewTab(nil, isPrivate: true, isPrivileged: true)
                 }
             case .FindInPage:
                 self.updateFindInPageVisibility(visible: true)
@@ -1400,7 +1400,7 @@ extension BrowserViewController: MenuActionDelegate {
     private func openHomePanel(panel: HomePanelType, forAppState appState: AppState) {
         switch appState.ui {
         case .Tab(_):
-            self.openURLInNewTab(panel.localhostURL, isPrivate: appState.ui.isPrivate())
+            self.openURLInNewTab(panel.localhostURL, isPrivate: appState.ui.isPrivate(), isPrivileged: true)
         case .HomePanels(_):
             self.homePanelController?.selectedPanel = panel
         default: break
@@ -1411,7 +1411,7 @@ extension BrowserViewController: MenuActionDelegate {
 
 extension BrowserViewController: SettingsDelegate {
     func settingsOpenURLInNewTab(url: NSURL) {
-        self.openURLInNewTab(url)
+        self.openURLInNewTab(url, isPrivileged: true)
     }
 }
 
@@ -1830,7 +1830,7 @@ extension BrowserViewController: TabDelegate {
         tab.addHelper(customSearchHelper, name: CustomSearchHelper.name())
 
         let openURL = {(url: NSURL) -> Void in
-            self.switchToTabForURLOrOpen(url)
+            self.switchToTabForURLOrOpen(url, isPrivileged: true)
         }
 
         let nightModeHelper = NightModeHelper(tab: tab)


### PR DESCRIPTION
Simply block any local requests opened via the firefox:// URI scheme.