### PR TITLE
Bug 1300903 - Don't let topsite cells set their background color to black. Use gray instead.

### DIFF
--- a/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
+++ b/Client/Frontend/Home/ActivityStreamTopSitesCell.swift
@@ -106,8 +106,8 @@ class TopSiteItemCell: UICollectionViewCell {
 
             // Get dominant colors using a scaled 25/25 image.
             img.getColors(CGSize(width: 25, height: 25)) { colors in
-                //In cases where the background is white. Force the background color to a different color
-                let colorArr = [colors.backgroundColor, colors.detailColor, colors.primaryColor].filter { !$0.isWhite }
+                //In cases where the background is black/white. Force the background color to a different color
+                let colorArr = [colors.backgroundColor, colors.detailColor, colors.primaryColor].filter { !$0.isBlackOrWhite }
                 self.contentView.backgroundColor = colorArr.isEmpty ? UIColor.lightGrayColor() : colorArr.first
             }
         }

--- a/ThirdParty/UIImageColors.swift
+++ b/ThirdParty/UIImageColors.swift
@@ -38,11 +38,6 @@ extension UIColor {
         return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91) || (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
     }
 
-    public var isWhite: Bool {
-        let RGB = CGColorGetComponents(self.CGColor)
-        return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91)
-    }
-
     private func isDistinct(compareColor: UIColor) -> Bool {
         let bg = CGColorGetComponents(self.CGColor)
         let fg = CGColorGetComponents(compareColor.CGColor)


### PR DESCRIPTION
A tiny UI fix. I was the one who added isWhite to the third party UIImageColors so I removed it now.