### PR TITLE
Bug 1303756 - Fix up deprecation warnings from SwiftKeychainWrapper

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -5411,16 +5411,13 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				INFOPLIST_FILE = Account/Info.plist;
@@ -5445,16 +5442,13 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				INFOPLIST_FILE = Account/Info.plist;
@@ -5945,7 +5939,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -5959,7 +5952,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
@@ -6112,7 +6104,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -6126,7 +6117,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
@@ -6324,16 +6314,13 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				INFOPLIST_FILE = Account/Info.plist;
@@ -6817,7 +6804,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -6831,7 +6817,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
@@ -7002,16 +6987,13 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				INFOPLIST_FILE = Account/Info.plist;
@@ -7300,7 +7282,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -7314,7 +7295,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
@@ -7552,16 +7532,13 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				INFOPLIST_FILE = Account/Info.plist;
@@ -7736,7 +7713,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -7754,7 +7730,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)",
 					"$(SDKROOT)/usr/include/libxml2",
-					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
 					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -427,10 +427,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func updateAuthenticationInfo() {
-        if let authInfo = KeychainWrapper.authenticationInfo() {
+        if let authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() {
             if !LAContext().canEvaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, error: nil) {
                 authInfo.useTouchID = false
-                KeychainWrapper.setAuthenticationInfo(authInfo)
+                KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authInfo)
             }
         }
     }

