### PR TITLE
Bug 1303845 - Explicitly unwrap previously unwrapped value so we dont have optionals in a URL

### DIFF
--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -87,9 +87,9 @@ public class TokenServerClient {
 
     public class func getAudienceForURL(URL: NSURL) -> String {
         if let port = URL.port {
-            return "\(URL.scheme)://\(URL.host!):\(port)"
+            return "\(URL.scheme!)://\(URL.host!):\(port)"
         } else {
-            return "\(URL.scheme)://\(URL.host!)"
+            return "\(URL.scheme!)://\(URL.host!)"
         }
     }
 

--- a/Client/Frontend/Browser/BrowserPrompts.swift
+++ b/Client/Frontend/Browser/BrowserPrompts.swift
@@ -134,8 +134,8 @@ private func titleForJavaScriptPanelInitiatedByFrame(frame: WKFrameInfo) -> Stri
             title += ":\(frame.securityOrigin.port)"
         }
     } else {
-        if let url = frame.request.URL {
-            title = "\(url.scheme)://\(url.hostPort))"
+        if let url = frame.request.URL, scheme = url.scheme {
+            title = "\(scheme)://\(url.hostPort))"
         }
     }
     return title

--- a/Storage/Logins.swift
+++ b/Storage/Logins.swift
@@ -308,12 +308,13 @@ public class Login: CustomStringConvertible, LoginData, LoginUsageData, Equatabl
 
     private class func getPasswordOrigin(uriString: String, allowJS: Bool = false) -> String? {
         var realm: String? = nil
-        if let uri = NSURL(string: uriString) where !(uri.scheme?.isEmpty ?? true) {
-            if allowJS && uri.scheme == "javascript" {
+        if let uri = NSURL(string: uriString),
+            scheme = uri.scheme where !scheme.isEmpty {
+            if allowJS && scheme == "javascript" {
                 return "javascript:"
             }
 
-            realm = "\(uri.scheme)://\(uri.host!)"
+            realm = "\(scheme)://\(uri.host!)"
 
             // If the URI explicitly specified a port, only include it when
             // it's not the default. (We never want "http://foo.com:80")


### PR DESCRIPTION
After digging into the problem a bit, a user is able to successfully login to their FxA account if they wait for a few seconds on the 'Confirm Email' screen. Putting that issue aside, when the user goes ahead and confirms their email then tries to sync, the first sync will fail because of the audience URL containing an optional value where before it contained a String. This patch addresses that.