### PR TITLE
Bug 1283143 - disable privacy mode toggle while adding a new tab

### DIFF
--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -182,11 +182,13 @@ class TopTabsViewController: UIViewController {
             }
         }
         delegate?.topTabsDidPressNewTab()
+        self.privateModeButton.enabled = false
         collectionView.performBatchUpdates({ _ in
             let count = self.collectionView.numberOfItemsInSection(0)
             self.collectionView.insertItemsAtIndexPaths([NSIndexPath(forItem: count, inSection: 0)])
             }, completion: { finished in
                 if finished {
+                    self.privateModeButton.enabled = true
                     self.scrollToCurrentTab()
                 }
         })


### PR DESCRIPTION
A crash was being caused when toggling privacy mode while opening a new tab. This caused the new tab to be opened in the wrong collection as the mode switch happened before the batch updates completed, causing a crash (assertion failure in CollectionViewData).
Therefore I am disabling the privacy toggle button for the duration of the add tab action, preventing this situation from ever occurring.