### PR TITLE
Bug 1302242 - Make MockProfile conform to Profile protocol to let tests build again.

### DIFF
--- a/ClientTests/MockProfile.swift
+++ b/ClientTests/MockProfile.swift
@@ -177,6 +177,10 @@ public class MockProfile: Profile {
         self.syncManager.onRemovedAccount(old)
     }
 
+    func flushAccount() {
+
+    }
+
     func getClients() -> Deferred<Maybe<[RemoteClient]>> {
         return deferMaybe([])
     }


### PR DESCRIPTION
This was preventing our tests from compiling because MockProfile didn't conform to the Profile protocol fully. I just added the new method from the protocol to MockProfile.  