### PR TITLE
Bug 1300766 - only run the reopening code on toolbar state trait coll…

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -179,8 +179,9 @@ class BrowserViewController: UIViewController {
     private func updateToolbarStateForTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator? = nil) {
         let showToolbar = shouldShowFooterForTraitCollection(newCollection)
         let showTopTabs = shouldShowTopTabsForTraitCollection(newCollection)
-        
-        if let mvc = menuViewController where showToolbar != (toolbar != nil) {
+
+        if UI_USER_INTERFACE_IDIOM() == .Pad,
+            let mvc = menuViewController where showToolbar != (toolbar != nil) {
             // Hide the menu, and then re-open it so that the menu is always the correct one for the given traits
             mvc.dismissViewControllerAnimated(true, completion: nil)
             coordinator?.animateAlongsideTransition(nil, completion: { _ in


### PR DESCRIPTION
…ection changes if on an iPad, otherwise it will always re-open the menu on rotation always.

This is because the trait collection change code runs before the menu dismissal code, which means the menu is dismissed and re-opened for the new trait collection by the time the shouldCloseMenu check is performed, causing `shouldCloseMenu` to always return false, ensuring that the menu is not dismissed when it should be. By limiting the toolbar dismissal code to iPad only, this keeps the menu rendering in the correct place on iPads, but does not interfere in the menu dismissal code for iPhones and portrait->landscape menu rendering on iPad.

I don't really like this solution - I can't help thinking that there must be a better way to detect trait collection on iPad multi tasking than dismissing and reopening the menu, but I can't think of it right now.