--- a/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
+++ b/Client/Frontend/AuthenticationManager/AppAuthenticator.swift
@@ -17,7 +17,7 @@ class AppAuthenticator {
                     // Update our authentication info's last validation timestamp so we don't ask again based
                     // on the set required interval
                     authenticationInfo.recordValidation()
-                    KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+                    KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
                     dispatch_async(dispatch_get_main_queue()) {
                         success?()
                     }

--- a/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
+++ b/Client/Frontend/AuthenticationManager/AuthenticationSettingsViewController.swift
@@ -65,7 +65,7 @@ class RequirePasscodeSetting: Setting {
 
     override var status: NSAttributedString {
         // Only show the interval if we are enabled and have an interval set.
-        let authenticationInterval = KeychainWrapper.authenticationInfo()
+        let authenticationInterval = KeychainWrapper.defaultKeychainWrapper().authenticationInfo()
         if let interval = authenticationInterval?.requiredPasscodeInterval where enabled {
             return NSAttributedString.disabledTableRowTitle(interval.settingTitle)
         }
@@ -82,7 +82,7 @@ class RequirePasscodeSetting: Setting {
     }
 
     override func onClick(_: UINavigationController?) {
-        guard let authInfo = KeychainWrapper.authenticationInfo() else {
+        guard let authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() else {
             navigateToRequireInterval()
             return
         }
@@ -134,7 +134,7 @@ class TouchIDSetting: Setting {
         self.touchIDSuccess = touchIDSuccess
         self.touchIDFallback = touchIDFallback
         self.navigationController = navigationController
-        self.authInfo = KeychainWrapper.authenticationInfo()
+        self.authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo()
         super.init(title: title, delegate: delegate, enabled: enabled)
     }
 
@@ -181,7 +181,7 @@ class TouchIDSetting: Setting {
 
     func toggleTouchID(enabled enabled: Bool) {
         authInfo?.useTouchID = enabled
-        KeychainWrapper.setAuthenticationInfo(authInfo)
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authInfo)
         switchControl?.setOn(enabled, animated: true)
     }
 }
@@ -207,7 +207,7 @@ class AuthenticationSettingsViewController: SettingsTableViewController {
     }
 
     override func generateSettings() -> [SettingSection] {
-        if let _ = KeychainWrapper.authenticationInfo() {
+        if let _ = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() {
             return passcodeEnabledSettings()
         } else {
             return passcodeDisabledSettings()

--- a/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/BasePasscodeViewController.swift
@@ -15,7 +15,7 @@ class BasePasscodeViewController: UIViewController {
     let errorPadding: CGFloat = 10
 
     init() {
-        self.authenticationInfo = KeychainWrapper.authenticationInfo()
+        self.authenticationInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo()
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -87,6 +87,6 @@ extension BasePasscodeViewController {
         inputView.resetCode()
 
         // Store mutations on authentication info object
-        KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
     }
 }

--- a/Client/Frontend/AuthenticationManager/ChangePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/ChangePasscodeViewController.swift
@@ -86,7 +86,7 @@ class ChangePasscodeViewController: PagingPasscodeViewController, PasscodeInputV
 
     private func changePasscodeToCode(code: String) {
         authenticationInfo?.updatePasscode(code)
-        KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.postNotificationName(NotificationPasscodeDidChange, object: nil)
     }

--- a/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
+++ b/Client/Frontend/AuthenticationManager/PasscodeEntryViewController.swift
@@ -56,7 +56,7 @@ extension PasscodeEntryViewController: PasscodeInputViewDelegate {
     func passcodeInputView(inputView: PasscodeInputView, didFinishEnteringCode code: String) {
         if let passcode = authenticationInfo?.passcode where passcode == code {
             authenticationInfo?.recordValidation()
-            KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+            KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
             delegate?.passcodeValidationDidSucceed()
         } else {
             passcodePane.shakePasscode()
@@ -64,7 +64,7 @@ extension PasscodeEntryViewController: PasscodeInputViewDelegate {
             passcodePane.codeInputView.resetCode()
 
             // Store mutations on authentication info object
-            KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+            KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
         }
     }
 }

--- a/Client/Frontend/AuthenticationManager/RemovePasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RemovePasscodeViewController.swift
@@ -49,7 +49,7 @@ class RemovePasscodeViewController: PagingPasscodeViewController, PasscodeInputV
     }
 
     private func removePasscode() {
-        KeychainWrapper.setAuthenticationInfo(nil)
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(nil)
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.postNotificationName(NotificationPasscodeDidRemove, object: nil)
     }

--- a/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
+++ b/Client/Frontend/AuthenticationManager/RequirePasscodeIntervalViewController.swift
@@ -52,7 +52,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        self.authenticationInfo = KeychainWrapper.authenticationInfo()
+        self.authenticationInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo()
         tableView.reloadData()
     }
 
@@ -71,7 +71,7 @@ class RequirePasscodeIntervalViewController: UITableViewController {
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         authenticationInfo?.updateRequiredPasscodeInterval(intervalOptions[indexPath.row])
-        KeychainWrapper.setAuthenticationInfo(authenticationInfo)
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(authenticationInfo)
         tableView.reloadData()
     }
 }

--- a/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SensitiveViewController.swift
@@ -38,7 +38,7 @@ class SensitiveViewController: UIViewController {
         }
 
         presentedViewController?.dismissViewControllerAnimated(false, completion: nil)
-        guard let authInfo = KeychainWrapper.authenticationInfo() where authInfo.requiresValidation() else {
+        guard let authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() where authInfo.requiresValidation() else {
             removeBackgroundedBlur()
             return
         }

--- a/Client/Frontend/AuthenticationManager/SetupPasscodeViewController.swift
+++ b/Client/Frontend/AuthenticationManager/SetupPasscodeViewController.swift
@@ -61,7 +61,7 @@ class SetupPasscodeViewController: PagingPasscodeViewController, PasscodeInputVi
     }
 
     private func createPasscodeWithCode(code: String) {
-        KeychainWrapper.setAuthenticationInfo(AuthenticationKeychainInfo(passcode: code))
+        KeychainWrapper.defaultKeychainWrapper().setAuthenticationInfo(AuthenticationKeychainInfo(passcode: code))
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.postNotificationName(NotificationPasscodeDidCreate, object: nil)
     }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -586,7 +586,7 @@ class LoginsSetting: Setting {
     }
 
     override func onClick(_: UINavigationController?) {
-        guard let authInfo = KeychainWrapper.authenticationInfo() else {
+        guard let authInfo = KeychainWrapper.defaultKeychainWrapper().authenticationInfo() else {
             settings?.navigateToLoginsList()
             return
         }

--- a/Sync/State.swift
+++ b/Sync/State.swift
@@ -408,7 +408,7 @@ public class Scratchpad {
         if let keyLabel = prefs.stringForKey(PrefKeyLabel) {
             b.keyLabel = keyLabel
             if let ckTS = prefs.unsignedLongForKey(PrefKeysTS) {
-                if let keys = KeychainWrapper.stringForKey("keys." + keyLabel) {
+                if let keys = KeychainWrapper.defaultKeychainWrapper().stringForKey("keys." + keyLabel) {
                     // We serialize as JSON.
                     let keys = Keys(payload: KeysPayload(keys))
                     if keys.valid {
@@ -454,7 +454,7 @@ public class Scratchpad {
     public class func clearFromPrefs(prefs: Prefs) {
         if let keyLabel = prefs.stringForKey(PrefKeyLabel) {
             log.debug("Removing saved key from keychain.")
-            KeychainWrapper.removeObjectForKey(keyLabel)
+            KeychainWrapper.defaultKeychainWrapper().removeObjectForKey(keyLabel)
         } else {
             log.debug("No key label; nothing to remove from keychain.")
         }
@@ -504,10 +504,10 @@ public class Scratchpad {
             prefs.setLong(keys.timestamp, forKey: PrefKeysTS)
 
             // TODO: I could have sworn that we could specify kSecAttrAccessibleAfterFirstUnlock here.
-            KeychainWrapper.setString(payload, forKey: label)
+            KeychainWrapper.defaultKeychainWrapper().setString(payload, forKey: label)
         } else {
             log.debug("Removing keys from Keychain.")
-            KeychainWrapper.removeObjectForKey(self.keyLabel)
+            KeychainWrapper.defaultKeychainWrapper().removeObjectForKey(self.keyLabel)
         }
 
         prefs.setString(clientName, forKey: PrefClientName)

--- a/Utils/AuthenticationKeychainInfo.swift
+++ b/Utils/AuthenticationKeychainInfo.swift
@@ -20,17 +20,17 @@ public enum PasscodeInterval: Int {
 
 // MARK: - Helper methods for accessing Authentication information from the Keychain
 public extension KeychainWrapper {
-    class func authenticationInfo() -> AuthenticationKeychainInfo? {
+    func authenticationInfo() -> AuthenticationKeychainInfo? {
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
-        return KeychainWrapper.objectForKey(KeychainKeyAuthenticationInfo) as? AuthenticationKeychainInfo
+        return objectForKey(KeychainKeyAuthenticationInfo) as? AuthenticationKeychainInfo
     }
 
-    class func setAuthenticationInfo(info: AuthenticationKeychainInfo?) {
+    func setAuthenticationInfo(info: AuthenticationKeychainInfo?) {
         NSKeyedArchiver.setClassName("AuthenticationKeychainInfo", forClass: AuthenticationKeychainInfo.self)
         if let info = info {
-            KeychainWrapper.setObject(info, forKey: KeychainKeyAuthenticationInfo)
+            setObject(info, forKey: KeychainKeyAuthenticationInfo)
         } else {
-            KeychainWrapper.removeObjectForKey(KeychainKeyAuthenticationInfo)
+            removeObjectForKey(KeychainKeyAuthenticationInfo)
         }
     }
 }

--- a/Utils/KeychainCache.swift
+++ b/Utils/KeychainCache.swift
@@ -30,7 +30,7 @@ public class KeychainCache<T: JSONLiteralConvertible> {
 
     public class func fromBranch(branch: String, withLabel label: String?, withDefault defaultValue: T? = nil, factory: JSON -> T?) -> KeychainCache<T> {
         if let l = label {
-            if let s = KeychainWrapper.stringForKey("\(branch).\(l)") {
+            if let s = KeychainWrapper.defaultKeychainWrapper().stringForKey("\(branch).\(l)") {
                 if let t = factory(JSON.parse(s)) {
                     log.info("Read \(branch) from Keychain with label \(branch).\(l).")
                     return KeychainCache(branch: branch, label: l, value: t)
@@ -54,9 +54,9 @@ public class KeychainCache<T: JSONLiteralConvertible> {
         // TODO: PII logging.
         if let value = value {
             let jsonString = value.asJSON().toString(false)
-            KeychainWrapper.setString(jsonString, forKey: "\(branch).\(label)")
+            KeychainWrapper.defaultKeychainWrapper().setString(jsonString, forKey: "\(branch).\(label)")
         } else {
-            KeychainWrapper.removeObjectForKey("\(branch).\(label)")
+            KeychainWrapper.defaultKeychainWrapper().removeObjectForKey("\(branch).\(label)")
         }
     }
 }


### PR DESCRIPTION
As part of migrating to Swift 2.3, we needed to update to the latest version of SwiftKeychainWrapper which has some deprecations around their API. This patch resolves warnings associated with that along with a minor warning we were getting from the linker on our framework targets.