### PR TITLE
Bug 1280456 - Fixes menu layout issue on iOS 9 devices when presenting as popover

### DIFF
--- a/Client/Frontend/Widgets/Menu/MenuViewController.swift
+++ b/Client/Frontend/Widgets/Menu/MenuViewController.swift
@@ -168,6 +168,10 @@ class MenuViewController: UIViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         self.view.backgroundColor = popoverBackgroundColor
+
+        if presentationStyle == .Popover {
+            self.preferredContentSize = CGSizeMake(view.bounds.size.width, menuView.bounds.size.height)
+        }
     }
 
     private func reloadView() {


### PR DESCRIPTION
Digging into this, it seems that `viewWillLayoutSubviews` doesn't get called as much as it does on iOS 9 causing the height to be incorrectly calculated on iOS 10. I have a feeling that there have been some undocumented changes to `UIPopoverPresentationController` as I had issues with it in a different bug (https://bugzilla.mozilla.org/show_bug.cgi?id=1297768). This fix is a bit of a hack as it just forces another layout when the popover will appear but it works for now.