### PR TITLE
Bug 1304395 - Stablize 6.0 features on master using feature flags

### DIFF
--- a/Client/Frontend/Browser/BrowserTrayAnimators.swift
+++ b/Client/Frontend/Browser/BrowserTrayAnimators.swift
@@ -54,7 +54,6 @@ private extension TrayToBrowserAnimator {
 
 
         let finalFrame = calculateExpandedCellFrameFromBVC(bvc)
-        bvc.urlBar.alpha = 1
         bvc.footer.alpha = shouldDisplayFooterForBVC(bvc) ? 1 : 0
         bvc.urlBar.isTransitioning = true
 
@@ -166,7 +165,8 @@ private extension BrowserToTrayAnimator {
                 cell.layoutIfNeeded()
 
                 transformHeaderFooterForBVC(bvc, toFrame: finalFrame, container: container)
-                bvc.urlBar.alpha = 0
+
+                bvc.urlBar.updateAlphaForSubviews(0)
                 bvc.footer.alpha = 0
                 tabCollectionViewSnapshot.alpha = 1
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -972,7 +972,10 @@ class BrowserViewController: UIViewController {
 
     private func runScriptsOnWebView(webView: WKWebView) {
         webView.evaluateJavaScript("__firefox__.favicons.getFavicons()", completionHandler: nil)
-        webView.evaluateJavaScript("__firefox__.metadata.extractMetadata()", completionHandler: nil)
+
+        if AppConstants.MOZ_CONTENT_METADATA_PARSING {
+            webView.evaluateJavaScript("__firefox__.metadata.extractMetadata()", completionHandler: nil)
+        }
     }
 
     private func updateUIForReaderHomeStateForTab(tab: Tab) {
@@ -1806,8 +1809,10 @@ extension BrowserViewController: TabDelegate {
 
         tab.addHelper(LocalRequestHelper(), name: LocalRequestHelper.name())
 
-        let metadataHelper = MetadataParserHelper(tab: tab, profile: profile)
-        tab.addHelper(metadataHelper, name: MetadataParserHelper.name())
+        if AppConstants.MOZ_CONTENT_METADATA_PARSING {
+            let metadataHelper = MetadataParserHelper(tab: tab, profile: profile)
+            tab.addHelper(metadataHelper, name: MetadataParserHelper.name())
+        }
     }
 
     func tab(tab: Tab, willDeleteWebView webView: WKWebView) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -29,6 +29,7 @@ private let ActionSheetTitleMaxLength = 120
 
 private struct BrowserViewControllerUX {
     private static let BackgroundColor = UIConstants.AppBackgroundColor
+    private static let ShowHeaderTapAreaHeight: CGFloat = 32
     private static let BookmarkStarAnimationDuration: Double = 0.5
     private static let BookmarkStarAnimationOffset: CGFloat = 80
 }
@@ -82,6 +83,7 @@ class BrowserViewController: UIViewController {
     var footer: UIView!
     var footerBackdrop: UIView!
     private var footerBackground: BlurWrapper?
+    private var topTouchArea: UIButton!
     let urlBarTopTabsContainer = UIView(frame: CGRect.zero)
 
     // Backdrop used for displaying greyed background for private tabs
@@ -131,12 +133,13 @@ class BrowserViewController: UIViewController {
             self.displayedPopoverController = nil
         }
 
+        guard let displayedPopoverController = self.displayedPopoverController else {
+            return
+        }
+
         coordinator.animateAlongsideTransition(nil) { context in
-            self.scrollController.showToolbars(animated: false)
-            if let displayedPopoverController = self.displayedPopoverController {
-                self.updateDisplayedPopoverProperties?()
-                self.presentViewController(displayedPopoverController, animated: true, completion: nil)
-            }
+            self.updateDisplayedPopoverProperties?()
+            self.presentViewController(displayedPopoverController, animated: true, completion: nil)
         }
     }
 
@@ -264,7 +267,7 @@ class BrowserViewController: UIViewController {
 
         displayedPopoverController?.dismissViewControllerAnimated(true, completion: nil)
 
-        // WKWebView looks like it has a bug where it doesn't invalidate its visible area when the user
+        // WKWebView looks like it has a bug where it doesn't invalidate it's visible area when the user
         // performs a device rotation. Since scrolling calls
         // _updateVisibleContentRects (https://github.com/WebKit/webkit/blob/master/Source/WebKit2/UIProcess/API/Cocoa/WKWebView.mm#L1430)
         // this method nudges the web view's scroll view by a single pixel to force it to invalidate.
@@ -272,6 +275,7 @@ class BrowserViewController: UIViewController {
             let contentOffset = scrollView.contentOffset
             coordinator.animateAlongsideTransition({ context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y + 1), animated: true)
+                self.scrollController.showToolbars(animated: false)
             }, completion: { context in
                 scrollView.setContentOffset(CGPoint(x: contentOffset.x, y: contentOffset.y), animated: false)
             })
@@ -280,6 +284,10 @@ class BrowserViewController: UIViewController {
 
     func SELappDidEnterBackgroundNotification() {
         displayedPopoverController?.dismissViewControllerAnimated(false, completion: nil)
+    }
+
+    func SELtappedTopArea() {
+        scrollController.showToolbars(animated: true)
     }
 
     func SELappWillResignActiveNotification() {
@@ -356,6 +364,12 @@ class BrowserViewController: UIViewController {
         statusBarOverlay.backgroundColor = BrowserViewControllerUX.BackgroundColor
         view.addSubview(statusBarOverlay)
 
+        log.debug("BVC setting up top touch area…")
+        topTouchArea = UIButton()
+        topTouchArea.isAccessibilityElement = false
+        topTouchArea.addTarget(self, action: #selector(BrowserViewController.SELtappedTopArea), forControlEvents: UIControlEvents.TouchUpInside)
+        view.addSubview(topTouchArea)
+
         log.debug("BVC setting up URL bar…")
         // Setup the URL bar, wrapped in a view to get transparency effect
         urlBar = URLBarView()
@@ -365,9 +379,6 @@ class BrowserViewController: UIViewController {
         header = BlurWrapper(view: urlBarTopTabsContainer)
         urlBarTopTabsContainer.addSubview(urlBar)
         urlBarTopTabsContainer.addSubview(topTabsContainer)
-        let showURLBarGesture = UITapGestureRecognizer(target: self, action: #selector(didTapURLBar))
-        showURLBarGesture.cancelsTouchesInView = false
-        urlBar.addGestureRecognizer(showURLBarGesture)
         view.addSubview(header)
 
         // UIAccessibilityCustomAction subclass holding an AccessibleAction instance does not work, thus unable to generate AccessibleActions and UIAccessibilityCustomActions "on-demand" and need to make them "persistent" e.g. by being stored in BVC
@@ -449,18 +460,14 @@ class BrowserViewController: UIViewController {
     }
 
     override func viewDidLayoutSubviews() {
+        log.debug("BVC viewDidLayoutSubviews…")
         super.viewDidLayoutSubviews()
         statusBarOverlay.snp_remakeConstraints { make in
             make.top.left.right.equalTo(self.view)
             make.height.equalTo(self.topLayoutGuide.length)
         }
         self.appDidUpdateState(getCurrentAppState())
-    }
-    
-    func didTapURLBar(recogniser: UITapGestureRecognizer) {
-        if self.urlBar.transitionValue < 1.0 {
-            self.scrollController.showToolbars(animated: true)
-        }
+        log.debug("BVC done.")
     }
 
     func loadQueuedTabs() {
@@ -607,7 +614,7 @@ class BrowserViewController: UIViewController {
 
     func resetBrowserChrome() {
         // animate and reset transform for tab chrome
-        urlBar.transitionValue = 1.0
+        urlBar.updateAlphaForSubviews(1)
 
         [header,
             footer,
@@ -620,6 +627,11 @@ class BrowserViewController: UIViewController {
 
     override func updateViewConstraints() {
         super.updateViewConstraints()
+
+        topTouchArea.snp_remakeConstraints { make in
+            make.top.left.right.equalTo(self.view)
+            make.height.equalTo(BrowserViewControllerUX.ShowHeaderTapAreaHeight)
+        }
 
         readerModeBar?.snp_remakeConstraints { make in
             make.top.equalTo(self.header.snp_bottom).constraint
@@ -1515,6 +1527,15 @@ extension BrowserViewController: URLBarDelegate {
         }
 
         self.presentViewController(longPressAlertController, animated: true, completion: nil)
+    }
+
+    func urlBarDidPressScrollToTop(urlBar: URLBarView) {
+        if let selectedTab = tabManager.selectedTab {
+            // Only scroll to top if we are not showing the home view controller
+            if homePanelController == nil {
+                selectedTab.webView?.scrollView.setContentOffset(CGPointZero, animated: true)
+            }
+        }
     }
 
     func urlBarLocationAccessibilityActions(urlBar: URLBarView) -> [UIAccessibilityCustomAction]? {

--- a/Client/Frontend/Browser/TabLocationView.swift
+++ b/Client/Frontend/Browser/TabLocationView.swift
@@ -24,7 +24,7 @@ struct TabLocationViewUX {
     static let BaseURLFontColor = UIColor.grayColor()
     static let BaseURLPitch = 0.75
     static let HostPitch = 1.0
-    static let LocationContentInset: CGFloat = 8
+    static let LocationContentInset = 8
 
     static let Themes: [String: Theme] = {
         var themes = [String: Theme]()
@@ -99,9 +99,6 @@ class TabLocationView: UIView {
         return NSAttributedString(string: placeholderText, attributes: [NSForegroundColorAttributeName: UIColor.grayColor()])
     }()
 
-    var urlTextLeading: CGFloat = 0
-    var urlTextTrailing: CGFloat = 0
-
     lazy var urlTextField: UITextField = {
         let urlTextField = DisplayTextField()
 
@@ -120,7 +117,7 @@ class TabLocationView: UIView {
         return urlTextField
     }()
 
-    lazy var lockImageView: UIImageView = {
+    private lazy var lockImageView: UIImageView = {
         let lockImageView = UIImageView(image: UIImage(named: "lock_verified.png"))
         lockImageView.hidden = true
         lockImageView.isAccessibilityElement = true
@@ -151,10 +148,7 @@ class TabLocationView: UIView {
         addSubview(readerModeButton)
 
         lockImageView.snp_makeConstraints { make in
-            make.leading.equalTo(self)
-            // Because the lock has greater visual weight lower down, we offset it slightly to make it look vertically centred.
-            let verticalOffset = -0.5
-            make.centerY.equalTo(self).offset(verticalOffset)
+            make.leading.centerY.equalTo(self)
             make.width.equalTo(self.lockImageView.intrinsicContentSize().width + CGFloat(TabLocationViewUX.LocationContentInset * 2))
         }
 
@@ -181,19 +175,20 @@ class TabLocationView: UIView {
         urlTextField.snp_remakeConstraints { make in
             make.top.bottom.equalTo(self)
 
-            self.urlTextLeading = self.lockImageView.hidden ? TabLocationViewUX.LocationContentInset : self.lockImageView.bounds.width
-            make.leading.equalTo(self).offset(self.urlTextLeading)
+            if lockImageView.hidden {
+                make.leading.equalTo(self).offset(TabLocationViewUX.LocationContentInset)
+            } else {
+                make.leading.equalTo(self.lockImageView.snp_trailing)
+            }
 
-            self.urlTextTrailing = self.readerModeButton.hidden ? -TabLocationViewUX.LocationContentInset : -self.readerModeButton.bounds.width
-            make.trailing.equalTo(self).offset(self.urlTextTrailing)
+            if readerModeButton.hidden {
+                make.trailing.equalTo(self).offset(-TabLocationViewUX.LocationContentInset)
+            } else {
+                make.trailing.equalTo(self.readerModeButton.snp_leading)
+            }
         }
 
         super.updateConstraints()
-    }
-    
-    func setBackgroundAlpha(alpha: CGFloat) {
-        self.backgroundColor = self.backgroundColor?.colorWithAlphaComponent(alpha)
-        self.readerModeButton.alpha = alpha
     }
 
     func SELtapReaderModeButton() {

--- a/Client/Frontend/Browser/TabScrollController.swift
+++ b/Client/Frontend/Browser/TabScrollController.swift
@@ -38,34 +38,21 @@ class TabScrollingController: NSObject {
 
     var footerBottomConstraint: Constraint?
     var headerTopConstraint: Constraint?
-    var toolbarsShowing: Bool { return self.urlBarState == 1.0 }
+    var toolbarsShowing: Bool { return headerTopOffset == 0 }
     private var suppressToolbarHiding: Bool = false
 
-    private var minifiedHeaderTopOffset: CGFloat {
-        return URLBarViewUX.MinifiedURLBarHeight - (self.header?.bounds.height ?? 0)
-    }
-
-    private var urlBarState: CGFloat {
-        get {
-            return self.urlBar?.transitionValue ?? 0.0
-        }
-        set {
-            guard let urlBar = self.urlBar else {
-                return
-            }
-            urlBar.transitionValue = newValue
-            let inverseState = 1.0 - urlBar.transitionValue
-            self.headerTopConstraint?.updateOffset(inverseState * self.minifiedHeaderTopOffset)
-            self.footerBottomConstraint?.updateOffset(inverseState * self.bottomScrollHeight)
+    private var headerTopOffset: CGFloat = 0 {
+        didSet {
+            headerTopConstraint?.updateOffset(headerTopOffset)
+            header?.superview?.setNeedsLayout()
         }
     }
 
-    private var headerTopOffset: CGFloat {
-        return (1.0 - self.urlBarState) * self.minifiedHeaderTopOffset
-    }
-
-    private var footerBottomOffset: CGFloat {
-        return (1.0 - self.urlBarState) * self.bottomScrollHeight
+    private var footerBottomOffset: CGFloat = 0 {
+        didSet {
+            footerBottomConstraint?.updateOffset(footerBottomOffset)
+            footer?.superview?.setNeedsLayout()
+        }
     }
 
     private lazy var panGesture: UIPanGestureRecognizer = {
@@ -102,7 +89,9 @@ class TabScrollingController: NSObject {
         self.animateToolbarsWithOffsets(
             animated: animated,
             duration: actualDuration,
-            state: 1.0,
+            headerOffset: 0,
+            footerOffset: 0,
+            alpha: 1,
             completion: completion)
     }
 
@@ -117,7 +106,9 @@ class TabScrollingController: NSObject {
         self.animateToolbarsWithOffsets(
             animated: animated,
             duration: actualDuration,
-            state: 0.0,
+            headerOffset: -topScrollHeight,
+            footerOffset: bottomScrollHeight,
+            alpha: 0,
             completion: completion)
     }
 
@@ -156,7 +147,7 @@ private extension TabScrollingController {
                     scrollWithDelta(delta)
                 }
 
-                if headerTopOffset == minifiedHeaderTopOffset {
+                if headerTopOffset == -topScrollHeight {
                     toolbarState = .Collapsed
                 } else if headerTopOffset == 0 {
                     toolbarState = .Visible
@@ -182,16 +173,21 @@ private extension TabScrollingController {
             return
         }
 
-        let updatedOffset = self.headerTopOffset - delta
+        var updatedOffset = headerTopOffset - delta
+        headerTopOffset = clamp(updatedOffset, min: -topScrollHeight, max: 0)
         if isHeaderDisplayedForGivenOffset(updatedOffset) {
             scrollView?.contentOffset = CGPoint(x: contentOffset.x, y: contentOffset.y - delta)
         }
 
-        self.urlBarState = 1.0 - (clamp(updatedOffset, min: self.minifiedHeaderTopOffset, max: 0) / self.minifiedHeaderTopOffset)
+        updatedOffset = footerBottomOffset + delta
+        footerBottomOffset = clamp(updatedOffset, min: 0, max: bottomScrollHeight)
+
+        let alpha = 1 - abs(headerTopOffset / topScrollHeight)
+        urlBar?.updateAlphaForSubviews(alpha)
     }
 
     func isHeaderDisplayedForGivenOffset(offset: CGFloat) -> Bool {
-        return offset > minifiedHeaderTopOffset && offset < 0
+        return offset > -topScrollHeight && offset < 0
     }
 
     func clamp(y: CGFloat, min: CGFloat, max: CGFloat) -> CGFloat {
@@ -203,9 +199,13 @@ private extension TabScrollingController {
         return y
     }
 
-    func animateToolbarsWithOffsets(animated animated: Bool, duration: NSTimeInterval, state: CGFloat, completion: ((finished: Bool) -> Void)?) {
+    func animateToolbarsWithOffsets(animated animated: Bool, duration: NSTimeInterval, headerOffset: CGFloat,
+        footerOffset: CGFloat, alpha: CGFloat, completion: ((finished: Bool) -> Void)?) {
+
         let animation: () -> Void = {
-            self.urlBarState = state
+            self.headerTopOffset = headerOffset
+            self.footerBottomOffset = footerOffset
+            self.urlBar?.updateAlphaForSubviews(alpha)
             self.header?.superview?.layoutIfNeeded()
         }
 

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -78,6 +78,7 @@ class TabCell: UICollectionViewCell {
 
     var title: UIVisualEffectView!
     var animator: SwipeAnimator!
+
     var isBeingArranged: Bool = false {
         didSet {
             if isBeingArranged {
@@ -373,7 +374,10 @@ class TabTrayController: UIViewController {
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: UIConstants.ToolbarHeight, right: 0)
         collectionView.registerClass(TabCell.self, forCellWithReuseIdentifier: TabCell.Identifier)
         collectionView.backgroundColor = TabTrayControllerUX.BackgroundColor
-        collectionView.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTab)))
+
+        if AppConstants.MOZ_REORDER_TAB_TRAY {
+            collectionView.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPressTab)))
+        }
 
         view.addSubview(collectionView)
         view.addSubview(toolbar)
@@ -430,7 +434,9 @@ class TabTrayController: UIViewController {
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
 
-        self.cancelExistingGestures()
+        if AppConstants.MOZ_REORDER_TAB_TRAY {
+            self.cancelExistingGestures()
+        }
 
         coordinator.animateAlongsideTransition({ _ in
             self.collectionView.collectionViewLayout.invalidateLayout()
@@ -493,7 +499,9 @@ class TabTrayController: UIViewController {
         mvc.menuTransitionDelegate = MenuPresentationAnimator()
         mvc.modalPresentationStyle = .OverCurrentContext
         mvc.fixedWidth = TabTrayControllerUX.MenuFixedWidth
-        self.cancelExistingGestures()
+        if AppConstants.MOZ_REORDER_TAB_TRAY {
+            self.cancelExistingGestures()
+        }
         self.presentViewController(mvc, animated: true, completion: nil)
     }
 
@@ -871,7 +879,9 @@ private class TabManagerDataSource: NSObject, UICollectionViewDataSource {
             tabCell.accessibilityLabel = AboutUtils.getAboutComponent(tab.url)
         }
 
-        tabCell.isBeingArranged = self.isRearrangingTabs
+        if AppConstants.MOZ_REORDER_TAB_TRAY {
+            tabCell.isBeingArranged = self.isRearrangingTabs
+        }
 
         tabCell.isAccessibilityElement = true
         tabCell.accessibilityHint = NSLocalizedString("Swipe right or left with three fingers to close the tab.", comment: "Accessibility hint for tab tray's displayed tab.")

--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -14,8 +14,8 @@ struct URLBarViewUX {
     static let TextFieldBorderColor = UIColor(rgb: 0xBBBBBB)
     static let TextFieldActiveBorderColor = UIColor(rgb: 0x4A90E2)
     static let TextFieldContentInset = UIOffsetMake(9, 5)
-    static let LocationLeftPadding: CGFloat = 5
-    static let LocationHeight: CGFloat = 28
+    static let LocationLeftPadding = 5
+    static let LocationHeight = 28
     static let LocationContentOffset: CGFloat = 8
     static let TextFieldCornerRadius: CGFloat = 3
     static let TextFieldBorderWidth: CGFloat = 1
@@ -28,8 +28,6 @@ struct URLBarViewUX {
     // buffer so we dont see edges when animation overshoots with spring
     static let URLBarCurveBounceBuffer: CGFloat = 8
     static let ProgressTintColor = UIColor(red:1, green:0.32, blue:0, alpha:1)
-
-    static let MinifiedURLBarHeight: CGFloat = 26
 
     static let TabsButtonRotationOffset: CGFloat = 1.5
     static let TabsButtonHeight: CGFloat = 18.0
@@ -72,6 +70,7 @@ protocol URLBarDelegate: class {
     func urlBarDidLeaveOverlayMode(urlBar: URLBarView)
     func urlBarDidLongPressLocation(urlBar: URLBarView)
     func urlBarLocationAccessibilityActions(urlBar: URLBarView) -> [UIAccessibilityCustomAction]?
+    func urlBarDidPressScrollToTop(urlBar: URLBarView)
     func urlBar(urlBar: URLBarView, didEnterText text: String)
     func urlBar(urlBar: URLBarView, didSubmitText text: String)
     func urlBarDisplayTextForURL(url: NSURL?) -> String?
@@ -91,58 +90,6 @@ class URLBarView: UIView {
             if inOverlayMode {
                 locationContainer.layer.borderColor = locationActiveBorderColor.CGColor
             }
-        }
-    }
-
-    // The transition between the URL bar being fully displayed (1.0) and being minimised (0.0)
-    var transitionValue: CGFloat = 1.0 {
-        didSet {
-            let inverseState = 1.0 - transitionValue
-            // Interaction
-            self.locationContainer.userInteractionEnabled = transitionValue == 1.0
-
-            // Spacing
-            let offsetToHide = UIConstants.ToolbarHeight + URLBarViewUX.URLBarCurveOffset - URLBarViewUX.LocationLeftPadding
-            let offsetForState = inverseState * offsetToHide
-            if !self.topTabsIsShowing {
-                self.tabsButton.snp_updateConstraints { make in
-                    make.trailing.equalTo(offsetForState)
-                }
-            }
-            // When in overlay mode always hide
-            let curveShapeOffset = inOverlayMode ? offsetToHide + URLBarViewUX.URLBarCurveOverlayOffset : offsetForState
-            self.curveShape.snp_updateConstraints { make in
-                self.rightBarConstraint = make.right.equalTo(self.defaultRightOffset + curveShapeOffset).constraint
-            }
-            self.locationContainer.snp_updateConstraints { make in
-                let border = (UIConstants.ToolbarHeight - URLBarViewUX.LocationHeight) / 2
-                let offset = (UIConstants.ToolbarHeight - URLBarViewUX.MinifiedURLBarHeight) / 2
-                make.top.equalTo(border + offset * inverseState)
-                make.bottom.equalTo(-border + offset * inverseState)
-            }
-            if let text = self.locationView.urlTextField.text, font = self.locationView.urlTextField.font {
-                let urlTextWidth = min(NSString(string: text).boundingRectWithSize(self.locationView.urlTextField.bounds.size, options: .TruncatesLastVisibleLine, attributes: [NSFontAttributeName: font], context: nil).width, self.locationView.urlTextField.bounds.width)
-                let maxOffset = self.bounds.width / 2 - self.locationView.convertPoint(CGPoint(x: urlTextWidth / 2 + self.locationView.urlTextLeading, y: 0), toView: self).x
-                // To prevent unnecessary changes to the trailing/leading constraints only animate when the changes will be significant
-                if maxOffset > URLBarViewUX.URLBarMinimumOffsetToAnimate {
-                    self.locationView.urlTextField.snp_updateConstraints { make in
-                        make.leading.equalTo(self.locationView.urlTextLeading + inverseState * maxOffset)
-                        make.trailing.equalTo(self.locationView.urlTextTrailing + inverseState * maxOffset)
-                    }
-                    self.locationView.lockImageView.snp_updateConstraints { make in
-                        make.leading.equalTo(inverseState * maxOffset)
-                    }
-                }
-
-            }
-
-            // Transparency
-            self.locationContainer.layer.borderColor = self.locationBorderColor.colorWithAlphaComponent(transitionValue * self.locationBorderColor.alpha).CGColor
-            self.locationView.setBackgroundAlpha(transitionValue)
-            if !self.inOverlayMode {
-                self.actionButtons.forEach { $0.alpha = transitionValue }
-            }
-            self.border.alpha = inverseState
         }
     }
 
@@ -179,7 +126,6 @@ class URLBarView: UIView {
     lazy var locationView: TabLocationView = {
         let locationView = TabLocationView()
         locationView.translatesAutoresizingMaskIntoConstraints = false
-        locationView.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         locationView.readerModeState = ReaderModeState.Unavailable
         locationView.delegate = self
         return locationView
@@ -188,6 +134,9 @@ class URLBarView: UIView {
     lazy var locationContainer: UIView = {
         let locationContainer = UIView()
         locationContainer.translatesAutoresizingMaskIntoConstraints = false
+
+        // Enable clipping to apply the rounded edges to subviews.
+        locationContainer.clipsToBounds = true
 
         locationContainer.layer.borderColor = self.locationBorderColor.CGColor
         locationContainer.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
@@ -224,15 +173,14 @@ class URLBarView: UIView {
         cancelButton.alpha = 0
         return cancelButton
     }()
-    
-    private lazy var border: UIView = {
-        let border = UIView()
-        border.backgroundColor = UIConstants.BorderColor
-        border.alpha = 0
-        return border
-    }()
 
     private lazy var curveShape: CurveView = { return CurveView() }()
+
+    private lazy var scrollToTopButton: UIButton = {
+        let button = UIButton()
+        button.addTarget(self, action: #selector(URLBarView.SELtappedScrollToTopArea), forControlEvents: UIControlEvents.TouchUpInside)
+        return button
+    }()
 
     lazy var shareButton: UIButton = { return UIButton() }()
 
@@ -278,7 +226,7 @@ class URLBarView: UIView {
     private func commonInit() {
         backgroundColor = URLBarViewUX.backgroundColorWithAlpha(0)
         addSubview(curveShape)
-        addSubview(border)
+        addSubview(scrollToTopButton)
 
         addSubview(progressBar)
         addSubview(tabsButton)
@@ -306,15 +254,14 @@ class URLBarView: UIView {
     }
 
     private func setupConstraints() {
+        scrollToTopButton.snp_makeConstraints { make in
+            make.top.equalTo(self)
+            make.left.right.equalTo(self.locationContainer)
+        }
 
         progressBar.snp_makeConstraints { make in
             make.top.equalTo(self.snp_bottom)
             make.width.equalTo(self)
-        }
-
-        border.snp_makeConstraints { make in
-            make.bottom.left.right.equalTo(self)
-            make.height.equalTo(0.5)
         }
 
         locationView.snp_makeConstraints { make in
@@ -327,7 +274,7 @@ class URLBarView: UIView {
         }
 
         tabsButton.snp_makeConstraints { make in
-            make.centerY.equalTo(self)
+            make.centerY.equalTo(self.locationContainer)
             make.trailing.equalTo(self)
             make.size.equalTo(UIConstants.ToolbarHeight)
         }
@@ -398,7 +345,7 @@ class URLBarView: UIView {
                 make.centerY.equalTo(self)
             }
         } else {
-            if topTabsIsShowing {
+            if (topTabsIsShowing) {
                 tabsButton.snp_remakeConstraints { make in
                     make.centerY.equalTo(self.locationContainer)
                     make.leading.equalTo(self.snp_trailing)
@@ -406,11 +353,7 @@ class URLBarView: UIView {
                 }
             } else {
                 tabsButton.snp_remakeConstraints { make in
-                    if self.toolbarIsShowing {
-                        make.centerY.equalTo(self)
-                    } else {
-                        make.centerY.equalTo(self.locationContainer)
-                    }
+                    make.centerY.equalTo(self.locationContainer)
                     make.trailing.equalTo(self)
                     make.size.equalTo(UIConstants.ToolbarHeight)
                 }
@@ -425,10 +368,12 @@ class URLBarView: UIView {
                     make.leading.equalTo(self).offset(URLBarViewUX.LocationLeftPadding)
                     make.trailing.equalTo(self.tabsButton.snp_leading).offset(-14)
                 }
+
+                make.height.equalTo(URLBarViewUX.LocationHeight)
+                make.centerY.equalTo(self)
             }
         }
-        // Fire the didSet handler to update the constraints regarding the minified URL bar
-        self.transitionValue = (self.transitionValue)
+
     }
 
     func createLocationTextField() {
@@ -439,7 +384,6 @@ class URLBarView: UIView {
         guard let locationTextField = locationTextField else { return }
 
         locationTextField.translatesAutoresizingMaskIntoConstraints = false
-        locationTextField.layer.cornerRadius = URLBarViewUX.TextFieldCornerRadius
         locationTextField.autocompleteDelegate = self
         locationTextField.keyboardType = UIKeyboardType.WebSearch
         locationTextField.autocorrectionType = UITextAutocorrectionType.No
@@ -477,6 +421,13 @@ class URLBarView: UIView {
             updateConstraintsIfNeeded()
         }
         updateViewsForOverlayModeAndToolbarChanges()
+    }
+
+    func updateAlphaForSubviews(alpha: CGFloat) {
+        self.tabsButton.alpha = alpha
+        self.locationContainer.alpha = alpha
+        self.backgroundColor = URLBarViewUX.backgroundColorWithAlpha(1 - alpha)
+        self.actionButtons.forEach { $0.alpha = alpha }
     }
 
     func updateTabCount(count: Int, animated: Bool = true) {
@@ -635,6 +586,10 @@ class URLBarView: UIView {
 
     func SELdidClickCancel() {
         leaveOverlayMode(didCancel: true)
+    }
+
+    func SELtappedScrollToTopArea() {
+        delegate?.urlBarDidPressScrollToTop(self)
     }
 }
 

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -200,6 +200,23 @@ public struct AppConstants {
         #endif
     }()
 
+    /// Toggles the ability to reorder tabs in the tab tray
+    public static let MOZ_REORDER_TAB_TRAY: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_NIGHTLY
+            return false
+        #elseif MOZ_CHANNEL_FENNEC
+            return false
+        #elseif MOZ_CHANNEL_AURORA
+            return false
+        #else
+            return false
+        #endif
+    }()
+
     ///  Enables/disables the activity stream for iPhone
     public static let MOZ_AS_PANEL: Bool = {
         #if MOZ_CHANNEL_RELEASE

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -217,6 +217,24 @@ public struct AppConstants {
         #endif
     }()
 
+    /// Enables the injection of the experimental page-metadata-parser into the WKWebView for
+    /// extracting metadata content from web pages
+    public static let MOZ_CONTENT_METADATA_PARSING: Bool = {
+        #if MOZ_CHANNEL_RELEASE
+            return false
+        #elseif MOZ_CHANNEL_BETA
+            return false
+        #elseif MOZ_CHANNEL_NIGHTLY
+            return false
+        #elseif MOZ_CHANNEL_FENNEC
+            return false
+        #elseif MOZ_CHANNEL_AURORA
+            return false
+        #else
+            return false
+        #endif
+    }()
+
     ///  Enables/disables the activity stream for iPhone
     public static let MOZ_AS_PANEL: Bool = {
         #if MOZ_CHANNEL_RELEASE

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -154,7 +154,7 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return true
+            return false
         #elseif MOZ_CHANNEL_NIGHTLY
             return true
         #elseif MOZ_CHANNEL_FENNEC
@@ -171,7 +171,7 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return true
+            return false
         #elseif MOZ_CHANNEL_NIGHTLY
             return true
         #elseif MOZ_CHANNEL_FENNEC
@@ -188,7 +188,7 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return true
+            return false
         #elseif MOZ_CHANNEL_NIGHTLY
             return true
         #elseif MOZ_CHANNEL_FENNEC
@@ -207,13 +207,13 @@ public struct AppConstants {
         #elseif MOZ_CHANNEL_BETA
             return false
         #elseif MOZ_CHANNEL_NIGHTLY
-            return false
+            return true
         #elseif MOZ_CHANNEL_FENNEC
-            return false
+            return true
         #elseif MOZ_CHANNEL_AURORA
-            return false
+            return true
         #else
-            return false
+            return true
         #endif
     }()
 
@@ -240,7 +240,7 @@ public struct AppConstants {
         #if MOZ_CHANNEL_RELEASE
             return false
         #elseif MOZ_CHANNEL_BETA
-            return true
+            return false
         #elseif MOZ_CHANNEL_NIGHTLY
             return true
         #elseif MOZ_CHANNEL_FENNEC

--- a/Utils/Extensions/UIColorExtensions.swift
+++ b/Utils/Extensions/UIColorExtensions.swift
@@ -28,10 +28,4 @@ extension UIColor {
         NSScanner(string: colorString).scanHexInt(&colorInt)
         self.init(rgb: (Int) (colorInt ?? 0xaaaaaa))
     }
-
-    public var alpha: CGFloat {
-        var alpha: CGFloat = 0
-        self.getWhite(nil, alpha: &alpha)
-        return alpha
-    }
 }


### PR DESCRIPTION
Some features we've landed for 6.0 already have feature flags (yay) while others do not. In hopes of stabilizing master and preparing for a stability release, I've gone through feature-related pull requests that have been merged over the 6.0 timeframe and have done the following:

* Added MOZ_REORDER_TAB_TRAY feature flag for toggling the tab reorder functionality in the tray.
* Added MOZ_CONTENT_METADATA_PARSING feature flag for disabling experimental metadata parsing scripts.
* Reverted the new minified URL bar transitions we added (https://github.com/mozilla/firefox-ios/pull/2063). Unfortunately the majority of the code is modification to existing code instead of new features and I was unable to wrap it in a feature flag.
* Disabled all 6.0 landed features on the beta channel but kept them enabled for nightly.