### PR TITLE
Bug 1291304 - Reject connections if the DB is closed

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -392,6 +392,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.updateAuthenticationInfo()
 
         resetForegroundStartTime()
+
+        profile?.reopen()
     }
 
     private func resetForegroundStartTime() {

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -264,6 +264,18 @@ public class BrowserProfile: Profile {
         self.init(localName: localName, app: nil)
     }
 
+    func reopen() {
+        log.debug("Reopening profile.")
+
+        if dbCreated {
+            db.reopenIfClosed()
+        }
+
+        if loginsDBCreated {
+            loginsDB.reopenIfClosed()
+        }
+    }
+
     func shutdown() {
         log.debug("Shutting down profile.")
 

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -380,6 +380,10 @@ extension BrowserDB {
     public func forceClose() {
         db.forceClose()
     }
+
+    public func reopenIfClosed() {
+        db.reopenIfClosed()
+    }
 }
 
 extension BrowserDB: Changeable {


### PR DESCRIPTION
Simple fix to keep track of whether the database is closed, failing if it is.

While here, I also wrapped the existing `self.sharedConnection = nil` in `forceClose` inside of a `sharedConnectionQueue` block. `self.sharedConnection` needs to be synchronized since we're using it in `getSharedConnection`.