### PR TITLE
Bug 1288438 - Send Tab list of devices allows the header set to unselectable

### DIFF
--- a/Extensions/SendTo/ClientPickerViewController.swift
+++ b/Extensions/SendTo/ClientPickerViewController.swift
@@ -115,6 +115,10 @@ class ClientPickerViewController: UITableViewController {
         return cell
     }
 
+    override func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+         return indexPath.section != 0
+    }
+
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         if clients.count > 0 && indexPath.section == 1 {
             tableView.deselectRowAtIndexPath(indexPath, animated: true)


### PR DESCRIPTION
Bug 1288438 - Send Tab list of devices allows the header set to unselectable