### PR TITLE
Bug 1299641 - Added the ability to long press a topsite to remove it from AS.

### DIFF
--- a/Storage/History.swift
+++ b/Storage/History.swift
@@ -23,6 +23,7 @@ public protocol BrowserHistory {
     func clearHistory() -> Success
     func removeHistoryForURL(url: String) -> Success
     func removeSiteFromTopSites(site: Site) -> Success
+    func removeHostFromTopSites(host: String) -> Success
 
     func getSitesByFrecencyWithHistoryLimit(limit: Int) -> Deferred<Maybe<Cursor<Site>>>
     func getSitesByFrecencyWithHistoryLimit(limit: Int, whereURLContains filter: String) -> Deferred<Maybe<Cursor<Site>>>

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -124,10 +124,14 @@ private let topSitesQuery = "SELECT * FROM \(TableCachedTopSites) ORDER BY frece
 extension SQLiteHistory: BrowserHistory {
     public func removeSiteFromTopSites(site: Site) -> Success {
         if let host = site.url.asURL?.normalizedHost() {
-            return db.run([("UPDATE \(TableDomains) set showOnTopSites = 0 WHERE domain = ?", [host])])
-                >>> { return self.refreshTopSitesCache() }
+            return self.removeHostFromTopSites(host)
         }
         return deferMaybe(DatabaseError(description: "Invalid url for site \(site.url)"))
+    }
+
+    public func removeHostFromTopSites(host: String) -> Success {
+        return db.run([("UPDATE \(TableDomains) set showOnTopSites = 0 WHERE domain = ?", [host])])
+            >>> { return self.refreshTopSitesCache() }
     }
 
     public func removeHistoryForURL(url: String) -> Success {


### PR DESCRIPTION
Instead of adding a tiny delete button above every TopSiteCell I've opted for an AlertView that appears from the bottom. There are lots of weird state issues that came up in the old TopSites and it made reasoning with the code harder. This also gives us room to expand. Right now the context menu only contains a delete action. But later I can add more actions such as the ability to open in a private tab. 

Instead of adding a long press gesture to every cell I add a single gesture to the UICollectionview. Then I translate the location of the press into an IndexPath. This keeps things pretty simple. 